### PR TITLE
fix(search): harden fetch clients and ACP query calls

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "rich>=13.0",
     "arxiv>=2.1",
     "numpy>=1.24",
+    "certifi>=2024.0.0",
 ]
 readme = "README.md"
 license = {text = "MIT"}

--- a/researchclaw/agents/code_searcher/github_client.py
+++ b/researchclaw/agents/code_searcher/github_client.py
@@ -21,6 +21,8 @@ from dataclasses import dataclass, field
 from typing import Any
 from urllib.parse import quote
 
+from researchclaw.utils.ssl_context import get_default_ssl_context
+
 logger = logging.getLogger(__name__)
 
 _GITHUB_API = "https://api.github.com"
@@ -104,7 +106,9 @@ class GitHubClient:
         self._request_count += 1
 
         try:
-            with urllib.request.urlopen(req, timeout=15) as resp:
+            with urllib.request.urlopen(
+                req, timeout=15, context=get_default_ssl_context(),
+            ) as resp:
                 return json.loads(resp.read().decode("utf-8"))
         except urllib.error.HTTPError as e:
             if e.code == 403:

--- a/researchclaw/agents/code_searcher/pattern_extractor.py
+++ b/researchclaw/agents/code_searcher/pattern_extractor.py
@@ -9,6 +9,7 @@ Uses LLM to analyze reference code and extract:
 
 from __future__ import annotations
 
+import inspect
 import json
 import logging
 import re
@@ -144,7 +145,13 @@ def _llm_extract(
             code_snippets=combined,
         )
 
-        if hasattr(llm, "chat"):
+        if hasattr(llm, "chat_sync"):
+            resp = llm.chat_sync(
+                [{"role": "user", "content": prompt}],
+                system="You extract code patterns as JSON.",
+                max_tokens=1500,
+            )
+        elif hasattr(llm, "chat"):
             import asyncio
             try:
                 loop = asyncio.get_running_loop()
