### PR TITLE
fix(cli): respect project.mode for HITL gate behavior

### DIFF
--- a/researchclaw/cli.py
+++ b/researchclaw/cli.py
@@ -109,9 +109,16 @@ def cmd_run(args: argparse.Namespace) -> int:
     print(f"  Run ID:  {run_id}")
     print(f"  Topic:   {config.research.topic}")
     print(f"  Output:  {run_dir}")
-    print(f"  Mode:    {config.experiment.mode}")
+    print(f"  Mode:    {config.project.mode}")
     print(f"  From:    Stage {int(from_stage)}: {from_stage.name}")
     print()
+
+    # Derive gate behavior from project.mode (fixes #45)
+    # - "docs-first" / "semi-auto": gates block and wait for approval
+    # - "full-auto": gates auto-approve (or use --auto-approve flag)
+    stop_on_gate = config.project.mode in ("semi-auto", "docs-first")
+    if config.project.mode == "full-auto":
+        auto_approve = True
 
     results = execute_pipeline(
         run_dir=run_dir,
@@ -120,6 +127,7 @@ def cmd_run(args: argparse.Namespace) -> int:
         adapters=adapters,
         from_stage=from_stage,
         auto_approve_gates=auto_approve,
+        stop_on_gate=stop_on_gate,
         skip_noncritical=skip_noncritical,
         kb_root=kb_root_path,
     )


### PR DESCRIPTION
## Summary
Fixes #45

The `project.mode` config value was loaded but never used to control gate behavior. This caused HITL gates configured via `security.hitl_required_stages` to be silently bypassed in `semi-auto` mode.

### Root Cause
1. `config.project.mode` was never consulted to determine gate behavior
2. `stop_on_gate` parameter defaulted to `False` and was never set by any caller

### Changes
- Derive `stop_on_gate` from `project.mode`:
  - `"docs-first"` / `"semi-auto"`: gates block (`stop_on_gate=True`)
  - `"full-auto"`: gates auto-approve
- Pass `stop_on_gate` to `execute_pipeline()`
- Fix Mode print to show `project.mode` instead of `experiment.mode`

### Behavior After Fix
| project.mode | Gate Behavior |
|--------------|---------------|
| `docs-first` | Blocks, waits for approval |
| `semi-auto` | Blocks, waits for approval |
| `full-auto` | Auto-approves |

## Test Plan
- [x] Verified `stop_on_gate` is derived from `project.mode`
- [x] Verified `stop_on_gate` is passed to `execute_pipeline()`

Closes #45