### PR TITLE
fix(network): use certifi SSL context for urllib clients

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "rich>=13.0",
     "arxiv>=2.1",
     "numpy>=1.24",
+    "certifi>=2024.0.0",
 ]
 readme = "README.md"
 license = {text = "MIT"}

--- a/researchclaw/agents/code_searcher/github_client.py
+++ b/researchclaw/agents/code_searcher/github_client.py
@@ -21,6 +21,8 @@ from dataclasses import dataclass, field
 from typing import Any
 from urllib.parse import quote
 
+from researchclaw.utils.ssl_context import get_default_ssl_context
+
 logger = logging.getLogger(__name__)
 
 _GITHUB_API = "https://api.github.com"
@@ -104,7 +106,9 @@ class GitHubClient:
         self._request_count += 1
 
         try:
-            with urllib.request.urlopen(req, timeout=15) as resp:
+            with urllib.request.urlopen(
+                req, timeout=15, context=get_default_ssl_context(),
+            ) as resp:
                 return json.loads(resp.read().decode("utf-8"))
         except urllib.error.HTTPError as e:
             if e.code == 403:

--- a/researchclaw/literature/openalex_client.py
+++ b/researchclaw/literature/openalex_client.py
@@ -29,6 +29,7 @@ import urllib.request
 from typing import Any
 
 from researchclaw.literature.models import Author, Paper
+from researchclaw.utils.ssl_context import get_default_ssl_context
 
 logger = logging.getLogger(__name__)
 
@@ -137,7 +138,11 @@ def _request_with_retry(
                     "User-Agent": f"ResearchClaw/1.0 (mailto:{email})",
                 },
             )
-            with urllib.request.urlopen(req, timeout=_TIMEOUT_SEC) as resp:
+            with urllib.request.urlopen(
+                req,
+                timeout=_TIMEOUT_SEC,
+                context=get_default_ssl_context(),
+            ) as resp:
                 body = resp.read().decode("utf-8")
                 return json.loads(body)
         except urllib.error.HTTPError as exc:

--- a/researchclaw/literature/semantic_scholar.py
+++ b/researchclaw/literature/semantic_scholar.py
@@ -28,6 +28,7 @@ import urllib.request
 from typing import Any
 
 from researchclaw.literature.models import Author, Paper
+from researchclaw.utils.ssl_context import get_default_ssl_context
 
 logger = logging.getLogger(__name__)
 
@@ -228,7 +229,11 @@ def _request_with_retry(
     for attempt in range(_MAX_RETRIES):
         try:
             req = urllib.request.Request(url, headers=headers)
-            with urllib.request.urlopen(req, timeout=_TIMEOUT_SEC) as resp:
+            with urllib.request.urlopen(
+                req,
+                timeout=_TIMEOUT_SEC,
+                context=get_default_ssl_context(),
+            ) as resp:
                 body = resp.read().decode("utf-8")
                 _cb_on_success()
                 return json.loads(body)
@@ -345,7 +350,11 @@ def _post_with_retry(
     for attempt in range(_MAX_RETRIES):
         try:
             req = urllib.request.Request(url, data=body, headers=headers, method="POST")
-            with urllib.request.urlopen(req, timeout=_TIMEOUT_SEC) as resp:
+            with urllib.request.urlopen(
+                req,
+                timeout=_TIMEOUT_SEC,
+                context=get_default_ssl_context(),
+            ) as resp:
                 data = json.loads(resp.read().decode("utf-8"))
                 _cb_on_success()
                 return data if isinstance(data, list) else None

--- a/researchclaw/literature/verify.py
+++ b/researchclaw/literature/verify.py
@@ -32,6 +32,7 @@ from enum import Enum
 from typing import Sequence
 
 from researchclaw.literature.models import Author, Paper
+from researchclaw.utils.ssl_context import get_default_ssl_context
 
 logger = logging.getLogger(__name__)
 
@@ -189,7 +190,11 @@ def verify_by_arxiv_id(arxiv_id: str, expected_title: str) -> CitationResult | N
 
     try:
         req = urllib.request.Request(url, headers={"User-Agent": "ResearchClaw/0.1"})
-        with urllib.request.urlopen(req, timeout=_ARXIV_TIMEOUT) as resp:
+        with urllib.request.urlopen(
+            req,
+            timeout=_ARXIV_TIMEOUT,
+            context=get_default_ssl_context(),
+        ) as resp:
             data = resp.read().decode("utf-8")
     except Exception as exc:
         logger.debug("arXiv ID verification failed for %s: %s", arxiv_id, exc)
@@ -288,7 +293,11 @@ def _verify_doi_datacite(doi: str, expected_title: str) -> CitationResult | None
                 "Accept": "application/json",
             },
         )