@@ -152,11 +159,12 @@ def _llm_extract(
                 loop = None
             if loop and loop.is_running():
                 return _heuristic_extract(snippets)
-            resp = llm.chat(
+            chat_call = llm.chat(
                 [{"role": "user", "content": prompt}],
                 system="You extract code patterns as JSON.",
                 max_tokens=1500,
             )
+            resp = asyncio.run(chat_call) if inspect.isawaitable(chat_call) else chat_call
         else:
             return _heuristic_extract(snippets)
 

--- a/researchclaw/agents/code_searcher/query_gen.py
+++ b/researchclaw/agents/code_searcher/query_gen.py
@@ -6,6 +6,7 @@ for GitHub repository and code search.
 
 from __future__ import annotations
 
+import inspect
 import json
 import logging
 import re
@@ -129,14 +130,28 @@ def _llm_generate(
             needs=", ".join(needs) if needs else "general usage",
         )
 
-        # Synchronous LLM call — LLMClient.chat() is sync and takes
-        # (messages, *, system=, max_tokens=) signature.
-        if hasattr(llm, "chat"):
-            resp = llm.chat(
+        if hasattr(llm, "chat_sync"):
+            resp = llm.chat_sync(
                 [{"role": "user", "content": prompt}],
                 system="You generate concise GitHub search queries.",
                 max_tokens=200,
             )
+        elif hasattr(llm, "chat"):
+            import asyncio
+            try:
+                loop = asyncio.get_running_loop()
+            except RuntimeError:
+                loop = None
+            if loop and loop.is_running():
+                # Already in async context — use heuristic fallback
+                logger.debug("In async context, using heuristic query gen")
+                return _heuristic_generate(topic, domain_name, libraries, needs)
+            chat_call = llm.chat(
+                [{"role": "user", "content": prompt}],
+                system="You generate concise GitHub search queries.",
+                max_tokens=200,
+            )
+            resp = asyncio.run(chat_call) if inspect.isawaitable(chat_call) else chat_call
         else:
             return _heuristic_generate(topic, domain_name, libraries, needs)
 

--- a/researchclaw/domains/detector.py
+++ b/researchclaw/domains/detector.py
@@ -13,6 +13,7 @@ Detection strategy (three-level):
 
 from __future__ import annotations
 
+import inspect
 import logging
 import re
 from dataclasses import dataclass, field
@@ -335,11 +336,30 @@ def _llm_detect(
     """
     try:
         prompt = _LLM_CLASSIFY_PROMPT.format(topic=topic, context=context)
-        response = llm.chat(
-            [{"role": "user", "content": prompt}],
-            system="You are a precise domain classifier.",
-            max_tokens=50,
-        )
+        if hasattr(llm, "chat_sync"):
+            response = llm.chat_sync(
+                [{"role": "user", "content": prompt}],
+                system="You are a precise domain classifier.",
+                max_tokens=50,
+            )
+        else:
+            chat_call = llm.chat(
+                [{"role": "user", "content": prompt}],
+                system="You are a precise domain classifier.",
+                max_tokens=50,
+            )
+            response = chat_call
+            if inspect.isawaitable(chat_call):
+                import asyncio
+                try:
+                    loop = asyncio.get_running_loop()
+                except RuntimeError:
+                    loop = None
+                if loop and loop.is_running():
+                    logger.warning("LLM domain detection called from running event loop")
+                    return None
+                response = asyncio.run(chat_call)
+
         content = getattr(response, "content", None)
         if not content or not content.strip():
             logger.warning("LLM domain detection returned empty response")

--- a/researchclaw/literature/openalex_client.py
+++ b/researchclaw/literature/openalex_client.py
@@ -29,6 +29,7 @@ import urllib.request
 from typing import Any
 
 from researchclaw.literature.models import Author, Paper
+from researchclaw.utils.ssl_context import get_default_ssl_context
 
 logger = logging.getLogger(__name__)
 
@@ -137,7 +138,11 @@ def _request_with_retry(
                     "User-Agent": f"ResearchClaw/1.0 (mailto:{email})",
                 },
             )
-            with urllib.request.urlopen(req, timeout=_TIMEOUT_SEC) as resp:
+            with urllib.request.urlopen(
+                req,
+                timeout=_TIMEOUT_SEC,
+                context=get_default_ssl_context(),
+            ) as resp:
                 body = resp.read().decode("utf-8")
                 return json.loads(body)
         except urllib.error.HTTPError as exc:

--- a/researchclaw/literature/semantic_scholar.py
+++ b/researchclaw/literature/semantic_scholar.py
@@ -28,6 +28,7 @@ import urllib.request
 from typing import Any
 
 from researchclaw.literature.models import Author, Paper
+from researchclaw.utils.ssl_context import get_default_ssl_context
 
 logger = logging.getLogger(__name__)
 
@@ -228,7 +229,11 @@ def _request_with_retry(
     for attempt in range(_MAX_RETRIES):
         try:
             req = urllib.request.Request(url, headers=headers)
-            with urllib.request.urlopen(req, timeout=_TIMEOUT_SEC) as resp:
+            with urllib.request.urlopen(
+                req,
+                timeout=_TIMEOUT_SEC,
+                context=get_default_ssl_context(),
+            ) as resp:
                 body = resp.read().decode("utf-8")
                 _cb_on_success()
                 return json.loads(body)
@@ -345,7 +350,11 @@ def _post_with_retry(
     for attempt in range(_MAX_RETRIES):
         try:
             req = urllib.request.Request(url, data=body, headers=headers, method="POST")
-            with urllib.request.urlopen(req, timeout=_TIMEOUT_SEC) as resp:
+            with urllib.request.urlopen(
+                req,
+                timeout=_TIMEOUT_SEC,
+                context=get_default_ssl_context(),
+            ) as resp:
                 data = json.loads(resp.read().decode("utf-8"))
                 _cb_on_success()
                 return data if isinstance(data, list) else None

--- a/researchclaw/literature/verify.py
+++ b/researchclaw/literature/verify.py
@@ -32,6 +32,7 @@ from enum import Enum
 from typing import Sequence
 
 from researchclaw.literature.models import Author, Paper
+from researchclaw.utils.ssl_context import get_default_ssl_context
 
 logger = logging.getLogger(__name__)
 
@@ -189,7 +190,11 @@ def verify_by_arxiv_id(arxiv_id: str, expected_title: str) -> CitationResult | N
 
     try:
         req = urllib.request.Request(url, headers={"User-Agent": "ResearchClaw/0.1"})
-        with urllib.request.urlopen(req, timeout=_ARXIV_TIMEOUT) as resp:
+        with urllib.request.urlopen(
+            req,
+            timeout=_ARXIV_TIMEOUT,
+            context=get_default_ssl_context(),
+        ) as resp:
             data = resp.read().decode("utf-8")
     except Exception as exc:
         logger.debug("arXiv ID verification failed for %s: %s", arxiv_id, exc)
@@ -288,7 +293,11 @@ def _verify_doi_datacite(doi: str, expected_title: str) -> CitationResult | None
                 "Accept": "application/json",
             },
         )
-        with urllib.request.urlopen(req, timeout=_DATACITE_TIMEOUT) as resp:
+        with urllib.request.urlopen(
+            req,
+            timeout=_DATACITE_TIMEOUT,
+            context=get_default_ssl_context(),
+        ) as resp:
             body = json.loads(resp.read().decode("utf-8"))
     except urllib.error.HTTPError as exc:
         if exc.code == 404:
@@ -368,7 +377,11 @@ def verify_by_doi(doi: str, expected_title: str) -> CitationResult | None:
                 "Accept": "application/json",
             },
         )
-        with urllib.request.urlopen(req, timeout=_CROSSREF_TIMEOUT) as resp:
+        with urllib.request.urlopen(
+            req,
+            timeout=_CROSSREF_TIMEOUT,
+            context=get_default_ssl_context(),
+        ) as resp:
             body = json.loads(resp.read().decode("utf-8"))
     except urllib.error.HTTPError as exc:
         if exc.code == 404:
@@ -468,7 +481,11 @@ def verify_by_openalex(title: str) -> CitationResult | None:
                 "Accept": "application/json",
             },
         )
-        with urllib.request.urlopen(req, timeout=_OPENALEX_TIMEOUT) as resp:
+        with urllib.request.urlopen(
+            req,
+            timeout=_OPENALEX_TIMEOUT,
+            context=get_default_ssl_context(),
+        ) as resp:
             body = json.loads(resp.read().decode("utf-8"))
     except Exception as exc:
         logger.debug("OpenAlex search failed for %r: %s", title, exc)

--- a/researchclaw/metaclaw_bridge/prm_gate.py
+++ b/researchclaw/metaclaw_bridge/prm_gate.py
@@ -15,6 +15,8 @@ import urllib.request
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from statistics import mode
 
+from researchclaw.utils.ssl_context import get_default_ssl_context
+
 logger = logging.getLogger(__name__)
 
 # Stage-specific evaluation instructions
@@ -95,7 +97,7 @@ def _single_judge_call(
     )
 
     try:
-        with urllib.request.urlopen(req, timeout=60) as resp:
+        with urllib.request.urlopen(req, timeout=60, context=get_default_ssl_context()) as resp:
             data = json.loads(resp.read())
         content = data["choices"][0]["message"]["content"]
         # Parse "Score: X"

--- a/researchclaw/utils/ssl_context.py
+++ b/researchclaw/utils/ssl_context.py
@@ -1,0 +1,14 @@
+"""Helpers for creating a consistent HTTPS trust store for urllib clients."""
+
+from __future__ import annotations
+
+import ssl
+from functools import lru_cache
+
+import certifi
+
+
+@lru_cache(maxsize=1)
+def get_default_ssl_context() -> ssl.SSLContext:
+    """Return an SSL context backed by certifi's CA bundle."""
+    return ssl.create_default_context(cafile=certifi.where())

--- a/researchclaw/web/crawler.py
+++ b/researchclaw/web/crawler.py
@@ -21,6 +21,8 @@ from dataclasses import dataclass, field
 from typing import Any
 from urllib.request import Request, urlopen
 
+from researchclaw.utils.ssl_context import get_default_ssl_context
+
 logger = logging.getLogger(__name__)
 
 
@@ -192,7 +194,7 @@ class WebCrawler:
     def _crawl_with_urllib(self, url: str, t0: float) -> CrawlResult:
         """Lightweight fallback: fetch HTML and strip tags."""
         req = Request(url, headers={"User-Agent": self.user_agent})
-        resp = urlopen(req, timeout=self.timeout)  # noqa: S310
+        resp = urlopen(req, timeout=self.timeout, context=get_default_ssl_context())  # noqa: S310
         content_type = resp.headers.get("Content-Type", "")
         raw = resp.read()
 

--- a/researchclaw/web/pdf_extractor.py
+++ b/researchclaw/web/pdf_extractor.py
@@ -20,6 +20,8 @@ from pathlib import Path
 from typing import Any
 from urllib.request import Request, urlopen
 
+from researchclaw.utils.ssl_context import get_default_ssl_context
+
 try:
     import fitz  # PyMuPDF
     HAS_FITZ = True
@@ -145,7 +147,7 @@ class PDFExtractor:
             req = Request(url, headers={
                 "User-Agent": "ResearchClaw/0.5 (Academic Research Bot)"
             })
-            resp = urlopen(req, timeout=30)  # noqa: S310
+            resp = urlopen(req, timeout=30, context=get_default_ssl_context())  # noqa: S310
             data = resp.read()
 
             with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:

--- a/researchclaw/web/search.py
+++ b/researchclaw/web/search.py
@@ -20,6 +20,8 @@ from typing import Any
 from urllib.request import Request, urlopen
 from urllib.parse import quote_plus
 
+from researchclaw.utils.ssl_context import get_default_ssl_context
+
 logger = logging.getLogger(__name__)
 
 
@@ -201,7 +203,7 @@ class WebSearchClient:
         })
 
         try:
-            resp = urlopen(req, timeout=15)  # noqa: S310
+            resp = urlopen(req, timeout=15, context=get_default_ssl_context())  # noqa: S310
             html = resp.read().decode("utf-8", errors="replace")
         except Exception as exc:  # noqa: BLE001
             elapsed = time.monotonic() - t0

--- a/tests/test_code_searcher.py
+++ b/tests/test_code_searcher.py
@@ -6,6 +6,7 @@ import json
 import time
 import pytest
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from researchclaw.agents.code_searcher.agent import CodeSearchAgent, CodeSearchResult
@@ -35,6 +36,24 @@ from researchclaw.domains.detector import DomainProfile, get_profile
 
 
 class TestQueryGeneration:
+    class _FakeAsyncLLM:
+        def __init__(self, response_text: str):
+            self.response_text = response_text
+            self.calls: list[tuple[list[dict[str, str]], dict[str, object]]] = []
+
+        async def chat(self, messages: list[dict[str, str]], **kwargs: object):
+            self.calls.append((messages, kwargs))
+            return SimpleNamespace(content=self.response_text)
+
+    class _FakeSyncLLM:
+        def __init__(self, response_text: str):
+            self.response_text = response_text
+            self.calls: list[tuple[list[dict[str, str]], dict[str, object]]] = []
+
+        def chat(self, messages: list[dict[str, str]], **kwargs: object):
+            self.calls.append((messages, kwargs))
+            return SimpleNamespace(content=self.response_text)
+
     def test_heuristic_generates_queries(self):
         queries = _heuristic_generate(
             topic="finite element method for Poisson equation",
@@ -73,6 +92,36 @@ class TestQueryGeneration:
         )
         assert isinstance(queries, list)
         assert len(queries) >= 2
+
+    def test_generate_with_llm_uses_messages_interface(self):
+        llm = self._FakeAsyncLLM('["numpy example", "scipy tutorial"]')
+
+        queries = generate_search_queries(
+            topic="molecular dynamics simulation",
+            domain_name="Computational Physics",
+            core_libraries=["numpy", "scipy"],
+            llm=llm,
+        )
+
+        assert queries == ["numpy example", "scipy tutorial"]
+        assert len(llm.calls) == 1
+        messages, kwargs = llm.calls[0]
+        assert messages[0]["role"] == "user"
+        assert messages[0]["content"]
+        assert kwargs["system"] == "You generate concise GitHub search queries."
+
+    def test_generate_with_sync_llm_does_not_require_asyncio(self):
+        llm = self._FakeSyncLLM('["numpy example", "scipy tutorial"]')
+
+        queries = generate_search_queries(
+            topic="molecular dynamics simulation",
+            domain_name="Computational Physics",
+            core_libraries=["numpy", "scipy"],
+            llm=llm,
+        )
+
+        assert queries == ["numpy example", "scipy tutorial"]
+        assert len(llm.calls) == 1
 
 
 # ---------------------------------------------------------------------------
@@ -118,6 +167,49 @@ class TestPatternExtractor:
 
         with_data = CodePatterns(api_patterns=["import x"])
         assert with_data.has_content
+
+    def test_extract_patterns_with_llm_uses_messages_interface(self):
+        llm = TestQueryGeneration._FakeAsyncLLM(
+            json.dumps({
+                "api_patterns": ["import numpy as np"],
+                "file_structure": {"main.py": "entry point"},
+                "evaluation_patterns": ["print(acc)"],
+                "library_versions": {"numpy": "1.0"},
+            }),
+        )
+
+        patterns = extract_patterns(
+            ["import numpy as np\nprint('hi')"],
+            topic="test topic",
+            domain_name="Test Domain",
+            llm=llm,
+        )
+
+        assert patterns.api_patterns == ["import numpy as np"]
+        assert len(llm.calls) == 1
+        messages, kwargs = llm.calls[0]
+        assert messages[0]["role"] == "user"
+        assert messages[0]["content"]
+        assert kwargs["system"] == "You extract code patterns as JSON."
+
+    def test_extract_patterns_with_sync_llm_does_not_require_asyncio(self):
+        llm = TestQueryGeneration._FakeSyncLLM(
+            json.dumps({
+                "api_patterns": ["import numpy as np"],
+                "file_structure": {"main.py": "entry point"},
+                "evaluation_patterns": ["print(acc)"],
+                "library_versions": {"numpy": "1.0"},
+            }),
+        )
+
+        patterns = extract_patterns(
+            ["import numpy as np\nprint('hi')"],
+            topic="test topic",
+            domain_name="Test Domain",
+            llm=llm,
+        )
+
+        assert patterns.api_patterns == ["import numpy as np"]
 
 
 # ---------------------------------------------------------------------------
@@ -221,6 +313,35 @@ class TestGitHubClient:
         client = GitHubClient(token="")
         headers = client._headers()
         assert "Authorization" not in headers
+
+    def test_get_uses_certifi_ssl_context(self, monkeypatch: pytest.MonkeyPatch):
+        client = GitHubClient(token="")
+        ssl_context = object()
+        captured: dict[str, object] = {}
+
+        class _Resp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self) -> bytes:
+                return b'{"items":[]}'
+
+        def fake_urlopen(req, **kwargs):
+            captured["context"] = kwargs.get("context")
+            return _Resp()
+
+        monkeypatch.setattr(
+            "researchclaw.agents.code_searcher.github_client.get_default_ssl_context",
+            lambda: ssl_context,
+        )
+        with patch("urllib.request.urlopen", fake_urlopen):
+            result = client._get("https://api.github.com/search/repositories")
+
+        assert result == {"items": []}
+        assert captured["context"] is ssl_context
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_rc_literature.py
+++ b/tests/test_rc_literature.py
@@ -743,6 +743,39 @@ class TestOpenAlex:
         papers = search_openalex("test", limit=5)
         assert papers == []
 
+    def test_openalex_uses_certifi_ssl_context(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """OpenAlex requests should pass an explicit SSL context."""
+        from researchclaw.literature.openalex_client import search_openalex
+
+        response_bytes = json.dumps(SAMPLE_OPENALEX_RESPONSE).encode("utf-8")
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = response_bytes
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        ssl_context = object()
+        captured: dict[str, object] = {}
+
+        def fake_urlopen(*args, **kwargs):
+            captured.update(kwargs)
+            return mock_resp
+
+        monkeypatch.setattr(
+            "researchclaw.literature.openalex_client.get_default_ssl_context",
+            lambda: ssl_context,
+        )
+        monkeypatch.setattr(
+            "researchclaw.literature.openalex_client.urllib.request.urlopen",
+            fake_urlopen,
+        )
+
+        papers = search_openalex("attention", limit=5)
+
+        assert len(papers) == 1
+        assert captured["context"] is ssl_context
+
 
 # ──────────────────────────────────────────────────────────────────────
 # Multi-source fallback tests

--- a/tests/test_web_crawler.py
+++ b/tests/test_web_crawler.py
@@ -112,6 +112,27 @@ class TestCrawlUrllibFallback:
         result = crawler._crawl_with_urllib("https://example.com", t0)
         assert len(result.markdown) <= 1100  # 1000 + truncation notice
 
+    def test_crawl_urllib_uses_certifi_ssl_context(self, monkeypatch: pytest.MonkeyPatch):
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = b"<html><body><p>Content here</p></body></html>"
+        mock_resp.headers = {"Content-Type": "text/html; charset=utf-8"}
+        ssl_context = object()
+        captured: dict[str, object] = {}
+
+        def fake_urlopen(*args, **kwargs):
+            captured["context"] = kwargs.get("context")
+            return mock_resp
+
+        monkeypatch.setattr("researchclaw.web.crawler.get_default_ssl_context", lambda: ssl_context)
+        monkeypatch.setattr("researchclaw.web.crawler.urlopen", fake_urlopen)
+
+        crawler = WebCrawler()
+        import time
+        t0 = time.monotonic()
+        _ = crawler._crawl_with_urllib("https://example.com", t0)
+
+        assert captured["context"] is ssl_context
+
 
 # ---------------------------------------------------------------------------
 # Sync crawl (goes through crawl4ai → urllib fallback chain)

--- a/tests/test_web_pdf_extractor.py
+++ b/tests/test_web_pdf_extractor.py
@@ -95,3 +95,22 @@ We evaluate on several benchmarks.
         extractor = PDFExtractor()
         result = extractor.extract_from_url("https://example.com/paper.pdf")
         assert not result.success or result.error
+
+    def test_extract_from_url_uses_certifi_ssl_context(self, monkeypatch: pytest.MonkeyPatch):
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = b"%PDF-1.4"
+        ssl_context = object()
+        captured: dict[str, object] = {}
+
+        def fake_urlopen(*args, **kwargs):
+            captured["context"] = kwargs.get("context")
+            return mock_resp
+
+        monkeypatch.setattr("researchclaw.web.pdf_extractor.get_default_ssl_context", lambda: ssl_context)
+        monkeypatch.setattr("researchclaw.web.pdf_extractor.urlopen", fake_urlopen)
+
+        extractor = PDFExtractor()
+        with patch.object(PDFExtractor, "extract", return_value=PDFContent(path="tmp.pdf", success=True)):
+            _ = extractor.extract_from_url("https://example.com/paper.pdf")
+
+        assert captured["context"] is ssl_context

--- a/tests/test_web_search.py
+++ b/tests/test_web_search.py
@@ -155,3 +155,25 @@ class TestWebSearchClient:
                 r.url != responses[0].results[0].url
                 for r in responses[1].results
             )
+
+    def test_search_ddg_uses_certifi_ssl_context(self, monkeypatch: pytest.MonkeyPatch):
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = b"""
+        <a class="result__a" href="https://paper.com">Paper Title</a>
+        <a class="result__snippet">About the paper</a>
+        """
+        ssl_context = object()
+        captured: dict[str, object] = {}
+
+        def fake_urlopen(*args, **kwargs):
+            captured["context"] = kwargs.get("context")
+            return mock_resp
+
+        monkeypatch.setattr("researchclaw.web.search.get_default_ssl_context", lambda: ssl_context)
+        monkeypatch.setattr("researchclaw.web.search.urlopen", fake_urlopen)
+
+        client = WebSearchClient(api_key="")
+        response = client.search("test query")
+
+        assert response.source == "duckduckgo"
+        assert captured["context"] is ssl_context


### PR DESCRIPTION
## Summary
- switch the search and fetch clients onto a shared certifi-backed SSL context so GitHub, DuckDuckGo, literature lookups, crawler fetches, PDF downloads, and PRM gating no longer fail on local certificate chains
- update the ACP-backed code-search and domain-detection calls to use the client message interface that the current ACP client expects, while preserving newer `chat_sync` support from `main`
- add regression coverage for the new SSL helper and the ACP-safe query generation paths

## Why This Is Separate
This PR is only about search/fetch robustness and ACP-compatible query generation. It intentionally leaves the Codex setup and ACP doctor/runtime wiring to the ACP-focused PR.

## Tests
- `pytest tests/` on the pre-rebase branch head: passed (`1642 passed, 1 skipped`)
- `pytest tests/` after rebasing onto current `main`: blocked by an existing upstream failure in `tests/test_rc_runner.py::test_write_checkpoint_preserves_old_on_write_failure`
- `pytest tests/test_rc_runner.py -k test_write_checkpoint_preserves_old_on_write_failure` on detached `origin/main`: reproduces the same failure
