### PR TITLE
fix(code_agent): use f-strings consistently to avoid KeyError

### DIFF
--- a/researchclaw/pipeline/code_agent.py
+++ b/researchclaw/pipeline/code_agent.py
@@ -982,10 +982,10 @@ class CodeAgent:
             f"## Other Files in Project\n{dep_summaries}\n\n"
             f"## Full File ({target_file}, {total_lines} lines)\n"
             f"```python\n{code}\n```\n\n"
-            "Output the COMPLETE fixed `{target_file}` in "
-            "```filename:{target_file}``` format. Fix the root cause, "
-            "not just the symptom."
-        ).format(target_file=target_file)
+            f"Output the COMPLETE fixed `{target_file}` in "
+            f"```filename:{target_file}``` format. Fix the root cause, "
+            f"not just the symptom."
+        )
 
         sys_prompt = (
             "You are a debugging expert. Fix the specific runtime error "


### PR DESCRIPTION
## Summary
Fixes #47

The repair prompt in `code_agent.py` (line ~988) used f-strings for most variables but then called `.format(target_file=target_file)` on the result. When interpolated `code`, `error_msg`, `full_stderr`, or `dep_summaries` contained curly braces (e.g. Python f-strings like `{len(train_loader)}`, dicts, set literals), `.format()` would try to interpret them as format keys and raise `KeyError`.

### Root Cause
```python
prompt = (
    f"... {error_msg} ... {code} ..."
    "Output the COMPLETE fixed `{target_file}` in "  # <-- regular string
    ...
).format(target_file=target_file)  # <-- crashes on braces in code/error_msg
```

The f-string portions are evaluated first, but `.format()` then scans the **entire** resulting string for `{...}` patterns, including braces from user code.

### Fix
Convert the remaining string literals to f-strings and remove the `.format()` call entirely:

```python
prompt = (
    f"... {error_msg} ... {code} ..."
    f"Output the COMPLETE fixed `{target_file}` in "  # <-- now f-string
    f"...`{target_file}`..."
)  # <-- no .format() call
```

## Test Plan
- [x] Verified no `.format()` calls remain in code_agent.py
- [x] All string interpolation now uses f-strings consistently

Closes #47