### PR TITLE
Fix figure-agent config parsing and doctor console fallback

### DIFF
--- a/researchclaw/config.py
+++ b/researchclaw/config.py
@@ -627,12 +627,21 @@ def _parse_benchmark_agent_config(data: dict[str, Any]) -> BenchmarkAgentConfig:
 def _parse_figure_agent_config(data: dict[str, Any]) -> FigureAgentConfig:
     if not data:
         return FigureAgentConfig()
+    use_docker_raw = data.get("use_docker", None)
     return FigureAgentConfig(
         enabled=bool(data.get("enabled", True)),
         min_figures=int(data.get("min_figures", 3)),
         max_figures=int(data.get("max_figures", 8)),
         max_iterations=int(data.get("max_iterations", 3)),
         render_timeout_sec=int(data.get("render_timeout_sec", 30)),
+        use_docker=(
+            None if use_docker_raw is None else bool(use_docker_raw)
+        ),
+        docker_image=data.get("docker_image", "researchclaw/experiment:latest"),
+        output_format=data.get("output_format", "python"),
+        gemini_api_key=data.get("gemini_api_key", ""),
+        gemini_model=data.get("gemini_model", "gemini-2.5-flash-image"),
+        nano_banana_enabled=bool(data.get("nano_banana_enabled", True)),
         strict_mode=bool(data.get("strict_mode", False)),
         dpi=int(data.get("dpi", 300)),
     )

--- a/researchclaw/health.py
+++ b/researchclaw/health.py
@@ -624,9 +624,15 @@ def run_doctor(config_path: str | Path) -> DoctorReport:
 def print_doctor_report(report: DoctorReport) -> None:
     """Pretty-print doctor report to stdout."""
     icon_by_status = {"pass": "✅", "fail": "❌", "warn": "⚠️"}
+    encoding = getattr(sys.stdout, "encoding", None) or "utf-8"
+    try:
+        for icon in icon_by_status.values():
+            icon.encode(encoding)
+    except UnicodeEncodeError:
+        icon_by_status = {"pass": "[OK]", "fail": "[FAIL]", "warn": "[WARN]"}
     print(f"ResearchClaw Doctor Report ({report.timestamp})")
     for check in report.checks:
-        icon = icon_by_status.get(check.status, "•")
+        icon = icon_by_status.get(check.status, "-")
         print(f"{icon} {check.name}: {check.detail}")
         if check.fix:
             print(f"   Fix: {check.fix}")

--- a/tests/test_figure_agent.py
+++ b/tests/test_figure_agent.py
@@ -868,6 +868,23 @@ class TestFigureAgentConfig:
         assert cfg.max_figures == 6
         assert cfg.dpi == 150
 
+    def test_parse_from_dict_extended_fields(self):
+        from researchclaw.config import _parse_figure_agent_config
+        cfg = _parse_figure_agent_config({
+            "use_docker": False,
+            "docker_image": "custom/figure:latest",
+            "output_format": "latex",
+            "gemini_api_key": "test-key",
+            "gemini_model": "gemini-test",
+            "nano_banana_enabled": False,
+        })
+        assert cfg.use_docker is False
+        assert cfg.docker_image == "custom/figure:latest"
+        assert cfg.output_format == "latex"
+        assert cfg.gemini_api_key == "test-key"
+        assert cfg.gemini_model == "gemini-test"
+        assert cfg.nano_banana_enabled is False
+
     def test_parse_empty(self):
         from researchclaw.config import _parse_figure_agent_config
         cfg = _parse_figure_agent_config({})

--- a/tests/test_rc_health.py
+++ b/tests/test_rc_health.py
@@ -573,3 +573,34 @@ def test_run_doctor_acp_includes_agent_check(tmp_path: Path) -> None:
     assert "acp_agent" in check_names
     assert report.overall == "pass"
     assert len(report.checks) == 7
+
+
+def test_print_doctor_report_ascii_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    report = health.DoctorReport(
+        timestamp="2026-01-01T00:00:00+00:00",
+        checks=[health.CheckResult("python_version", "pass", "ok")],
+        overall="pass",
+    )
+
+    class _AsciiStdout:
+        encoding = "ascii"
+
+        def __init__(self) -> None:
+            self.parts: list[str] = []
+
+        def write(self, text: str) -> int:
+            text.encode(self.encoding)
+            self.parts.append(text)
+            return len(text)
+
+        def flush(self) -> None:
+            return None
+
+    fake_stdout = _AsciiStdout()
+    monkeypatch.setattr(health.sys, "stdout", fake_stdout)
+
+    health.print_doctor_report(report)
+
+    out = "".join(fake_stdout.parts)
+    assert "[OK] python_version: ok" in out
+    assert "Result: PASS" in out


### PR DESCRIPTION
## Summary
- parse all figure agent configuration fields, including docker/image-generation settings
- add an ASCII fallback for `researchclaw doctor` when the console encoding cannot print emoji
- add targeted regression tests for both fixes

## Testing
- `uv run --python .venv\Scripts\python.exe pytest tests\test_figure_agent.py::TestFigureAgentConfig::test_parse_from_dict tests\test_figure_agent.py::TestFigureAgentConfig::test_parse_from_dict_extended_fields`
- `uv run --python .venv\Scripts\python.exe pytest tests\test_rc_health.py -k "test_print_doctor_report_fail or test_print_doctor_report_ascii_fallback"`