### PR TITLE
fix: increase ACP timeout_sec default from 600 to 1800 (#25)

### DIFF
--- a/researchclaw/llm/acp_client.py
+++ b/researchclaw/llm/acp_client.py
@@ -37,7 +37,7 @@ class ACPConfig:
     cwd: str = "."
     acpx_command: str = ""  # auto-detect if empty
     session_name: str = "researchclaw"
-    timeout_sec: int = 600  # per-prompt timeout
+    timeout_sec: int = 1800  # per-prompt timeout
 
 
 def _find_acpx() -> str | None:


### PR DESCRIPTION
Increases the default `timeout_sec` in `ACPConfig` from 600 to 1800.

Reasoning models (Claude Opus, GPT-5.4 xhigh) routinely need 5-15 min for TOPIC_INIT and 15-30+ min for CODE_GENERATION. The 600s default causes false `subprocess.TimeoutExpired` failures.

**Observed timings from our ACP test run:**
| Stage | Claude Sonnet | Codex gpt-5.4 |
|---|---|---|
| 01-topic_init | 63s | 474s |
| 09-experiment_design | 91s | 1395s |
| 10-code_generation | 1959s | 2716s (timed out) |

Single line change. Configurable via `llm.acp.timeout_sec` in config YAML.

Fixes #25