### PR TITLE
docs: add GitHub Copilot CLI as supported ACP agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ AutoResearchClaw can use **any ACP-compatible coding agent** as its LLM backend 
 |-------|---------|-------|
 | Claude Code | `claude` | Anthropic |
 | Codex CLI | `codex` | OpenAI |
+| Copilot CLI | `gh` | GitHub |
 | Gemini CLI | `gemini` | Google |
 | OpenCode | `opencode` | SST |
 | Kimi CLI | `kimi` | Moonshot |
@@ -229,6 +230,7 @@ researchclaw run --config config.yaml --topic "Your research idea" --auto-approv
 | **Standalone CLI** | `researchclaw run --topic "..." --auto-approve` |
 | **Python API** | `from researchclaw.pipeline import Runner; Runner(config).run()` |
 | **Claude Code** | Reads `RESEARCHCLAW_CLAUDE.md` — just say *"Run research on [topic]"* |
+| **Copilot CLI** | `researchclaw run --topic "..."` with `llm.acp.agent: "gh"` |
 | **OpenCode** | Reads `.claude/skills/` — same natural language interface |
 | **Any AI CLI** | Provide `RESEARCHCLAW_AGENTS.md` as context → agent auto-bootstraps |
 

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -709,6 +709,23 @@ You: Research the impact of attention mechanisms on speech recognition
 Claude: [Reads project context, runs the pipeline, returns results]
 ```
 
+### Copilot CLI (GitHub)
+
+GitHub Copilot can be used as an ACP agent via the `gh` CLI command (GitHub CLI with Copilot extension). Set the ACP agent to `gh` in your config:
+
+```yaml
+llm:
+  provider: "acp"
+  acp:
+    agent: "gh"
+    cwd: "."
+```
+
+Prerequisites:
+1. Install [GitHub CLI](https://cli.github.com/) (`gh`)
+2. Install the Copilot extension: `gh extension install github/gh-copilot`
+3. Authenticate: `gh auth login`
+
 ### OpenCode
 
 OpenCode loads skills from `.claude/skills/`. The `researchclaw` skill activates on research-related queries and guides the agent through the pipeline.


### PR DESCRIPTION
## Summary

Add GitHub Copilot CLI (`gh`) as a documented ACP agent alongside Claude Code, Codex CLI, Gemini CLI, OpenCode, and Kimi CLI.

## Changes

- **README.md**: Added Copilot CLI to the ACP agents table and the "Other Ways to Run" table
- **docs/integration-guide.md**: Added a new "Copilot CLI (GitHub)" section with configuration example and prerequisites (GitHub CLI + Copilot extension + auth)

## Details

The ACP architecture is already fully generic — no code changes are needed. GitHub Copilot works as an ACP agent via the `gh` CLI command with the Copilot extension installed. Authentication is handled through `gh auth`, so no API keys are required in the config.

```yaml
llm:
  provider: "acp"
  acp:
    agent: "gh"
    cwd: "."
```

**Prerequisites for users:**
1. Install [GitHub CLI](https://cli.github.com/)
2. `gh extension install github/gh-copilot`
3. `gh auth login`