### PR TITLE
fix: pipeline resilience — signal handling, CodeAgent fallback, ACP timeout retry

### DIFF
--- a/researchclaw/llm/acp_client.py
+++ b/researchclaw/llm/acp_client.py
@@ -260,7 +260,7 @@ class ACPClient:
                 if use_file:
                     return self._send_prompt_via_file(acpx, prompt)
                 return self._send_prompt_cli(acpx, prompt)
-            except RuntimeError as exc:
+            except (RuntimeError, subprocess.TimeoutExpired) as exc:
                 if not any(pat in str(exc) for pat in self._RECONNECT_ERRORS):
                     raise
                 last_exc = exc

--- a/researchclaw/pipeline/executor.py
+++ b/researchclaw/pipeline/executor.py
@@ -3392,41 +3392,50 @@ def _execute_code_generation(
             domain_profile=_domain_profile,
             code_search_result=_code_search_result,
         )
-        _agent_result = _agent.generate(
-            topic=config.research.topic,
-            exp_plan=exp_plan,
-            metric=metric,
-            pkg_hint=pkg_hint + "\n" + compute_budget + "\n" + extra_guidance,
-            max_tokens=_code_max_tokens,
-        )
-        files = _agent_result.files
-        _code_agent_active = True
-
-        # Write agent artifacts
-        (stage_dir / "code_agent_log.json").write_text(
-            json.dumps(
-                {
-                    "log": _agent_result.validation_log,
-                    "llm_calls": _agent_result.total_llm_calls,
-                    "sandbox_runs": _agent_result.total_sandbox_runs,
-                    "best_score": _agent_result.best_score,
-                    "tree_nodes_explored": _agent_result.tree_nodes_explored,
-                    "review_rounds": _agent_result.review_rounds,
-                },
-                indent=2,
-            ),
-            encoding="utf-8",
-        )
-        if _agent_result.architecture_spec:
-            (stage_dir / "architecture_spec.yaml").write_text(
-                _agent_result.architecture_spec, encoding="utf-8",
+        try:
+            _agent_result = _agent.generate(
+                topic=config.research.topic,
+                exp_plan=exp_plan,
+                metric=metric,
+                pkg_hint=pkg_hint + "\n" + compute_budget + "\n" + extra_guidance,
+                max_tokens=_code_max_tokens,
             )
-        logger.info(
-            "CodeAgent: %d LLM calls, %d sandbox runs, score=%.2f",
-            _agent_result.total_llm_calls,
-            _agent_result.total_sandbox_runs,
-            _agent_result.best_score,
-        )
+            files = _agent_result.files
+            _code_agent_active = True
+
+            # Write agent artifacts
+            (stage_dir / "code_agent_log.json").write_text(
+                json.dumps(
+                    {
+                        "log": _agent_result.validation_log,
+                        "llm_calls": _agent_result.total_llm_calls,
+                        "sandbox_runs": _agent_result.total_sandbox_runs,
+                        "best_score": _agent_result.best_score,
+                        "tree_nodes_explored": _agent_result.tree_nodes_explored,
+                        "review_rounds": _agent_result.review_rounds,
+                    },
+                    indent=2,
+                ),
+                encoding="utf-8",
+            )
+            if _agent_result.architecture_spec:
+                (stage_dir / "architecture_spec.yaml").write_text(
+                    _agent_result.architecture_spec, encoding="utf-8",
+                )
+            logger.info(
+                "CodeAgent: %d LLM calls, %d sandbox runs, score=%.2f",
+                _agent_result.total_llm_calls,
+                _agent_result.total_sandbox_runs,
+                _agent_result.best_score,
+            )
+        except Exception as _ca_exc:
+            logger.warning(
+                "CodeAgent failed (%s: %s) — falling back to legacy/fallback code",
+                type(_ca_exc).__name__, _ca_exc,
+            )
+            (stage_dir / "code_agent_error.txt").write_text(
+                f"{type(_ca_exc).__name__}: {_ca_exc}", encoding="utf-8",
+            )
     elif not _beast_mode_used and llm is not None:
         # ── Legacy single-shot generation ─────────────────────────────────
         topic = config.research.topic

--- a/researchclaw/pipeline/runner.py
+++ b/researchclaw/pipeline/runner.py
@@ -4,6 +4,7 @@ import json
 import importlib
 import logging
 import os
+import signal
 import shutil
 import tempfile
 import time as _time
@@ -209,24 +210,60 @@ def execute_pipeline(
     started = False
     total_stages = len(STAGE_SEQUENCE)
 
-    for stage in STAGE_SEQUENCE:
+    # --- Signal handling: survive SIGTERM/SIGHUP from parent session death ---
+    _interrupted = False
+    _original_sigterm = signal.getsignal(signal.SIGTERM)
+    _original_sighup = signal.getsignal(signal.SIGHUP)
+
+    def _graceful_shutdown(signum: int, frame: object) -> None:
+        nonlocal _interrupted
+        _interrupted = True
+        logger.warning(
+            "Received signal %d — will finish current stage then exit gracefully",
+            signum,
+        )
+
+    signal.signal(signal.SIGTERM, _graceful_shutdown)
+    signal.signal(signal.SIGHUP, _graceful_shutdown)
+    logger.info("Signal handlers installed (SIGTERM, SIGHUP → graceful shutdown)")
+
+    try:
+      for stage in STAGE_SEQUENCE:
         started = _should_start(stage, from_stage, started)
         if not started:
             continue
+
+        # Check for pending signal-based interruption
+        if _interrupted:
+            print(f"[{run_id}] Interrupted by signal — stopping pipeline")
+            logger.warning("Pipeline interrupted by signal before stage %s", stage.name)
+            break
 
         stage_num = int(stage)
         prefix = f"[{run_id}] Stage {stage_num:02d}/{total_stages}"
         print(f"{prefix} {stage.name} — running...")
         t0 = _time.monotonic()
 
-        result = execute_stage(
-            stage,
-            run_dir=run_dir,
-            run_id=run_id,
-            config=config,
-            adapters=adapters,
-            auto_approve_gates=auto_approve_gates,
-        )
+        try:
+            result = execute_stage(
+                stage,
+                run_dir=run_dir,
+                run_id=run_id,
+                config=config,
+                adapters=adapters,
+                auto_approve_gates=auto_approve_gates,
+            )
+        except (SystemExit, KeyboardInterrupt) as exc:
+            logger.error(
+                "Stage %s killed by %s: %s", stage.name, type(exc).__name__, exc
+            )
+            result = StageResult(
+                stage=stage,
+                status=StageStatus.FAILED,
+                artifacts=(),
+                error=f"Killed by {type(exc).__name__}: {exc}",
+                decision="retry",
+            )
         elapsed = _time.monotonic() - t0
         if result.status == StageStatus.DONE:
             arts = ", ".join(result.artifacts) if result.artifacts else "none"
@@ -355,6 +392,11 @@ def execute_pipeline(
                 break
         if result.status == StageStatus.BLOCKED_APPROVAL and stop_on_gate:
             break
+
+    finally:
+        # Restore original signal handlers
+        signal.signal(signal.SIGTERM, _original_sigterm)
+        signal.signal(signal.SIGHUP, _original_sighup)
 
     summary = _build_pipeline_summary(
         run_id=run_id,


### PR DESCRIPTION
## Problem

When running the full 23-stage pipeline to completion, several failure modes cause the pipeline to crash without recovery:

1. **Silent process death** — When the parent terminal/session exits, `SIGTERM`/`SIGHUP` kills the pipeline process without checkpointing. Python's `except Exception` does not catch signals.
2. **Stage 10 (CODE_GENERATION) crashes** — If `CodeAgent.generate()` or the legacy single-shot LLM call raises an exception, the entire pipeline crashes instead of falling through to the fallback experiment code.
3. **ACP client timeout not retried** — `_send_prompt()` catches `RuntimeError` for retry, but `subprocess.run(..., timeout=1800)` raises `subprocess.TimeoutExpired` (subclass of `SubprocessError`), which bypasses the retry loop entirely.

## Changes

### 1. `runner.py` — Signal handling + graceful shutdown
- Install `SIGTERM`/`SIGHUP` handlers that set an `_interrupted` flag
- Pipeline finishes current stage, checkpoints, then exits cleanly
- Wrap `execute_stage()` to catch `SystemExit`/`KeyboardInterrupt`
- Restore original signal handlers in `finally` block

### 2. `executor.py` — CodeAgent fallback protection
- Wrap `CodeAgent.generate()` in `try/except` so failures fall through to legacy/fallback code
- Log error to `code_agent_error.txt` for debugging
- Pipeline continues with fallback experiment instead of crashing

### 3. `acp_client.py` — TimeoutExpired retry
- Add `subprocess.TimeoutExpired` to the `except` clause in the retry loop
- ACP timeouts now trigger reconnect + retry instead of crashing

## Testing

Pipeline successfully progressed from stuck-at-stage-10 to completing 19/23 stages after these fixes. The `--resume` checkpoint mechanism correctly resumes from the last completed stage.

## Diff summary
```
3 files changed, 94 insertions(+), 43 deletions(-)
```