-        with urllib.request.urlopen(req, timeout=_DATACITE_TIMEOUT) as resp:
+        with urllib.request.urlopen(
+            req,
+            timeout=_DATACITE_TIMEOUT,
+            context=get_default_ssl_context(),
+        ) as resp:
             body = json.loads(resp.read().decode("utf-8"))
     except urllib.error.HTTPError as exc:
         if exc.code == 404:
@@ -368,7 +377,11 @@ def verify_by_doi(doi: str, expected_title: str) -> CitationResult | None:
                 "Accept": "application/json",
             },
         )
-        with urllib.request.urlopen(req, timeout=_CROSSREF_TIMEOUT) as resp:
+        with urllib.request.urlopen(
+            req,
+            timeout=_CROSSREF_TIMEOUT,
+            context=get_default_ssl_context(),
+        ) as resp:
             body = json.loads(resp.read().decode("utf-8"))
     except urllib.error.HTTPError as exc:
         if exc.code == 404:
@@ -468,7 +481,11 @@ def verify_by_openalex(title: str) -> CitationResult | None:
                 "Accept": "application/json",
             },
         )
-        with urllib.request.urlopen(req, timeout=_OPENALEX_TIMEOUT) as resp:
+        with urllib.request.urlopen(
+            req,
+            timeout=_OPENALEX_TIMEOUT,
+            context=get_default_ssl_context(),
+        ) as resp:
             body = json.loads(resp.read().decode("utf-8"))
     except Exception as exc:
         logger.debug("OpenAlex search failed for %r: %s", title, exc)

--- a/researchclaw/metaclaw_bridge/prm_gate.py
+++ b/researchclaw/metaclaw_bridge/prm_gate.py
@@ -15,6 +15,8 @@ import urllib.request
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from statistics import mode
 
+from researchclaw.utils.ssl_context import get_default_ssl_context
+
 logger = logging.getLogger(__name__)
 
 # Stage-specific evaluation instructions
@@ -95,7 +97,7 @@ def _single_judge_call(
     )
 
     try:
-        with urllib.request.urlopen(req, timeout=60) as resp:
+        with urllib.request.urlopen(req, timeout=60, context=get_default_ssl_context()) as resp:
             data = json.loads(resp.read())
         content = data["choices"][0]["message"]["content"]
         # Parse "Score: X"

--- a/researchclaw/utils/ssl_context.py
+++ b/researchclaw/utils/ssl_context.py
@@ -1,0 +1,14 @@
+"""Helpers for creating a consistent HTTPS trust store for urllib clients."""
+
+from __future__ import annotations
+
+import ssl
+from functools import lru_cache
+
+import certifi
+
+
+@lru_cache(maxsize=1)
+def get_default_ssl_context() -> ssl.SSLContext:
+    """Return an SSL context backed by certifi's CA bundle."""
+    return ssl.create_default_context(cafile=certifi.where())

--- a/researchclaw/web/crawler.py
+++ b/researchclaw/web/crawler.py
@@ -21,6 +21,8 @@ from dataclasses import dataclass, field
 from typing import Any
 from urllib.request import Request, urlopen
 
+from researchclaw.utils.ssl_context import get_default_ssl_context
+
 logger = logging.getLogger(__name__)
 
 
@@ -192,7 +194,7 @@ class WebCrawler:
     def _crawl_with_urllib(self, url: str, t0: float) -> CrawlResult:
         """Lightweight fallback: fetch HTML and strip tags."""
         req = Request(url, headers={"User-Agent": self.user_agent})
-        resp = urlopen(req, timeout=self.timeout)  # noqa: S310
+        resp = urlopen(req, timeout=self.timeout, context=get_default_ssl_context())  # noqa: S310
         content_type = resp.headers.get("Content-Type", "")
         raw = resp.read()
 

--- a/researchclaw/web/pdf_extractor.py
+++ b/researchclaw/web/pdf_extractor.py
@@ -20,6 +20,8 @@ from pathlib import Path
 from typing import Any
 from urllib.request import Request, urlopen
 
