### PR TITLE
feat: Add ACP provider — use Claude Code, Codex, or any ACP agent as LLM backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,33 @@ openclaw_bridge:
 
 Each flag activates a typed adapter protocol. When OpenClaw provides these capabilities, the adapters consume them without code changes. See [`docs/integration-guide.md`](docs/integration-guide.md) for full details.
 
+### ACP (Agent Client Protocol)
+
+AutoResearchClaw can use **any ACP-compatible coding agent** as its LLM backend — no API keys required. The agent communicates via [acpx](https://github.com/openclaw/acpx), maintaining a single persistent session across all 23 pipeline stages.
+
+| Agent | Command | Notes |
+|-------|---------|-------|
+| Claude Code | `claude` | Anthropic |
+| Codex CLI | `codex` | OpenAI |
+| Gemini CLI | `gemini` | Google |
+| OpenCode | `opencode` | SST |
+| Kimi CLI | `kimi` | Moonshot |
+
+```yaml
+# config.yaml — ACP example
+llm:
+  provider: "acp"
+  acp:
+    agent: "claude"   # Any ACP-compatible agent CLI command
+    cwd: "."          # Working directory for the agent
+  # No base_url or api_key needed — the agent handles its own auth.
+```
+
+```bash
+# Just run — the agent uses its own credentials
+researchclaw run --config config.yaml --topic "Your research idea" --auto-approve
+```
+
 ### 🛠️ Other Ways to Run
 
 | Method | How |
@@ -282,13 +309,16 @@ runtime:
 
 # === LLM ===
 llm:
-  provider: "openai-compatible"    # Provider type
-  base_url: "https://..."          # API endpoint (required)
-  api_key_env: "OPENAI_API_KEY"    # Env var for API key (required)
+  provider: "openai-compatible"    # "openai-compatible" (default) or "acp"
+  base_url: "https://..."          # API endpoint (required for openai-compatible)
+  api_key_env: "OPENAI_API_KEY"    # Env var for API key (required for openai-compatible)
   api_key: ""                      # Or hardcode key here
   primary_model: "gpt-4o"          # Primary model
   fallback_models: ["gpt-4o-mini"] # Fallback chain
   s2_api_key: ""                   # Semantic Scholar API key (optional, higher rate limits)
+  acp:                             # Only used when provider: "acp"
+    agent: "claude"                # ACP agent CLI command (claude, codex, gemini, etc.)
+    cwd: "."                       # Working directory for the agent
 
 # === Experiment ===
 experiment:

--- a/researchclaw/cli.py
+++ b/researchclaw/cli.py
@@ -46,9 +46,9 @@ def cmd_run(args: argparse.Namespace) -> int:
 
     # --- LLM Preflight ---
     if not skip_preflight:
-        from researchclaw.llm.client import LLMClient
+        from researchclaw.llm import create_llm_client
 
-        client = LLMClient.from_rc_config(config)
+        client = create_llm_client(config)
         print("Preflight check...", end=" ", flush=True)
         ok, msg = client.preflight()
         if ok:

--- a/researchclaw/config.py
+++ b/researchclaw/config.py
@@ -99,15 +99,27 @@ class OpenClawBridgeConfig:
 
 
 @dataclass(frozen=True)
+class AcpConfig:
+    """ACP (Agent Client Protocol) settings."""
+
+    agent: str = "claude"
+    cwd: str = "."
+    acpx_command: str = ""
+    session_name: str = "researchclaw"
+    timeout_sec: int = 600
+
+
+@dataclass(frozen=True)
 class LlmConfig:
     provider: str
-    base_url: str
-    api_key_env: str
+    base_url: str = ""
+    api_key_env: str = ""
     api_key: str = ""
     primary_model: str = ""
     fallback_models: tuple[str, ...] = ()
     s2_api_key: str = ""
     notes: str = ""
+    acp: AcpConfig = field(default_factory=AcpConfig)
 
 
 @dataclass(frozen=True)
@@ -261,16 +273,7 @@ class RCConfig:
                 use_web_fetch=bool(bridge.get("use_web_fetch", False)),
                 use_browser=bool(bridge.get("use_browser", False)),
             ),
