### PR TITLE
docs: add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,40 @@
+# Contributing to AutoResearchClaw
+
+## Setup
+
+1. Fork and clone the repo
+2. Create a venv and install with dev extras:
+   ```
+   python3 -m venv .venv && source .venv/bin/activate
+   pip install -e ".[dev]"
+   ```
+3. Generate your local config:
+   ```
+   researchclaw init
+   ```
+4. Edit `config.arc.yaml` with your LLM settings
+
+## Config Convention
+
+- `config.researchclaw.example.yaml` — tracked template (do not add secrets)
+- `config.arc.yaml` — your local config (gitignored, created by `researchclaw init`)
+- `config.yaml` — also gitignored, supported as fallback
+
+## Running Tests
+
+```
+pytest tests/
+```
+
+## Checking Your Environment
+
+```
+researchclaw doctor
+```
+
+## PR Guidelines
+
+- Branch from main
+- One concern per PR
+- Ensure `pytest tests/` passes
+- Include tests for new functionality


### PR DESCRIPTION
## Problem

No contributor guide exists. New contributors must reverse-engineer the setup process from scattered files and README fragments.

## Solution

Add CONTRIBUTING.md covering:
- Fork, clone, venv, and `pip install -e ".[dev]"` setup
- Config conventions (`config.arc.yaml` vs `config.yaml` vs example template)
- Running tests and `researchclaw doctor`
- PR guidelines

## Test plan

- [x] Setup steps verified end-to-end on a fresh clone
- [x] Docs-only change — no code tests needed