### PR TITLE
feat: add MiniMax as first-class LLM provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,7 +397,7 @@ runtime:
 
 # === LLM ===
 llm:
-  provider: "openai-compatible"    # "openai-compatible" (default) or "acp"
+  provider: "openai-compatible"    # openai | openrouter | deepseek | minimax | acp | openai-compatible
   base_url: "https://..."          # API endpoint (required for openai-compatible)
   api_key_env: "OPENAI_API_KEY"    # Env var for API key (required for openai-compatible)
   api_key: ""                      # Or hardcode key here

--- a/config.researchclaw.example.yaml
+++ b/config.researchclaw.example.yaml
@@ -43,6 +43,12 @@ llm:
   fallback_models:
     - "gpt-4.1"
     - "gpt-4o-mini"
+  # --- MiniMax provider example ---
+  # provider: "minimax"
+  # api_key_env: "MINIMAX_API_KEY"
+  # primary_model: "MiniMax-M2.5"
+  # fallback_models:
+  #   - "MiniMax-M2.5-highspeed"
 
 security:
   hitl_required_stages: [5, 9, 20]

--- a/researchclaw/cli.py
+++ b/researchclaw/cli.py
@@ -323,13 +323,15 @@ _PROVIDER_CHOICES = {
     "1": ("openai", "OPENAI_API_KEY"),
     "2": ("openrouter", "OPENROUTER_API_KEY"),
     "3": ("deepseek", "DEEPSEEK_API_KEY"),
-    "4": ("acp", ""),
+    "4": ("minimax", "MINIMAX_API_KEY"),
+    "5": ("acp", ""),
 }
 
 _PROVIDER_URLS = {
     "openai": "https://api.openai.com/v1",
     "openrouter": "https://openrouter.ai/api/v1",
     "deepseek": "https://api.deepseek.com/v1",
+    "minimax": "https://api.minimax.io/v1",
 }
 
 _PROVIDER_MODELS = {
@@ -339,6 +341,7 @@ _PROVIDER_MODELS = {
         ["google/gemini-pro-1.5", "meta-llama/llama-3.1-70b-instruct"],
     ),
     "deepseek": ("deepseek-chat", ["deepseek-reasoner"]),
+    "minimax": ("MiniMax-M2.5", ["MiniMax-M2.5-highspeed"]),
 }
 
 
@@ -373,7 +376,8 @@ def cmd_init(args: argparse.Namespace) -> int:
         print("  1) openai       (requires OPENAI_API_KEY)")
         print("  2) openrouter   (requires OPENROUTER_API_KEY)")
         print("  3) deepseek     (requires DEEPSEEK_API_KEY)")
-        print("  4) acp          (local AI agent — no API key needed)")
+        print("  4) minimax      (requires MINIMAX_API_KEY)")
+        print("  5) acp          (local AI agent — no API key needed)")
         try:
             raw = input("Choice [1]: ").strip()
         except (EOFError, KeyboardInterrupt):

