### PR TITLE
fix: handle LLM API error responses gracefully

### DIFF
--- a/researchclaw/llm/client.py
+++ b/researchclaw/llm/client.py
@@ -273,11 +273,28 @@ class LLMClient:
         with urllib.request.urlopen(req, timeout=self.config.timeout_sec) as resp:
             data = json.loads(resp.read())
 
+        # Handle API error responses (e.g., {"error": {"message": "..."}})
+        if "error" in data:
+            error_info = data["error"]
+            error_msg = error_info.get("message", str(error_info))
+            error_type = error_info.get("type", "api_error")
+            raise urllib.error.HTTPError(
+                url, 500, f"{error_type}: {error_msg}", {}, None  # noqa: PLW2901
+            )
+
+        # Validate response structure
+        if "choices" not in data or not data["choices"]:
+            raise ValueError(f"Malformed API response: missing choices. Got: {data}")
+
         choice = data["choices"][0]
         usage = data.get("usage", {})
 
+        # Safely extract content (may be None for some responses)
+        message = choice.get("message", {})
+        content = message.get("content") or ""
+
         return LLMResponse(
-            content=choice["message"]["content"] or "",
+            content=content,
             model=data.get("model", model),
             prompt_tokens=usage.get("prompt_tokens", 0),
             completion_tokens=usage.get("completion_tokens", 0),


### PR DESCRIPTION
## Problem
When LLM API returns error responses like:
```json
{"error": {"message": "Internal Network Failure", "type": "api_error"}}
```

The client crashes with `KeyError: 'choices'` because the code assumes all responses have a `choices` field.

## Solution

1. **Check for `error` field** - If present, raise HTTPError with the error message
2. **Validate response structure** - Ensure `choices` exists and is not empty
3. **Safely extract content** - Use `.get()` instead of direct key access

## Files Changed
- `researchclaw/llm/client.py` (+18 lines)