### PR TITLE
fix(runner): preserve checkpoints on temp write failures

### DIFF
--- a/researchclaw/pipeline/runner.py
+++ b/researchclaw/pipeline/runner.py
@@ -80,12 +80,15 @@ def _write_checkpoint(run_dir: Path, stage: Stage, run_id: str) -> None:
     }
     target = run_dir / "checkpoint.json"
     fd, tmp_path = tempfile.mkstemp(dir=run_dir, suffix=".tmp", prefix="checkpoint_")
-    os.close(fd)
     try:
-        with open(tmp_path, "w", encoding="utf-8") as fh:
+        with open(fd, "w", encoding="utf-8", closefd=True) as fh:
             fh.write(json.dumps(checkpoint, indent=2))
         Path(tmp_path).replace(target)
     except BaseException:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
         Path(tmp_path).unlink(missing_ok=True)
         raise
 

--- a/tests/test_rc_runner.py
+++ b/tests/test_rc_runner.py
@@ -752,6 +752,28 @@ def test_write_checkpoint_preserves_old_on_write_failure(
     assert list(run_dir.glob("checkpoint_*.tmp")) == []
 
 
+def test_write_checkpoint_preserves_old_on_rename_failure(
+    run_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If the final rename fails, the existing checkpoint must survive."""
+    rc_runner._write_checkpoint(run_dir, Stage.TOPIC_INIT, "run-ok")
+
+    original_replace = Path.replace
+
+    def _exploding_replace(self: Path, target: Path) -> Path:
+        if self.name.startswith("checkpoint_") and self.suffix == ".tmp":
+            raise OSError("rename failed")
+        return original_replace(self, target)
+
+    monkeypatch.setattr(Path, "replace", _exploding_replace)
+    with pytest.raises(OSError):
+        rc_runner._write_checkpoint(run_dir, Stage.PROBLEM_DECOMPOSE, "run-ok")
+
+    data = json.loads((run_dir / "checkpoint.json").read_text(encoding="utf-8"))
+    assert data["last_completed_stage"] == int(Stage.TOPIC_INIT)
+    assert list(run_dir.glob("checkpoint_*.tmp")) == []
+
+
 def test_write_checkpoint_overwrites_previous(run_dir: Path) -> None:
     """A second checkpoint call must fully replace the first"""
     rc_runner._write_checkpoint(run_dir, Stage.TOPIC_INIT, "run-1")


### PR DESCRIPTION
## Summary
- write checkpoint JSON through the `mkstemp` file descriptor instead of reopening by path, so temp-file open failures are surfaced and the old checkpoint remains intact
- keep the existing cleanup behavior so failed writes and failed renames both remove the temp file instead of leaving checkpoint debris behind
- add a rename-failure regression test alongside the existing write-failure coverage

## Why This Is Separate
This PR only fixes the checkpoint atomic-write regression that is currently breaking `tests/test_rc_runner.py`. It does not touch ACP integration or search/fetch clients.

## Tests
- `pytest tests/test_rc_runner.py -k "write_checkpoint"`
- `pytest tests/`
