### PR TITLE
fix(acp): add strip_thinking param and use stdin for prompts

### DIFF
--- a/researchclaw/llm/acp_client.py
+++ b/researchclaw/llm/acp_client.py
@@ -100,6 +100,7 @@ class ACPClient:
         temperature: float | None = None,
         json_mode: bool = False,
         system: str | None = None,
+        strip_thinking: bool = False,
     ) -> LLMResponse:
         """Send a prompt and return the agent's response.
 
@@ -110,6 +111,9 @@ class ACPClient:
         """
         prompt_text = self._messages_to_prompt(messages, system=system)
         content = self._send_prompt(prompt_text)
+        if strip_thinking:
+            from researchclaw.utils.thinking_tags import strip_thinking_tags
+            content = strip_thinking_tags(content)
         return LLMResponse(
             content=content,
             model=f"acp:{self.config.agent}",
@@ -242,11 +246,12 @@ class ACPClient:
         return self._send_prompt_via_file(acpx, prompt)
 
     def _send_prompt_cli(self, acpx: str, prompt: str) -> str:
-        """Send prompt as a CLI argument (original path)."""
+        """Send prompt via stdin to avoid ARG_MAX limits (fixes #43)."""
         result = subprocess.run(
             [acpx, "--approve-all", "--ttl", "0", "--cwd", self._abs_cwd(),
              self.config.agent, "-s", self.config.session_name,
-             prompt],
+             "-f", "-"],
+            input=prompt,
             capture_output=True, text=True,
             timeout=self.config.timeout_sec,
         )


### PR DESCRIPTION
## Summary
Fixes #43 and #44

### Issue #44: Missing strip_thinking parameter
`ACPClient.chat()` was missing the `strip_thinking` keyword argument that `LLMClient.chat()` accepts. This caused a `TypeError` at Stage 3 (SEARCH_STRATEGY) and any subsequent stage that calls `_chat_with_prompt()` with `strip_thinking=True`.

**Fix:**
- Added `strip_thinking: bool = False` parameter to `ACPClient.chat()`
- Apply `strip_thinking_tags()` to response content when enabled

### Issue #43: ARG_MAX limit with large prompts
The entire prompt text was passed as a command-line argument to `subprocess.run`, which hits the Linux ARG_MAX limit when the LITERATURE_SCREEN stage has a large prompt.

**Fix:**
- Changed `_send_prompt_cli()` to use stdin via `-f -` flag
- Prompt is now passed via `input=prompt` parameter to `subprocess.run()`

## Test Plan
- [x] Verified `strip_thinking` parameter is accepted by `ACPClient.chat()`
- [x] Verified `-f -` flag passes prompt via stdin
- [x] Code follows existing patterns in the codebase

Closes #43
Closes #44