### PR TITLE
Fix minimal runtime regressions

### DIFF
--- a/researchclaw/experiment/factory.py
+++ b/researchclaw/experiment/factory.py
@@ -39,5 +39,15 @@ def create_sandbox(config: ExperimentConfig, workdir: Path) -> SandboxProtocol:
 
         return DockerSandbox(docker_cfg, workdir)
 
-    # Default: subprocess sandbox
+    if config.mode == "ssh_remote":
+        raise RuntimeError(
+            "ssh_remote mode is configured but not implemented in this build. "
+            "Use mode: sandbox or mode: docker."
+        )
+
+    if config.mode != "sandbox":
+        raise RuntimeError(
+            f"Unsupported experiment mode for create_sandbox(): {config.mode}"
+        )
+
     return ExperimentSandbox(config.sandbox, workdir)

--- a/researchclaw/experiment/runner.py
+++ b/researchclaw/experiment/runner.py
@@ -118,7 +118,7 @@ class ExperimentRunner:
         # Git integration (Phase 3)
         self._git: _GitManager | None = None
         if git_repo_dir is not None:
-            from arc.experiment_git import ExperimentGitManager
+            from researchclaw.experiment.git_manager import ExperimentGitManager
             mgr = ExperimentGitManager(git_repo_dir)
             if mgr.is_git_repo():
                 self._git = mgr

--- a/researchclaw/llm/__init__.py
+++ b/researchclaw/llm/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from typing import TYPE_CHECKING, Union
 
 if TYPE_CHECKING:
@@ -58,7 +59,11 @@ def create_llm_client(config: RCConfig) -> LLMClient | ACPClient:
     return _LLM(
         LLMConfig(
             base_url=base_url,
-            api_key=config.llm.api_key,
+            api_key=(
+                config.llm.api_key
+                or os.environ.get(config.llm.api_key_env, "")
+                or ""
+            ),
             primary_model=config.llm.primary_model or "gpt-4o",
             fallback_models=list(config.llm.fallback_models or []),
         )

--- a/researchclaw/pipeline/executor.py
+++ b/researchclaw/pipeline/executor.py
@@ -2654,8 +2654,8 @@ def _execute_code_generation(
         )
         try:
             review_resp = llm.chat(
+                [{"role": "user", "content": review_prompt}],
                 system="You are a meticulous ML code reviewer. Be strict.",
-                user=review_prompt,
                 max_tokens=2048,
             )
             # Extract JSON from LLM response (may be wrapped in markdown fences)
@@ -2713,7 +2713,7 @@ def _execute_code_generation(
                     try:
                         fix_resp = _chat_with_prompt(
                             llm,
-                            _pm.prompts["code_generation"]["system"],
+                            _pm.system("code_generation"),
                             fix_prompt,
                             max_tokens=_code_max_tokens,
                         )
@@ -2759,11 +2759,11 @@ def _execute_code_generation(
         )
         try:
             align_resp = llm.chat(
+                [{"role": "user", "content": align_prompt}],
                 system="You are a scientific code reviewer checking topic-experiment alignment.",
-                user=align_prompt,
                 max_tokens=1024,
             )
-            align_data = _safe_json_loads(align_resp, {})
+            align_data = _safe_json_loads(align_resp.content, {})
             if isinstance(align_data, dict) and not align_data.get("aligned", True):
                 alignment_ok = False
                 alignment_note = align_data.get("reason", "Misaligned")
@@ -2788,11 +2788,11 @@ def _execute_code_generation(
                 )
                 regen_resp = _chat_with_prompt(
                     llm,
-                    system=_pm.prompts["code_generation"]["system"],
+                    system=_pm.system("code_generation"),
                     user=regen_prompt,
                     max_tokens=_code_max_tokens,
                 )
-                regen_files = _extract_multi_file_blocks(regen_resp)
+                regen_files = _extract_multi_file_blocks(regen_resp.content)
                 if regen_files and "main.py" in regen_files:
                     files = regen_files
                     for fname, code in files.items():
@@ -2815,11 +2815,11 @@ def _execute_code_generation(
                 '{"has_duplicates": true/false, "details": "which conditions are identical"}'
             )
             abl_resp = llm.chat(
+                [{"role": "user", "content": ablation_prompt}],
                 system="You are a code reviewer checking experimental conditions.",
-                user=ablation_prompt,
                 max_tokens=512,
             )
-            abl_data = _safe_json_loads(abl_resp, {})
+            abl_data = _safe_json_loads(abl_resp.content, {})
             if isinstance(abl_data, dict) and abl_data.get("has_duplicates"):
                 logger.warning(
                     "Stage 10: Duplicate ablation conditions detected: %s",
@@ -6761,7 +6761,9 @@ def execute_stage(
                     )
                     break
 
-    if gate_required(stage, config.security.hitl_required_stages):
+    if result.status == StageStatus.DONE and gate_required(
+        stage, config.security.hitl_required_stages
+    ):
         if auto_approve_gates:
             if bridge.use_memory:
                 adapters.memory.append("gates", f"{run_id}:{int(stage)}:auto-approved")


### PR DESCRIPTION
## Summary

  This PR keeps the scope intentionally small and fixes a few runtime regressions
  that can break normal execution:

  - read the LLM API key from `api_key_env` during CLI preflight, so env-based
  configuration works as documented
  - fail fast for `ssh_remote` experiment mode instead of silently falling back to
  the local sandbox
  - fix the git integration import path to use the in-repo module
  - fix Stage 10 review/alignment/ablation checks to use the current `LLMClient` API
  - only apply HITL gate blocking when a stage actually completed, so real failures
  are not rewritten as `BLOCKED_APPROVAL`

  ## Validation

  - `PYTHONPYCACHEPREFIX=/tmp/pycache python3 -m compileall researchclaw`