-            llm=LlmConfig(
-                provider=llm.get("provider", ""),
-                base_url=llm["base_url"],
-                api_key_env=llm["api_key_env"],
-                api_key=llm.get("api_key", ""),
-                primary_model=llm.get("primary_model", ""),
-                fallback_models=tuple(llm.get("fallback_models") or ()),
-                s2_api_key=llm.get("s2_api_key", ""),
-                notes=llm.get("notes", ""),
-            ),
+            llm=_parse_llm_config(llm),
             security=SecurityConfig(
                 hitl_required_stages=tuple(
                     int(s) for s in security.get("hitl_required_stages", (5, 9, 20))
@@ -319,7 +322,11 @@ def validate_config(
     errors: list[str] = []
     warnings: list[str] = []
 
+    llm_provider = _get_by_path(data, "llm.provider")
     for key in REQUIRED_FIELDS:
+        # ACP provider doesn't need base_url or api_key_env
+        if llm_provider == "acp" and key in ("llm.base_url", "llm.api_key_env"):
+            continue
         value = _get_by_path(data, key)
         if _is_blank(value):
             errors.append(f"Missing required field: {key}")
@@ -364,6 +371,27 @@ def validate_config(
 
     return ValidationResult(
         ok=not errors, errors=tuple(errors), warnings=tuple(warnings)
+    )
+
+
+def _parse_llm_config(data: dict[str, Any]) -> LlmConfig:
+    acp_data = data.get("acp") or {}
+    return LlmConfig(
+        provider=data.get("provider", "openai-compatible"),
+        base_url=data.get("base_url", ""),
+        api_key_env=data.get("api_key_env", ""),
+        api_key=data.get("api_key", ""),
+        primary_model=data.get("primary_model", ""),
+        fallback_models=tuple(data.get("fallback_models") or ()),
+        s2_api_key=data.get("s2_api_key", ""),
+        notes=data.get("notes", ""),
+        acp=AcpConfig(
+            agent=acp_data.get("agent", "claude"),
+            cwd=acp_data.get("cwd", "."),
+            acpx_command=acp_data.get("acpx_command", ""),
+            session_name=acp_data.get("session_name", "researchclaw"),
+            timeout_sec=int(acp_data.get("timeout_sec", 600)),
+        ),
     )
 
 

--- a/researchclaw/llm/__init__.py
+++ b/researchclaw/llm/__init__.py
@@ -1,1 +1,26 @@
-"""LLM integration — OpenAI-compatible chat client."""
+"""LLM integration — OpenAI-compatible and ACP agent clients."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Union
+
+if TYPE_CHECKING:
+    from researchclaw.config import RCConfig
+    from researchclaw.llm.acp_client import ACPClient
+    from researchclaw.llm.client import LLMClient
+
+
+def create_llm_client(config: RCConfig) -> LLMClient | ACPClient:
+    """Factory: return the right LLM client based on ``config.llm.provider``.
+
+    - ``"acp"`` → :class:`ACPClient` (spawns an ACP-compatible agent)
+    - anything else → :class:`LLMClient` (OpenAI-compatible HTTP)
+    """
+    if config.llm.provider == "acp":
+        from researchclaw.llm.acp_client import ACPClient as _ACP
+
+        return _ACP.from_rc_config(config)
+
+    from researchclaw.llm.client import LLMClient as _LLM
+
+    return _LLM.from_rc_config(config)

--- a/researchclaw/llm/acp_client.py
+++ b/researchclaw/llm/acp_client.py
@@ -1,0 +1,275 @@
+"""ACP (Agent Client Protocol) LLM client via acpx.
+
+Uses acpx as the ACP bridge to communicate with any ACP-compatible agent
+(Claude Code, Codex, Gemini CLI, etc.) via persistent named sessions.
+
+Key advantage: a single persistent session maintains context across all
+23 pipeline stages — the agent remembers everything.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import shutil
+import subprocess
+from dataclasses import dataclass
+from typing import Any
+
+from researchclaw.llm.client import LLMResponse
+
+logger = logging.getLogger(__name__)
+
+# acpx output markers
+_DONE_RE = re.compile(r"^\[done\]")
+_CLIENT_RE = re.compile(r"^\[client\]")
+_ACPX_RE = re.compile(r"^\[acpx\]")
+_TOOL_RE = re.compile(r"^\[tool\]")
+
+
+@dataclass
+class ACPConfig:
+    """Configuration for ACP agent connection."""
+
+    agent: str = "claude"
+    cwd: str = "."
+    acpx_command: str = ""  # auto-detect if empty
+    session_name: str = "researchclaw"
+    timeout_sec: int = 600  # per-prompt timeout
+
+
+def _find_acpx() -> str | None:
+    """Find the acpx binary — check PATH, then OpenClaw's plugin directory."""
+    found = shutil.which("acpx")
+    if found:
+        return found
+    # Check OpenClaw's bundled acpx plugin
+    openclaw_acpx = os.path.expanduser(
+        "~/.openclaw/extensions/acpx/node_modules/.bin/acpx"
+    )
+    if os.path.isfile(openclaw_acpx) and os.access(openclaw_acpx, os.X_OK):
+        return openclaw_acpx
+    return None
+
+
+class ACPClient:
+    """LLM client that uses acpx to communicate with ACP agents.
+
+    Spawns persistent named sessions via acpx, reusing them across
+    ``.chat()`` calls so the agent maintains context across the full
+    23-stage pipeline.
+    """
+
+    def __init__(self, acp_config: ACPConfig) -> None:
+        self.config = acp_config
+        self._acpx: str | None = acp_config.acpx_command or None
+        self._session_ready = False
+
+    @classmethod
+    def from_rc_config(cls, rc_config: Any) -> ACPClient:
+        """Build from a ResearchClaw ``RCConfig``."""
+        acp = rc_config.llm.acp
+        return cls(ACPConfig(
+            agent=acp.agent,
+            cwd=acp.cwd,
+            acpx_command=getattr(acp, "acpx_command", ""),
+            session_name=getattr(acp, "session_name", "researchclaw"),
+        ))
+
+    # ------------------------------------------------------------------
+    # Public interface (matches LLMClient)
+    # ------------------------------------------------------------------
+
+    def chat(
+        self,
+        messages: list[dict[str, str]],
+        *,
+        model: str | None = None,
+        max_tokens: int | None = None,
+        temperature: float | None = None,
+        json_mode: bool = False,
+        system: str | None = None,
+    ) -> LLMResponse:
+        """Send a prompt and return the agent's response.
+
+        Parameters mirror ``LLMClient.chat()`` for drop-in compatibility.
+        ``model``, ``max_tokens``, ``temperature``, and ``json_mode`` are
+        accepted but not forwarded — the agent manages its own model and
+        parameters.
+        """
+        prompt_text = self._messages_to_prompt(messages, system=system)
+        content = self._send_prompt(prompt_text)
+        return LLMResponse(
+            content=content,
+            model=f"acp:{self.config.agent}",
+            finish_reason="stop",
+        )
+
+    def preflight(self) -> tuple[bool, str]:
+        """Check that acpx and the agent are available."""
+        acpx = self._resolve_acpx()
+        if not acpx:
+            return False, (
+                "acpx not found. Install it: npm install -g acpx  "
+                "or set llm.acp.acpx_command in config."
+            )
+        # Check the agent binary exists
+        agent = self.config.agent
+        if not shutil.which(agent):
+            return False, f"ACP agent CLI not found: {agent!r} (not on PATH)"
+        # Create the session
+        try:
+            self._ensure_session()
+            return True, f"OK - ACP session ready ({agent} via acpx)"
+        except Exception as exc:  # noqa: BLE001
+            return False, f"ACP session init failed: {exc}"
+
+    def close(self) -> None:
+        """Close the acpx session."""
+        if not self._session_ready:
+            return
+        acpx = self._resolve_acpx()
+        if not acpx:
+            return
+        try:
+            subprocess.run(
+                [acpx, "--cwd", self._abs_cwd(),
+                 self.config.agent, "sessions", "close",
+                 self.config.session_name],
+                capture_output=True, timeout=15,
+            )
+        except Exception:  # noqa: BLE001
+            pass
+        self._session_ready = False
+
+    def __del__(self) -> None:
+        """Best-effort cleanup on garbage collection."""
+        try:
+            self.close()
+        except Exception:  # noqa: BLE001
+            pass
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _resolve_acpx(self) -> str | None:
+        """Resolve the acpx binary path (cached)."""
+        if self._acpx:
+            return self._acpx
+        self._acpx = _find_acpx()
+        return self._acpx
+
+    def _abs_cwd(self) -> str:
+        return os.path.abspath(self.config.cwd)
+
+    def _ensure_session(self) -> None:
+        """Find or create the named acpx session."""
+        if self._session_ready:
+            return
+        acpx = self._resolve_acpx()
+        if not acpx:
+            raise RuntimeError("acpx not found")
+
+        # Use 'ensure' which finds existing or creates new
+        result = subprocess.run(
+            [acpx, "--cwd", self._abs_cwd(),
+             self.config.agent, "sessions", "ensure",
+             "--name", self.config.session_name],
+            capture_output=True, text=True, timeout=30,
+        )
+        if result.returncode != 0:
+            # Fall back to 'new'
+            result = subprocess.run(
+                [acpx, "--cwd", self._abs_cwd(),
+                 self.config.agent, "sessions", "new",
+                 "--name", self.config.session_name],
+                capture_output=True, text=True, timeout=30,
+            )
+            if result.returncode != 0:
+                raise RuntimeError(
+                    f"Failed to create ACP session: {result.stderr.strip()}"
+                )
+        self._session_ready = True
+        logger.info("ACP session '%s' ready (%s)", self.config.session_name, self.config.agent)
+
+    def _send_prompt(self, prompt: str) -> str:
+        """Send a prompt via acpx and return the response text."""
+        self._ensure_session()
+        acpx = self._resolve_acpx()
+        if not acpx:
+            raise RuntimeError("acpx not found")
+
+        result = subprocess.run(
+            [acpx, "--approve-all", "--cwd", self._abs_cwd(),
+             self.config.agent, "-s", self.config.session_name,
+             prompt],
+            capture_output=True, text=True,
+            timeout=self.config.timeout_sec,
+        )
+
+        if result.returncode != 0:
+            stderr = result.stderr.strip()
+            raise RuntimeError(f"ACP prompt failed (exit {result.returncode}): {stderr}")
+
+        return self._extract_response(result.stdout)
+
+    @staticmethod
+    def _extract_response(raw_output: str) -> str:
+        """Extract the agent's actual response from acpx output.
+
+        Strips acpx metadata lines ([client], [acpx], [tool], [done])
+        and their continuation lines (indented or sub-field lines like
+        ``input:``, ``output:``, ``files:``, ``kind:``).
+        """
+        lines: list[str] = []
+        in_tool_block = False
+        for line in raw_output.splitlines():
+            # Skip acpx control lines
+            if _DONE_RE.match(line) or _CLIENT_RE.match(line) or _ACPX_RE.match(line):
+                in_tool_block = False
+                continue
+            if _TOOL_RE.match(line):
+                in_tool_block = True
+                continue
+            # Tool blocks have indented continuation lines
+            if in_tool_block:
+                if line.startswith("  ") or not line.strip():
+                    continue
+                # Non-indented, non-empty line = end of tool block
+                in_tool_block = False
+            # Skip empty lines at start
+            if not lines and not line.strip():
+                continue
+            lines.append(line)
+
+        # Trim trailing empty lines
+        while lines and not lines[-1].strip():
+            lines.pop()
+
+        return "\n".join(lines)
+
+    @staticmethod
+    def _messages_to_prompt(
+        messages: list[dict[str, str]],
+        *,
+        system: str | None = None,
+    ) -> str:
+        """Flatten a chat-messages list into a single text prompt.
+
+        Preserves role labels so the agent can distinguish context.
+        """
+        parts: list[str] = []
+        if system:
+            parts.append(f"[System]\n{system}")
+        for msg in messages:
+            role = msg.get("role", "user")
+            content = msg.get("content", "")
+            if role == "system":
+                parts.append(f"[System]\n{content}")
+            elif role == "assistant":
+                parts.append(f"[Previous Response]\n{content}")
+            else:
+                parts.append(content)
+        return "\n\n".join(parts)

--- a/researchclaw/pipeline/executor.py
+++ b/researchclaw/pipeline/executor.py
@@ -14,6 +14,7 @@ import yaml
 from researchclaw.adapters import AdapterBundle
 from researchclaw.config import RCConfig
 from researchclaw.hardware import HardwareProfile, detect_hardware, ensure_torch_available, is_metric_name
+from researchclaw.llm import create_llm_client
 from researchclaw.llm.client import LLMClient
 from researchclaw.prompts import PromptManager
 from researchclaw.pipeline.stages import (
@@ -5980,9 +5981,12 @@ def execute_stage(
 
     llm = None
     try:
-        candidate = LLMClient.from_rc_config(config)
-        if candidate.config.base_url and candidate.config.api_key:
-            llm = candidate
+        if config.llm.provider == "acp":
+            llm = create_llm_client(config)
+        else:
+            candidate = LLMClient.from_rc_config(config)
+            if candidate.config.base_url and candidate.config.api_key:
+                llm = candidate
     except Exception:  # noqa: BLE001
         llm = None
 


### PR DESCRIPTION
## Summary

Add support for the [Agent Client Protocol (ACP)](https://agentclientprotocol.com/) as an LLM provider, enabling AutoResearchClaw to use any ACP-compatible coding agent — Claude Code, Codex CLI, Gemini CLI, OpenCode, Kimi CLI, and others — as its LLM backend **without requiring API keys**.

## Key Benefits

🔑 **No API keys required** — ACP agents handle their own authentication through their CLI tools. Users already authenticated with `claude`, `codex`, or `gemini` can run AutoResearchClaw immediately.

🧠 **Session persistence across all 23 stages** — Unlike the OpenAI-compatible provider which makes independent API calls per stage, ACP maintains a single persistent session. The agent remembers the literature review (stage 4) when writing experiment code (stage 10), and remembers experiment results (stage 12) when drafting the paper (stage 17). This produces fundamentally more coherent research.

🔌 **Drop-in compatible** — `ACPClient.chat()` returns the same `LLMResponse` dataclass as `LLMClient`, so all 40+ stage executor functions work unchanged.

## Configuration

```yaml
llm:
  provider: "acp"
  acp:
    agent: "claude"  # or codex, gemini, opencode, kimi
    session_name: "researchclaw"  # persistent session name
```

## Requirements

- [acpx](https://github.com/openclaw/acpx) CLI as the ACP bridge (`npm install -g acpx`)
- Any ACP-compatible agent CLI installed and authenticated

## Supported Agents

| Agent | CLI | Status |
|-------|-----|--------|
| Claude Code | `claude` | ✅ Tested |
| Codex CLI | `codex` | ✅ Supported |
| Gemini CLI | `gemini` | ✅ Supported |
| OpenCode | `opencode` | ✅ Supported |
| Kimi CLI | `kimi` | ✅ Supported |

## Changes

| File | Change |
|------|--------|
| `researchclaw/llm/acp_client.py` | **New** — `ACPClient` class with acpx subprocess communication |
| `researchclaw/llm/__init__.py` | Factory function `create_llm_client()` routing by provider |
| `researchclaw/config.py` | `AcpConfig` dataclass, provider field, validation updates |
| `researchclaw/cli.py` | Uses factory for client creation |
| `researchclaw/pipeline/executor.py` | Uses factory for ACP support |
| `README.md` | Documents ACP provider option |

## Testing

Tested end-to-end with Claude Code via acpx on macOS (Apple M4 Max). Pipeline successfully completed stages 1-8 (TOPIC_INIT through HYPOTHESIS_GEN) with session persistence confirmed — the agent maintained context across stages.

## Architecture

```
AutoResearchClaw → acpx (ACP bridge) → Agent CLI (claude/codex/gemini)
                    ↕ JSON-RPC over stdio
              Persistent session maintains
              context across all 23 stages
```

The `ACPClient` uses acpx as the ACP bridge rather than spawning agents directly, because most agents (Claude Code, Codex) implement ACP through acpx adapters rather than native stdio. This ensures compatibility with the full ACP ecosystem.

---
Closes #2