### PR TITLE
fix(config): use correct default python_path for Windows sandbox

### DIFF
--- a/config.researchclaw.example.yaml
+++ b/config.researchclaw.example.yaml
@@ -66,6 +66,7 @@ experiment:
   metric_key: "primary_metric"
   metric_direction: "minimize"
   sandbox:
+    # Use ".venv/Scripts/python.exe" on Windows
     python_path: ".venv/bin/python3"
     gpu_required: false
     max_memory_mb: 4096

--- a/researchclaw/config.py
+++ b/researchclaw/config.py
@@ -6,7 +6,10 @@ from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any
 
+import sys
 import yaml
+
+DEFAULT_PYTHON_PATH = ".venv/Scripts/python.exe" if sys.platform == "win32" else ".venv/bin/python3"
 
 CONFIG_SEARCH_ORDER: tuple[str, ...] = ("config.arc.yaml", "config.yaml")
 EXAMPLE_CONFIG = "config.researchclaw.example.yaml"
@@ -147,7 +150,7 @@ class SecurityConfig:
 
 @dataclass(frozen=True)
 class SandboxConfig:
-    python_path: str = ".venv/bin/python3"
+    python_path: str = DEFAULT_PYTHON_PATH
     gpu_required: bool = False
     allowed_imports: tuple[str, ...] = (
         "math",
@@ -618,7 +621,7 @@ def _parse_experiment_config(data: dict[str, Any]) -> ExperimentConfig:
         metric_direction=data.get("metric_direction", "minimize"),
         keep_threshold=float(data.get("keep_threshold", 0.0)),
         sandbox=SandboxConfig(
-            python_path=sandbox_data.get("python_path", ".venv/bin/python3"),
+            python_path=sandbox_data.get("python_path", DEFAULT_PYTHON_PATH),
             gpu_required=bool(sandbox_data.get("gpu_required", False)),
             allowed_imports=tuple(
                 sandbox_data.get("allowed_imports", SandboxConfig.allowed_imports)

--- a/tests/test_rc_config.py
+++ b/tests/test_rc_config.py
@@ -248,9 +248,10 @@ def test_experiment_config_defaults_mode_is_simulated():
 
 
 def test_sandbox_config_defaults_match_expected_values():
+    from researchclaw.config import DEFAULT_PYTHON_PATH
     defaults = SandboxConfig()
 
-    assert defaults.python_path == ".venv/bin/python3"
+    assert defaults.python_path == DEFAULT_PYTHON_PATH
     assert defaults.gpu_required is False
     assert defaults.max_memory_mb == 4096
     assert "numpy" in defaults.allowed_imports


### PR DESCRIPTION
## Summary

Fixes an issue where the sandbox execution fails on Windows with `[WinError 2] The system cannot find the file specified`.

The default `python_path` for the sandbox was hardcoded to `.venv/bin/python3`, which is specific to Linux/macOS. On Windows, virtual environments place the Python executable in `.venv/Scripts/python.exe`.

This PR introduces a `DEFAULT_PYTHON_PATH` constant that checks `sys.platform` and sets the correct path dynamically.

## Changes
- Added `DEFAULT_PYTHON_PATH` in `researchclaw/config.py` that resolves to `.venv/Scripts/python.exe` on Windows and `.venv/bin/python3` elsewhere.
- Replaced hardcoded paths in `SandboxConfig` and the config parser.
- Updated `config.researchclaw.example.yaml` with a comment explaining the Windows path.
- Updated `tests/test_rc_config.py` to use the dynamic constant instead of the hardcoded string.