### PR TITLE
feat: add dev extras to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,9 @@ license = {text = "MIT"}
 [project.scripts]
 researchclaw = "researchclaw.cli:main"
 
+[project.optional-dependencies]
+dev = ["pytest>=7.0"]
+
 [tool.hatch.build.targets.wheel]
 packages = ["researchclaw", "sibyl", "arc"]
 


### PR DESCRIPTION
## Summary
- Add `[project.optional-dependencies]` with `dev = ["pytest>=7.0"]` to `pyproject.toml`
- Enables `pip install -e ".[dev]"` for first-time contributors

## Test plan
- [x] `pip install -e ".[dev]"` succeeds and includes pytest
- [x] Full test suite passes (1251 tests)