### PR TITLE
feat: add Novita AI as LLM provider

### DIFF
--- a/researchclaw/llm/__init__.py
+++ b/researchclaw/llm/__init__.py
@@ -24,7 +24,7 @@ PROVIDER_PRESETS = {
         "base_url": "https://api.anthropic.com",
     },
     "novita": {
-        "base_url": "https://api.novita.ai/v3/openai",
+        "base_url": "https://api.novita.ai/openai",
     },
     "openai-compatible": {
         "base_url": None,  # Use user-provided base_url


### PR DESCRIPTION
## Description

Add [Novita AI](https://novita.ai) as a supported LLM provider for AutoResearchClaw.

Novita AI provides fast and affordable LLM inference with OpenAI-compatible API, making it a drop-in replacement for OpenAI with competitive pricing.

## Changes

- Add `novita` to `PROVIDER_PRESETS` with base URL `https://api.novita.ai/openai`
- Update docstring to document Novita AI support

## Usage

Users can now configure AutoResearchClaw to use Novita AI:

```yaml
llm:
  provider: novita
  api_key_env: NOVITA_API_KEY
  primary_model: moonshotai/kimi-k2.5
```