--- a/researchclaw/llm/__init__.py
+++ b/researchclaw/llm/__init__.py
@@ -26,6 +26,9 @@ PROVIDER_PRESETS = {
     "novita": {
         "base_url": "https://api.novita.ai/openai",
     },
+    "minimax": {
+        "base_url": "https://api.minimax.io/v1",
+    },
     "openai-compatible": {
         "base_url": None,  # Use user-provided base_url
     },
@@ -41,6 +44,7 @@ def create_llm_client(config: RCConfig) -> LLMClient | ACPClient:
     - ``"openai"`` → :class:`LLMClient` with OpenAI base URL
     - ``"deepseek"`` → :class:`LLMClient` with DeepSeek base URL
     - ``"novita"`` → :class:`LLMClient` with Novita AI base URL
+    - ``"minimax"`` → :class:`LLMClient` with MiniMax base URL
     - ``"openai-compatible"`` (default) → :class:`LLMClient` with custom base_url
 
     OpenRouter is fully compatible with the OpenAI API format, making it

--- a/researchclaw/llm/client.py
+++ b/researchclaw/llm/client.py
@@ -336,10 +336,16 @@ class LLMClient:
             # retries and model-fallback — each attempt must start from the
             # original, un-modified messages).
             msgs = [dict(m) for m in messages]
+
+            # MiniMax API requires temperature in [0, 1.0]
+            _temp = temperature
+            if "api.minimax.io" in self.config.base_url:
+                _temp = max(0.0, min(_temp, 1.0))
+
             body: dict[str, Any] = {
                 "model": model,
                 "messages": msgs,
-                "temperature": temperature,
+                "temperature": _temp,
             }
 
             # Use correct token parameter based on model

--- a/tests/test_minimax_provider.py
+++ b/tests/test_minimax_provider.py
@@ -1,0 +1,426 @@
+"""Tests for MiniMax provider integration.
+
+Covers: provider preset, CLI registration, factory wiring,
+temperature clamping, and live API integration.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.request
+from types import SimpleNamespace
+from typing import Any, Mapping
+
+import pytest
+
+from researchclaw.llm import PROVIDER_PRESETS, create_llm_client
+from researchclaw.llm.client import LLMClient, LLMConfig, LLMResponse
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+class _DummyHTTPResponse:
+    """Minimal stub for ``urllib.request.urlopen`` results."""
+
+    def __init__(self, payload: Mapping[str, Any]):
+        self._payload = payload
+
+    def read(self) -> bytes:
+        return json.dumps(self._payload).encode("utf-8")
+
+    def __enter__(self) -> _DummyHTTPResponse:
+        return self
+
+    def __exit__(self, *a: object) -> None:
+        return None
+
+
+def _make_minimax_client(
+    *,
+    api_key: str = "test-minimax-key",
+    primary_model: str = "MiniMax-M2.5",
+    fallback_models: list[str] | None = None,
+) -> LLMClient:
+    config = LLMConfig(
+        base_url="https://api.minimax.io/v1",
+        api_key=api_key,
+        primary_model=primary_model,
+        fallback_models=fallback_models or ["MiniMax-M2.5-highspeed"],
+    )
+    return LLMClient(config)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — provider preset
+# ---------------------------------------------------------------------------
+
+
+class TestMiniMaxPreset:
+    """Verify MiniMax is registered in PROVIDER_PRESETS."""
+
+    def test_minimax_in_provider_presets(self):
+        assert "minimax" in PROVIDER_PRESETS
+
+    def test_minimax_base_url(self):
+        assert PROVIDER_PRESETS["minimax"]["base_url"] == "https://api.minimax.io/v1"
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — from_rc_config wiring
+# ---------------------------------------------------------------------------
+
+
+class TestMiniMaxFromRCConfig:
+    """Verify that LLMClient.from_rc_config resolves MiniMax preset."""
+
+    def test_from_rc_config_sets_minimax_base_url(self):
+        rc_config = SimpleNamespace(
+            llm=SimpleNamespace(
+                provider="minimax",
+                base_url="",
+                api_key="mk-test",
+                api_key_env="",
+                primary_model="MiniMax-M2.5",
+                fallback_models=("MiniMax-M2.5-highspeed",),
+            ),
+        )
+        client = LLMClient.from_rc_config(rc_config)
+        assert client.config.base_url == "https://api.minimax.io/v1"
+        assert client.config.api_key == "mk-test"
+        assert client.config.primary_model == "MiniMax-M2.5"
+        assert client.config.fallback_models == ["MiniMax-M2.5-highspeed"]
+
+    def test_from_rc_config_reads_minimax_api_key_from_env(self, monkeypatch):
+        monkeypatch.setenv("MINIMAX_API_KEY", "env-minimax-key")
+        rc_config = SimpleNamespace(
+            llm=SimpleNamespace(
+                provider="minimax",
+                base_url="",
+                api_key="",
+                api_key_env="MINIMAX_API_KEY",
+                primary_model="MiniMax-M2.5",
+                fallback_models=(),
+            ),
+        )
+        client = LLMClient.from_rc_config(rc_config)
+        assert client.config.api_key == "env-minimax-key"
+
+    def test_from_rc_config_custom_base_url_overrides_preset(self):
+        rc_config = SimpleNamespace(
+            llm=SimpleNamespace(
+                provider="minimax",
+                base_url="https://custom-proxy.example/v1",
+                api_key="mk-test",
+                api_key_env="",
+                primary_model="MiniMax-M2.5",
+                fallback_models=(),
+            ),
+        )
+        client = LLMClient.from_rc_config(rc_config)
+        assert client.config.base_url == "https://custom-proxy.example/v1"
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — temperature clamping
+# ---------------------------------------------------------------------------
+
+
+class TestMiniMaxTemperatureClamping:
+    """MiniMax API requires temperature in [0, 1.0]."""
+
+    def _capture_body(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        client: LLMClient,
+        temperature: float,
+    ) -> dict[str, Any]:
+        captured: dict[str, Any] = {}
+
+        def fake_urlopen(req: urllib.request.Request, timeout: int) -> _DummyHTTPResponse:
+            captured["body"] = json.loads(req.data.decode("utf-8"))
+            return _DummyHTTPResponse(
+                {"choices": [{"message": {"content": "ok"}, "finish_reason": "stop"}]}
+            )
+
+        monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+        client._raw_call(
+            "MiniMax-M2.5",
+            [{"role": "user", "content": "hi"}],
+            1024,
+            temperature,
+            False,
+        )
+        return captured["body"]
+
+    def test_temperature_above_one_clamped(self, monkeypatch):
+        client = _make_minimax_client()
+        body = self._capture_body(monkeypatch, client, 1.5)
+        assert body["temperature"] == 1.0
+
+    def test_temperature_within_range_unchanged(self, monkeypatch):
+        client = _make_minimax_client()
+        body = self._capture_body(monkeypatch, client, 0.7)
+        assert body["temperature"] == 0.7
+
+    def test_temperature_zero_allowed(self, monkeypatch):
+        client = _make_minimax_client()
+        body = self._capture_body(monkeypatch, client, 0.0)
+        assert body["temperature"] == 0.0
+
+    def test_temperature_negative_clamped_to_zero(self, monkeypatch):
+        client = _make_minimax_client()
+        body = self._capture_body(monkeypatch, client, -0.1)
+        assert body["temperature"] == 0.0
+
+    def test_non_minimax_url_no_clamping(self, monkeypatch):
+        """Non-MiniMax URLs should not clamp temperature."""
+        config = LLMConfig(
+            base_url="https://api.openai.com/v1",
+            api_key="test-key",
+            primary_model="gpt-4o",
+        )
+        client = LLMClient(config)
+        captured: dict[str, Any] = {}
+
+        def fake_urlopen(req: urllib.request.Request, timeout: int) -> _DummyHTTPResponse:
+            captured["body"] = json.loads(req.data.decode("utf-8"))
+            return _DummyHTTPResponse(
+                {"choices": [{"message": {"content": "ok"}, "finish_reason": "stop"}]}
+            )
+
+        monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+        client._raw_call("gpt-4o", [{"role": "user", "content": "hi"}], 1024, 1.5, False)
+        assert captured["body"]["temperature"] == 1.5  # no clamping
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — model chain
+# ---------------------------------------------------------------------------
+
+
+class TestMiniMaxModelChain:
+    """Model fallback chain for MiniMax."""
+
+    def test_model_chain_default(self):
+        client = _make_minimax_client()
+        assert client._model_chain == ["MiniMax-M2.5", "MiniMax-M2.5-highspeed"]
+
+    def test_model_chain_custom_fallbacks(self):
+        client = _make_minimax_client(
+            primary_model="MiniMax-M2.7",
+            fallback_models=["MiniMax-M2.5", "MiniMax-M2.5-highspeed"],
+        )
+        assert client._model_chain == [
+            "MiniMax-M2.7",
+            "MiniMax-M2.5",
+            "MiniMax-M2.5-highspeed",
+        ]
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — raw call body structure
+# ---------------------------------------------------------------------------
+
+
+class TestMiniMaxRawCall:
+    """Verify request body sent to MiniMax API."""
+
+    def test_request_body_structure(self, monkeypatch):
+        client = _make_minimax_client()
+        captured: dict[str, Any] = {}
+
+        def fake_urlopen(req: urllib.request.Request, timeout: int) -> _DummyHTTPResponse:
+            captured["url"] = req.full_url
+            captured["body"] = json.loads(req.data.decode("utf-8"))
+            captured["headers"] = {k.lower(): v for k, v in req.headers.items()}
+            return _DummyHTTPResponse(
+                {
+                    "model": "MiniMax-M2.5",
+                    "choices": [{"message": {"content": "pong"}, "finish_reason": "stop"}],
+                    "usage": {"prompt_tokens": 5, "completion_tokens": 1, "total_tokens": 6},
+                }
+            )
+
+        monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+        resp = client._raw_call(
+            "MiniMax-M2.5",
+            [{"role": "user", "content": "ping"}],
+            1024,
+            0.5,
+            False,
+        )
+        assert captured["url"] == "https://api.minimax.io/v1/chat/completions"
+        assert captured["body"]["model"] == "MiniMax-M2.5"
+        assert captured["body"]["temperature"] == 0.5
+        assert captured["headers"]["authorization"] == "Bearer test-minimax-key"
+        assert resp.content == "pong"
+        assert resp.model == "MiniMax-M2.5"
+
+    def test_json_mode_adds_response_format(self, monkeypatch):
+        client = _make_minimax_client()
+        captured: dict[str, Any] = {}
+
+        def fake_urlopen(req: urllib.request.Request, timeout: int) -> _DummyHTTPResponse:
+            captured["body"] = json.loads(req.data.decode("utf-8"))
+            return _DummyHTTPResponse(
+                {"choices": [{"message": {"content": "{}"}, "finish_reason": "stop"}]}
+            )
+
+        monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+        client._raw_call(
+            "MiniMax-M2.5",
+            [{"role": "user", "content": "json"}],
+            1024,
+            0.5,
+            True,
+        )
+        assert captured["body"]["response_format"] == {"type": "json_object"}
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — CLI provider registration
+# ---------------------------------------------------------------------------
+
+
+class TestMiniMaxCLI:
+    """Verify MiniMax is in the CLI interactive provider menu."""
+
+    def test_minimax_in_provider_choices(self):
+        from researchclaw.cli import _PROVIDER_CHOICES
+
+        found = any(v[0] == "minimax" for v in _PROVIDER_CHOICES.values())
+        assert found, "minimax not found in _PROVIDER_CHOICES"
+
+    def test_minimax_in_provider_urls(self):
+        from researchclaw.cli import _PROVIDER_URLS
+
+        assert _PROVIDER_URLS["minimax"] == "https://api.minimax.io/v1"
+
+    def test_minimax_in_provider_models(self):
+        from researchclaw.cli import _PROVIDER_MODELS
+
+        primary, fallbacks = _PROVIDER_MODELS["minimax"]
+        assert primary == "MiniMax-M2.5"
+        assert "MiniMax-M2.5-highspeed" in fallbacks
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — factory function
+# ---------------------------------------------------------------------------
+
+
+class TestMiniMaxFactory:
+    """Verify create_llm_client dispatches correctly for MiniMax."""
+
+    def test_create_llm_client_returns_llm_client(self):
+        from researchclaw.config import LlmConfig, RCConfig
+
+        rc_config = SimpleNamespace(
+            llm=SimpleNamespace(
+                provider="minimax",
+                base_url="",
+                api_key="mk-factory-test",
+                api_key_env="",
+                primary_model="MiniMax-M2.5",
+                fallback_models=(),
+            ),
+        )
+        client = create_llm_client(rc_config)
+        assert isinstance(client, LLMClient)
+        assert client.config.base_url == "https://api.minimax.io/v1"
+        assert client._anthropic is None  # Not anthropic
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — chat fallback with MiniMax models
+# ---------------------------------------------------------------------------
+
+
+class TestMiniMaxChatFallback:
+    """Verify fallback works with MiniMax models."""
+
+    def test_fallback_to_highspeed_on_primary_failure(self, monkeypatch):
+        client = _make_minimax_client()
+        calls: list[str] = []
+
+        def fake_call_with_retry(
+            self,
+            model: str,
+            messages: list[dict[str, str]],
+            max_tokens: int,
+            temperature: float,
+            json_mode: bool,
+        ) -> LLMResponse:
+            calls.append(model)
+            if model == "MiniMax-M2.5":
+                raise RuntimeError("rate limited")
+            return LLMResponse(content="ok", model=model)
+
+        monkeypatch.setattr(LLMClient, "_call_with_retry", fake_call_with_retry)
+        resp = client.chat([{"role": "user", "content": "test"}])
+        assert calls == ["MiniMax-M2.5", "MiniMax-M2.5-highspeed"]
+        assert resp.model == "MiniMax-M2.5-highspeed"
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — live MiniMax API (skipped without key)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    not os.environ.get("MINIMAX_API_KEY"),
+    reason="MINIMAX_API_KEY not set",
+)
+class TestMiniMaxLiveAPI:
+    """Integration tests against the real MiniMax API."""
+
+    def _live_client(self) -> LLMClient:
+        return LLMClient(
+            LLMConfig(
+                base_url="https://api.minimax.io/v1",
+                api_key=os.environ["MINIMAX_API_KEY"],
+                primary_model="MiniMax-M2.5",
+                fallback_models=["MiniMax-M2.5-highspeed"],
+                max_tokens=64,
+                timeout_sec=60,
+            )
+        )
+
+    def test_simple_chat_completion(self):
+        client = self._live_client()
+        resp = client.chat(
+            [{"role": "user", "content": "Say 'hello' and nothing else."}],
+            max_tokens=16,
+            temperature=0.1,
+        )
+        assert resp.content.strip(), "empty response"
+        assert "hello" in resp.content.lower()
+
+    def test_json_mode(self):
+        client = self._live_client()
+        resp = client.chat(
+            [
+                {"role": "system", "content": "You are a helpful assistant that responds in JSON."},
+                {"role": "user", "content": 'Return a JSON object with key "status" set to "ok".'},
+            ],
+            max_tokens=128,
+            temperature=0.1,
+            json_mode=True,
+            strip_thinking=True,
+        )
+        # MiniMax M2.5 may wrap JSON in markdown code fences
+        import re
+        text = resp.content.strip()
+        fence_match = re.search(r"```(?:json)?\s*\n(.*?)```", text, re.DOTALL)
+        if fence_match:
+            text = fence_match.group(1).strip()
+        parsed = json.loads(text)
+        assert "status" in parsed
+
+    def test_preflight_check(self):
+        client = self._live_client()
+        ok, msg = client.preflight()
+        assert ok, f"preflight failed: {msg}"


### PR DESCRIPTION
## Summary

Add MiniMax as a built-in LLM provider for AutoResearchClaw.

MiniMax offers OpenAI-compatible API with models:
- MiniMax-M2.5 (204K context)
- MiniMax-M2.5-highspeed (optimized for speed)

### Changes

- Register minimax preset in PROVIDER_PRESETS
- Add MiniMax to researchclaw init interactive menu
- Temperature clamping to [0, 1.0] for MiniMax API
- Config example and README update
- 19 unit + 3 integration tests

### Usage

Set provider to minimax and export MINIMAX_API_KEY.

### Test plan

- [x] 22 tests (19 unit + 3 integration)
- [x] All 70 existing tests pass