### PR TITLE
Improve GitHub nav button and framework image styling

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -283,7 +283,9 @@
       <h2>System Architecture</h2>
       <p>End-to-end pipeline architecture from topic input to published paper.</p>
     </div>
-    <img src="assets/framework.png" alt="AutoResearchClaw Framework" style="max-width: 900px; margin: 0 auto; border-radius: var(--radius-lg); border: 1px solid var(--color-border);">
+    <div class="framework-img-wrap">
+      <img src="assets/framework.png" alt="AutoResearchClaw Framework">
+    </div>
   </div>
 </section>
 

--- a/website/style.css
+++ b/website/style.css
@@ -67,19 +67,38 @@ img { max-width: 100%; height: auto; display: block; }
   font-weight: 700; font-size: 1.15rem; color: var(--color-white);
 }
 .nav-brand img { height: 32px; width: 32px; border-radius: 6px; }
-.nav-links { display: flex; gap: 1.5rem; list-style: none; }
+.nav-links { display: flex; align-items: center; gap: 1.5rem; list-style: none; }
 .nav-links a {
   color: var(--color-text-muted); font-size: 0.9rem; font-weight: 500;
   padding: 0.4rem 0; transition: color var(--transition);
 }
 .nav-links a:hover, .nav-links a.active { color: var(--color-primary); }
 .nav-github {
-  display: inline-flex; align-items: center; gap: 0.4rem;
-  background: var(--color-surface); color: var(--color-white);
-  padding: 0.45rem 1rem; border-radius: 9999px; font-size: 0.85rem;
-  font-weight: 600; transition: background var(--transition);
+  display: flex; 
+  gap: 0.5rem;
+  align-items: center; 
+  justify-content: center;
+  background: transparent; 
+  width: 100px;
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+  padding: 0.4rem 1rem;
+  border-radius: var(--radius); 
+  font-size: 0.82rem;
+  font-weight: 600; transition: all 0.25s ease;
+  letter-spacing: 0.01em;
 }
-.nav-github:hover { background: var(--color-primary-d); color: var(--color-white); }
+.nav-github::before {
+  content: '';
+  display: inline-block; width: 18px; height: 18px;
+  background: currentColor;
+  -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z'/%3E%3C/svg%3E") no-repeat center / contain;
+  mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z'/%3E%3C/svg%3E") no-repeat center / contain;
+}
+.nav-github:hover {
+  border-color: var(--color-white);
+  transform: translateY(-1px);
+}
 
 /* Mobile nav toggle */
 .nav-toggle { display: none; background: none; border: none; color: var(--color-text); font-size: 1.5rem; cursor: pointer; }
@@ -325,6 +344,23 @@ img { max-width: 100%; height: auto; display: block; }
 .stage-badge-new    { background: rgba(167,139,250,0.15); color: var(--color-accent); }
 .stage-badge-llm    { background: rgba(56,189,248,0.15); color: var(--color-primary); }
 .stage-badge-docker { background: rgba(74,222,128,0.15); color: var(--color-success); }
+
+/* ---------- Framework Image ---------- */
+.framework-img-wrap {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 2rem;
+  background: #f8fafc;
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(255,255,255,0.1);
+  box-shadow: var(--shadow-lg), 0 0 80px -20px rgba(56,189,248,0.12);
+  overflow: hidden;
+}
+.framework-img-wrap img {
+  width: 100%;
+  border-radius: 0.5rem;
+  display: block;
+}
 
 /* ---------- Footer ---------- */
 .footer {


### PR DESCRIPTION
## Summary
- Restyled the GitHub navbar link with an octocat SVG icon, transparent background with border, and hover effect
- Vertically centered all navbar items for consistent alignment
- Wrapped the System Architecture framework image in a white card container for better readability against the dark theme

## Test plan
- [ ] Verify GitHub nav button displays correctly with icon on desktop and mobile
- [ ] Confirm hover state on GitHub button (border highlight + slight lift)
- [ ] Check framework image section renders with white background card
- [ ] Test responsive layout on various screen sizes