+from researchclaw.utils.ssl_context import get_default_ssl_context
+
 try:
     import fitz  # PyMuPDF
     HAS_FITZ = True
@@ -145,7 +147,7 @@ class PDFExtractor:
             req = Request(url, headers={
                 "User-Agent": "ResearchClaw/0.5 (Academic Research Bot)"
             })
-            resp = urlopen(req, timeout=30)  # noqa: S310
+            resp = urlopen(req, timeout=30, context=get_default_ssl_context())  # noqa: S310
             data = resp.read()
 
             with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:

--- a/researchclaw/web/search.py
+++ b/researchclaw/web/search.py
@@ -20,6 +20,8 @@ from typing import Any
 from urllib.request import Request, urlopen
 from urllib.parse import quote_plus
 
+from researchclaw.utils.ssl_context import get_default_ssl_context
+
 logger = logging.getLogger(__name__)
 
 
@@ -201,7 +203,7 @@ class WebSearchClient:
         })
 
         try:
-            resp = urlopen(req, timeout=15)  # noqa: S310
+            resp = urlopen(req, timeout=15, context=get_default_ssl_context())  # noqa: S310
             html = resp.read().decode("utf-8", errors="replace")
         except Exception as exc:  # noqa: BLE001
             elapsed = time.monotonic() - t0

--- a/tests/test_code_searcher.py
+++ b/tests/test_code_searcher.py
@@ -222,6 +222,35 @@ class TestGitHubClient:
         headers = client._headers()
         assert "Authorization" not in headers
 
+    def test_get_uses_certifi_ssl_context(self, monkeypatch: pytest.MonkeyPatch):
+        client = GitHubClient(token="")
+        ssl_context = object()
+        captured: dict[str, object] = {}
+
+        class _Resp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self) -> bytes:
+                return b'{"items":[]}'
+
+        def fake_urlopen(req, **kwargs):
+            captured["context"] = kwargs.get("context")
+            return _Resp()
+
+        monkeypatch.setattr(
+            "researchclaw.agents.code_searcher.github_client.get_default_ssl_context",
+            lambda: ssl_context,
+        )
+        with patch("urllib.request.urlopen", fake_urlopen):
+            result = client._get("https://api.github.com/search/repositories")
+
+        assert result == {"items": []}
+        assert captured["context"] is ssl_context
+
 
 # ---------------------------------------------------------------------------
 # RepoInfo / CodeSnippet data class tests

--- a/tests/test_rc_literature.py
+++ b/tests/test_rc_literature.py
@@ -743,6 +743,39 @@ class TestOpenAlex:
         papers = search_openalex("test", limit=5)
         assert papers == []
 
