### PR TITLE
fix: correct stale import path for ExperimentGitManager

### DIFF
--- a/researchclaw/experiment/runner.py
+++ b/researchclaw/experiment/runner.py
@@ -118,7 +118,7 @@ class ExperimentRunner:
         # Git integration (Phase 3)
         self._git: _GitManager | None = None
         if git_repo_dir is not None:
-            from arc.experiment_git import ExperimentGitManager
+            from researchclaw.experiment.git_manager import ExperimentGitManager
             mgr = ExperimentGitManager(git_repo_dir)
             if mgr.is_git_repo():
                 self._git = mgr


### PR DESCRIPTION
## Summary
- `ExperimentRunner.__init__()` imports from `arc.experiment_git`, which is a pre-rename module path that no longer exists
- The actual class lives in `researchclaw.experiment.git_manager`
- Any call passing `git_repo_dir` raises `ModuleNotFoundError`

**One-line fix:** Update import to `researchclaw.experiment.git_manager`.

## Test plan
- [x] Verified `researchclaw.experiment.git_manager.ExperimentGitManager` exists
- [x] No other references to old `arc.experiment_git` path