### PR TITLE
fix: resolve KeyError in code repair stage due to string formatting conflict

### DIFF
--- a/researchclaw/pipeline/code_agent.py
+++ b/researchclaw/pipeline/code_agent.py
@@ -982,10 +982,10 @@ class CodeAgent:
             f"## Other Files in Project\n{dep_summaries}\n\n"
             f"## Full File ({target_file}, {total_lines} lines)\n"
             f"```python\n{code}\n```\n\n"
-            "Output the COMPLETE fixed `{target_file}` in "
-            "```filename:{target_file}``` format. Fix the root cause, "
-            "not just the symptom."
-        ).format(target_file=target_file)
+            f"Output the COMPLETE fixed `{target_file}` in "
+            f"```filename:{target_file}``` format. Fix the root cause, "
+            f"not just the symptom."
+        )
 
         sys_prompt = (
             "You are a debugging expert. Fix the specific runtime error "


### PR DESCRIPTION
### **Description:**
#### **The Problem**
The pipeline fails during `Stage 10/23 CODE_GENERATION` specifically within the `_targeted_file_repair` method. If the code being repaired contains literal curly braces (e.g., a Python dictionary like `{'num_episodes': 50}`), the program crashes with a `KeyError`.

#### **The Cause**
In `researchclaw/pipeline/code_agent.py`, the prompt was being constructed using a mix of f-strings and `.format()`. 
1. The f-strings evaluated first, inserting the user's code (containing braces) into the string.
2. The `.format(target_file=target_file)` call then ran on the *entire* resulting string. 
3. Python's `.format()` interpreter mistook the braces in the inserted code as placeholders, failed to find matching keyword arguments, and threw a `KeyError`.

#### **The Fix**
Converted the entire prompt block to use consistent f-strings and removed the trailing `.format()` call. This ensures the prompt is built in a single pass, treating the contents of the code variables as literal text rather than formatting templates.