### PR TITLE
Fix broken GitHub links pointing to old repo owner

### DIFF
--- a/website/features.html
+++ b/website/features.html
@@ -22,7 +22,7 @@
       <li><a href="features.html" class="active">Features</a></li>
       <li><a href="papers.html">Papers</a></li>
       <li><a href="getting-started.html">Get Started</a></li>
-      <li><a href="https://github.com/Jiaaqiliu/AutoResearchClaw" class="nav-github" target="_blank">GitHub</a></li>
+      <li><a href="https://github.com/aiming-lab/AutoResearchClaw" class="nav-github" target="_blank">GitHub</a></li>
     </ul>
   </div>
 </nav>
@@ -216,7 +216,7 @@
     <li><a href="features.html">Features</a></li>
     <li><a href="papers.html">Papers</a></li>
     <li><a href="getting-started.html">Get Started</a></li>
-    <li><a href="https://github.com/Jiaaqiliu/AutoResearchClaw" target="_blank">GitHub</a></li>
+    <li><a href="https://github.com/aiming-lab/AutoResearchClaw" target="_blank">GitHub</a></li>
   </ul>
   <p>AutoResearchClaw &mdash; Autonomous Research Paper Generation Pipeline</p>
 </footer>

--- a/website/getting-started.html
+++ b/website/getting-started.html
@@ -22,7 +22,7 @@
       <li><a href="features.html">Features</a></li>
       <li><a href="papers.html">Papers</a></li>
       <li><a href="getting-started.html" class="active">Get Started</a></li>
-      <li><a href="https://github.com/Jiaaqiliu/AutoResearchClaw" class="nav-github" target="_blank">GitHub</a></li>
+      <li><a href="https://github.com/aiming-lab/AutoResearchClaw" class="nav-github" target="_blank">GitHub</a></li>
     </ul>
   </div>
 </nav>
@@ -54,7 +54,7 @@
     <div class="step-block">
       <h3><span class="step-num">1</span> Clone the Repository</h3>
       <div class="code-block">
-git clone https://github.com/Jiaaqiliu/AutoResearchClaw.git<br>
+git clone https://github.com/aiming-lab/AutoResearchClaw.git<br>
 cd AutoResearchClaw
       </div>
     </div>
@@ -158,7 +158,7 @@ output/&lt;run-id&gt;/<br>
     </div>
 
     <div class="text-center mt-8">
-      <a href="https://github.com/Jiaaqiliu/AutoResearchClaw" class="btn btn-primary" target="_blank">View Full Documentation on GitHub</a>
+      <a href="https://github.com/aiming-lab/AutoResearchClaw#readme" class="btn btn-primary" target="_blank">View Full Documentation on GitHub</a>
     </div>
 
   </div>
@@ -172,7 +172,7 @@ output/&lt;run-id&gt;/<br>
     <li><a href="features.html">Features</a></li>
     <li><a href="papers.html">Papers</a></li>
     <li><a href="getting-started.html">Get Started</a></li>
-    <li><a href="https://github.com/Jiaaqiliu/AutoResearchClaw" target="_blank">GitHub</a></li>
+    <li><a href="https://github.com/aiming-lab/AutoResearchClaw" target="_blank">GitHub</a></li>
   </ul>
   <p>AutoResearchClaw &mdash; Autonomous Research Paper Generation Pipeline</p>
 </footer>

--- a/website/index.html
+++ b/website/index.html
@@ -26,7 +26,7 @@
       <li><a href="features.html">Features</a></li>
       <li><a href="papers.html">Papers</a></li>
       <li><a href="getting-started.html">Get Started</a></li>
-      <li><a href="https://github.com/Jiaaqiliu/AutoResearchClaw" class="nav-github" target="_blank">GitHub</a></li>
+      <li><a href="https://github.com/aiming-lab/AutoResearchClaw" class="nav-github" target="_blank">GitHub</a></li>
     </ul>
   </div>
 </nav>
@@ -296,7 +296,7 @@
     </p>
     <div class="hero-actions mt-8">
       <a href="getting-started.html" class="btn btn-primary">Quick Start Guide</a>
-      <a href="https://github.com/Jiaaqiliu/AutoResearchClaw" class="btn btn-outline" target="_blank">View on GitHub</a>
+      <a href="https://github.com/aiming-lab/AutoResearchClaw" class="btn btn-outline" target="_blank">View on GitHub</a>
     </div>
   </div>
 </section>
@@ -309,7 +309,7 @@
     <li><a href="features.html">Features</a></li>
     <li><a href="papers.html">Papers</a></li>
     <li><a href="getting-started.html">Get Started</a></li>
-    <li><a href="https://github.com/Jiaaqiliu/AutoResearchClaw" target="_blank">GitHub</a></li>
+    <li><a href="https://github.com/aiming-lab/AutoResearchClaw" target="_blank">GitHub</a></li>
   </ul>
   <p>AutoResearchClaw &mdash; Autonomous Research Paper Generation Pipeline</p>
 </footer>

--- a/website/papers.html
+++ b/website/papers.html
@@ -22,7 +22,7 @@
       <li><a href="features.html">Features</a></li>
       <li><a href="papers.html" class="active">Papers</a></li>
       <li><a href="getting-started.html">Get Started</a></li>
-      <li><a href="https://github.com/Jiaaqiliu/AutoResearchClaw" class="nav-github" target="_blank">GitHub</a></li>
+      <li><a href="https://github.com/aiming-lab/AutoResearchClaw" class="nav-github" target="_blank">GitHub</a></li>
     </ul>
   </div>
 </nav>
@@ -172,7 +172,7 @@
     <li><a href="features.html">Features</a></li>
     <li><a href="papers.html">Papers</a></li>
     <li><a href="getting-started.html">Get Started</a></li>
-    <li><a href="https://github.com/Jiaaqiliu/AutoResearchClaw" target="_blank">GitHub</a></li>
+    <li><a href="https://github.com/aiming-lab/AutoResearchClaw" target="_blank">GitHub</a></li>
   </ul>
   <p>AutoResearchClaw &mdash; Autonomous Research Paper Generation Pipeline</p>
 </footer>

--- a/website/pipeline.html
+++ b/website/pipeline.html
@@ -22,7 +22,7 @@
       <li><a href="features.html">Features</a></li>
       <li><a href="papers.html">Papers</a></li>
       <li><a href="getting-started.html">Get Started</a></li>
-      <li><a href="https://github.com/Jiaaqiliu/AutoResearchClaw" class="nav-github" target="_blank">GitHub</a></li>
+      <li><a href="https://github.com/aiming-lab/AutoResearchClaw" class="nav-github" target="_blank">GitHub</a></li>
     </ul>
   </div>
 </nav>
@@ -433,7 +433,7 @@
     <li><a href="features.html">Features</a></li>
     <li><a href="papers.html">Papers</a></li>
     <li><a href="getting-started.html">Get Started</a></li>
-    <li><a href="https://github.com/Jiaaqiliu/AutoResearchClaw" target="_blank">GitHub</a></li>
+    <li><a href="https://github.com/aiming-lab/AutoResearchClaw" target="_blank">GitHub</a></li>
   </ul>
   <p>AutoResearchClaw &mdash; Autonomous Research Paper Generation Pipeline</p>
 </footer>


### PR DESCRIPTION
## Summary
- Replaced all `Jiaaqiliu/AutoResearchClaw` GitHub links with `aiming-lab/AutoResearchClaw` across 5 HTML files (nav, footer, clone command, CTA buttons)
- Updated "View Full Documentation on GitHub" link in getting-started.html to point to `#readme`