+    def test_openalex_uses_certifi_ssl_context(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """OpenAlex requests should pass an explicit SSL context."""
+        from researchclaw.literature.openalex_client import search_openalex
+
+        response_bytes = json.dumps(SAMPLE_OPENALEX_RESPONSE).encode("utf-8")
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = response_bytes
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        ssl_context = object()
+        captured: dict[str, object] = {}
+
+        def fake_urlopen(*args, **kwargs):
+            captured.update(kwargs)
+            return mock_resp
+
+        monkeypatch.setattr(
+            "researchclaw.literature.openalex_client.get_default_ssl_context",
+            lambda: ssl_context,
+        )
+        monkeypatch.setattr(
+            "researchclaw.literature.openalex_client.urllib.request.urlopen",
+            fake_urlopen,
+        )
+
+        papers = search_openalex("attention", limit=5)
+
+        assert len(papers) == 1
+        assert captured["context"] is ssl_context
+
 
 # ──────────────────────────────────────────────────────────────────────
 # Multi-source fallback tests

--- a/tests/test_web_crawler.py
+++ b/tests/test_web_crawler.py
@@ -112,6 +112,27 @@ class TestCrawlUrllibFallback:
         result = crawler._crawl_with_urllib("https://example.com", t0)
         assert len(result.markdown) <= 1100  # 1000 + truncation notice
 
+    def test_crawl_urllib_uses_certifi_ssl_context(self, monkeypatch: pytest.MonkeyPatch):
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = b"<html><body><p>Content here</p></body></html>"
+        mock_resp.headers = {"Content-Type": "text/html; charset=utf-8"}
+        ssl_context = object()
+        captured: dict[str, object] = {}
+
+        def fake_urlopen(*args, **kwargs):
+            captured["context"] = kwargs.get("context")
+            return mock_resp
+
+        monkeypatch.setattr("researchclaw.web.crawler.get_default_ssl_context", lambda: ssl_context)
+        monkeypatch.setattr("researchclaw.web.crawler.urlopen", fake_urlopen)
+
+        crawler = WebCrawler()
+        import time
+        t0 = time.monotonic()
+        _ = crawler._crawl_with_urllib("https://example.com", t0)
+
+        assert captured["context"] is ssl_context
+
 
 # ---------------------------------------------------------------------------
 # Sync crawl (goes through crawl4ai → urllib fallback chain)

--- a/tests/test_web_pdf_extractor.py
+++ b/tests/test_web_pdf_extractor.py
@@ -95,3 +95,22 @@ We evaluate on several benchmarks.
         extractor = PDFExtractor()
         result = extractor.extract_from_url("https://example.com/paper.pdf")
         assert not result.success or result.error
+
+    def test_extract_from_url_uses_certifi_ssl_context(self, monkeypatch: pytest.MonkeyPatch):
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = b"%PDF-1.4"
+        ssl_context = object()
+        captured: dict[str, object] = {}
+
+        def fake_urlopen(*args, **kwargs):
+            captured["context"] = kwargs.get("context")
+            return mock_resp
+
+        monkeypatch.setattr("researchclaw.web.pdf_extractor.get_default_ssl_context", lambda: ssl_context)
+        monkeypatch.setattr("researchclaw.web.pdf_extractor.urlopen", fake_urlopen)
+
+        extractor = PDFExtractor()
+        with patch.object(PDFExtractor, "extract", return_value=PDFContent(path="tmp.pdf", success=True)):
+            _ = extractor.extract_from_url("https://example.com/paper.pdf")
+
+        assert captured["context"] is ssl_context

--- a/tests/test_web_search.py
+++ b/tests/test_web_search.py
@@ -155,3 +155,25 @@ class TestWebSearchClient:
                 r.url != responses[0].results[0].url
                 for r in responses[1].results
             )
+
+    def test_search_ddg_uses_certifi_ssl_context(self, monkeypatch: pytest.MonkeyPatch):
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = b"""
+        <a class="result__a" href="https://paper.com">Paper Title</a>
+        <a class="result__snippet">About the paper</a>
+        """
+        ssl_context = object()
+        captured: dict[str, object] = {}
+
+        def fake_urlopen(*args, **kwargs):
+            captured["context"] = kwargs.get("context")
+            return mock_resp
+
+        monkeypatch.setattr("researchclaw.web.search.get_default_ssl_context", lambda: ssl_context)
+        monkeypatch.setattr("researchclaw.web.search.urlopen", fake_urlopen)
+
+        client = WebSearchClient(api_key="")
+        response = client.search("test query")
+
+        assert response.source == "duckduckgo"
+        assert captured["context"] is ssl_context


### PR DESCRIPTION
## Summary
- resubmit only the SSL hardening portion from closed PR #103
- standardize urllib HTTPS calls on a shared `certifi`-backed SSL context
- intentionally drop the earlier LLM-call/interface changes (`chat_sync`, `inspect.isawaitable()`, `asyncio.run()`) per review feedback

## Why
Several urllib-based HTTPS clients in the repo can fail on local certificate chains. This change centralizes trust-store handling without changing LLM call semantics.

## What Changed
- added `certifi` as a runtime dependency
- added a shared SSL context helper
- wired that helper into the GitHub code search client, literature fetch/verify paths, PRM gate, DuckDuckGo fallback, crawler fallback, and PDF URL download
- kept only SSL-focused regression tests

## How To Test
- `pytest tests/test_code_searcher.py tests/test_rc_literature.py tests/test_web_crawler.py tests/test_web_pdf_extractor.py tests/test_web_search.py`
- `pytest tests/`

## Evidence
- Focused SSL suite: `114 passed`
- Full suite on this clean `main`-based branch: `1 failed, 1667 passed, 1 skipped`
- The failing test is the existing upstream regression `tests/test_rc_runner.py::test_write_checkpoint_preserves_old_on_write_failure`, which is addressed separately in PR #106

## Risk / Roll Back
Risk is limited to outbound urllib HTTPS behavior. Roll back by reverting this PR, which removes the shared SSL context helper and restores the previous urllib calls.
