### PR TITLE
fix: strip [thinking] tags before YAML/JSON parsing (#27)

### DIFF
--- a/researchclaw/pipeline/executor.py
+++ b/researchclaw/pipeline/executor.py
@@ -270,6 +270,9 @@ def _load_hardware_profile(run_dir: Path) -> dict[str, Any] | None:
 
 
 def _extract_yaml_block(text: str) -> str:
+    # Strip Claude extended thinking tags that break YAML parsing (#27)
+    import re
+    text = re.sub(r"\[thinking\].*?\[/thinking\]", "", text, flags=re.DOTALL).strip()
     if "```yaml" in text:
         return text.split("```yaml", 1)[1].split("```", 1)[0].strip()
     if "```yml" in text:
@@ -280,6 +283,9 @@ def _extract_yaml_block(text: str) -> str:
 
 
 def _safe_json_loads(text: str, default: Any) -> Any:
+    # Strip Claude extended thinking tags before JSON parsing (#27)
+    import re
+    text = re.sub(r"\[thinking\].*?\[/thinking\]", "", text, flags=re.DOTALL).strip()
     try:
         return json.loads(text)
     except Exception:  # noqa: BLE001


### PR DESCRIPTION
Strips `[thinking]...[/thinking]` blocks in `_extract_yaml_block` and `_safe_json_loads` before parsing.

Claude Opus/Sonnet returns extended thinking blocks before YAML content at Stage 09 (EXPERIMENT_DESIGN). The YAML parser fails and falls back to a template, losing the LLM-designed experiment plan.

**Observed log output:**
```
Stage 09: LLM response could not be parsed as YAML (len=3618, first 200 chars: [thinking] The user wants me to design a YAML experiment plan...)
Stage 09: LLM failed to produce valid experiment plan YAML. Using topic-derived fallback.
```

Uses regex to strip tags in both YAML and JSON parsing paths.

Fixes #27