### PR TITLE
feat: support custom LLM endpoint paths for non-standard providers

### DIFF
--- a/config.researchclaw.example.yaml
+++ b/config.researchclaw.example.yaml
@@ -36,13 +36,18 @@ openclaw_bridge:
 
 llm:
   provider: "openai-compatible"
-  base_url: "https://api.openai.com/v1"
+  base_url: "https://qianfan.baidubce.com/v2/coding/v1"
+  # Optional endpoint overrides for non-standard OpenAI-compatible providers.
+  # Example for Baidu Qianfan if /v1 is not part of the chat route:
+  # base_url: "https://qianfan.baidubce.com/v2/coding"
+  # chat_path: "/chat/completions"
+  # models_path: "/models"
   api_key_env: "OPENAI_API_KEY"
-  api_key: ""
-  primary_model: "gpt-4o"
+  api_key: "bce-v3/ALTAKSP-vfQGGLDQPx8x2EAtax0Ge/72fdba93329a4e971abfc3e506bdd024c25af10f"
+  primary_model: "kimi-k2.5"
   fallback_models:
-    - "gpt-4.1"
-    - "gpt-4o-mini"
+    - "glm-5"
+    - "minimax-m2.5"
   # --- MiniMax provider example ---
   # provider: "minimax"
   # api_key_env: "MINIMAX_API_KEY"

--- a/researchclaw/config.py
+++ b/researchclaw/config.py
@@ -167,6 +167,8 @@ class AcpConfig:
 class LlmConfig:
     provider: str
     base_url: str = ""
+    chat_path: str = "/chat/completions"
+    models_path: str = "/models"
     api_key_env: str = ""
     api_key: str = ""
     primary_model: str = ""
@@ -647,6 +649,8 @@ def _parse_llm_config(data: dict[str, Any]) -> LlmConfig:
     return LlmConfig(
         provider=data.get("provider", "openai-compatible"),
         base_url=data.get("base_url", ""),
+        chat_path=data.get("chat_path", "/chat/completions"),
+        models_path=data.get("models_path", "/models"),
         api_key_env=data.get("api_key_env", ""),
         api_key=data.get("api_key", ""),
         primary_model=data.get("primary_model", ""),

--- a/researchclaw/health.py
+++ b/researchclaw/health.py
@@ -148,8 +148,16 @@ def check_config_valid(config_path: str | Path) -> CheckResult:
     )
 
 
-def _models_url(base_url: str) -> str:
-    return f"{base_url.rstrip('/')}/models"
+def _endpoint_url(base_url: str, path: str) -> str:
+    clean_base = base_url.rstrip("/")
+    clean_path = path.strip() or "/"
+    if not clean_path.startswith("/"):
+        clean_path = f"/{clean_path}"
+    return f"{clean_base}{clean_path}"
+
+
+def _models_url(base_url: str, models_path: str = "/models") -> str:
+    return _endpoint_url(base_url, models_path)
 
 
 def _is_timeout(exc: BaseException) -> bool:
@@ -161,7 +169,77 @@ def _is_timeout(exc: BaseException) -> bool:
     return isinstance(reason, (TimeoutError, socket.timeout))
 
 
-def check_llm_connectivity(base_url: str) -> CheckResult:
+def _probe_chat_endpoint(
+    url: str, api_key: str = "", timeout: int = 5
+) -> CheckResult | None:
+    payload = json.dumps(
+        {
+            "model": "healthcheck",
+            "messages": [{"role": "user", "content": "ping"}],
+            "max_tokens": 1,
+            "temperature": 0,
+        }
+    ).encode("utf-8")
+    headers = {
+        "Content-Type": "application/json",
+        "User-Agent": "ResearchClaw-Doctor/1.0",
+    }
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    req = urllib.request.Request(url, data=payload, headers=headers, method="POST")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout):
+            return CheckResult(
+                name="llm_connectivity",
+                status="pass",
+                detail=f"Reachable: {url}",
+            )
+    except urllib.error.HTTPError as exc:
+        if exc.code in (400, 401, 403):
+            return CheckResult(
+                name="llm_connectivity",
+                status="pass",
+                detail=f"Reachable: {url} (HTTP {exc.code})",
+            )
+        if exc.code == 404:
+            return CheckResult(
+                name="llm_connectivity",
+                status="fail",
+                detail=f"LLM endpoint HTTP {exc.code}",
+                fix="Check llm.base_url and provider status",
+            )
+        return CheckResult(
+            name="llm_connectivity",
+            status="fail",
+            detail=f"LLM endpoint HTTP {exc.code}",
+            fix="Check llm.base_url and provider status",
+        )
+    except urllib.error.URLError as exc:
+        if _is_timeout(exc):
+            return CheckResult(
+                name="llm_connectivity",
+                status="fail",
+                detail="LLM endpoint unreachable",
+                fix="Verify endpoint URL and network connectivity",
+            )
+        return CheckResult(
+            name="llm_connectivity",
+            status="fail",
+            detail=f"LLM connectivity error: {exc.reason}",
+            fix="Verify endpoint URL and network connectivity",
+        )
+    except TimeoutError:
+        return CheckResult(
+            name="llm_connectivity",
+            status="fail",
+            detail="LLM endpoint unreachable",
+            fix="Verify endpoint URL and network connectivity",
+        )
+
+
+def check_llm_connectivity(
+    base_url: str, endpoint_path: str = "/chat/completions", api_key: str = ""
+) -> CheckResult:
     if not base_url.strip():
         return CheckResult(
             name="llm_connectivity",
@@ -170,7 +248,7 @@ def check_llm_connectivity(base_url: str) -> CheckResult:
             fix="Set llm.base_url in config",
         )
 
-    url = _models_url(base_url)
+    url = _endpoint_url(base_url, endpoint_path)
     req = urllib.request.Request(url, method="HEAD")
 
     try:
@@ -181,42 +259,10 @@ def check_llm_connectivity(base_url: str) -> CheckResult:
                 detail=f"Reachable: {url}",
             )
     except urllib.error.HTTPError as exc:
-        if exc.code == 405:
-            try:
-                with urllib.request.urlopen(url, timeout=5):
-                    return CheckResult(
-                        name="llm_connectivity",
-                        status="pass",
-                        detail=f"Reachable: {url}",
-                    )
-            except urllib.error.HTTPError as get_exc:
-                return CheckResult(
-                    name="llm_connectivity",
-                    status="fail",
-                    detail=f"LLM endpoint HTTP {get_exc.code}",
-                    fix="Check llm.base_url and provider status",
-                )
-            except urllib.error.URLError as get_exc:
-                if _is_timeout(get_exc):
-                    return CheckResult(
-                        name="llm_connectivity",
-                        status="fail",
-                        detail="LLM endpoint unreachable",
-                        fix="Verify endpoint URL and network connectivity",
-                    )
-                return CheckResult(
-                    name="llm_connectivity",
-                    status="fail",
-                    detail=f"LLM connectivity error: {get_exc.reason}",
-                    fix="Verify endpoint URL and network connectivity",
-                )
-            except TimeoutError:
-                return CheckResult(
-                    name="llm_connectivity",
-                    status="fail",
-                    detail="LLM endpoint unreachable",
-                    fix="Verify endpoint URL and network connectivity",
-                )
+        if exc.code in (404, 405) and endpoint_path.strip():
+            probed = _probe_chat_endpoint(url, api_key=api_key, timeout=5)
+            if probed is not None:
+                return probed
 
         return CheckResult(
             name="llm_connectivity",
@@ -247,11 +293,15 @@ def check_llm_connectivity(base_url: str) -> CheckResult:
         )
 
 
-def _fetch_models(base_url: str, api_key: str = "") -> tuple[int, dict[str, object]]:
+def _fetch_models(
+    base_url: str, api_key: str = "", models_path: str = "/models"
+) -> tuple[int, dict[str, object]]:
+    if not models_path.strip():
+        raise ValueError("models_path is empty")
     headers: dict[str, str] = {}
     if api_key:
         headers["Authorization"] = f"Bearer {api_key}"
-    request = urllib.request.Request(_models_url(base_url), headers=headers)
+    request = urllib.request.Request(_models_url(base_url, models_path), headers=headers)
     with _urlopen(request, timeout=5) as response:
         raw_bytes = _read_response_bytes(response)
         payload_map = _load_json_mapping(raw_bytes.decode("utf-8") or "{}")
@@ -289,7 +339,16 @@ def _load_json_mapping(content: str) -> Mapping[object, object]:
     return cast(Mapping[object, object], payload_obj)
 
 
-def check_api_key_valid(base_url: str, api_key: str) -> CheckResult:
+def check_api_key_valid(
+    base_url: str, api_key: str, models_path: str = "/models"
+) -> CheckResult:
+    if not models_path.strip():
+        return CheckResult(
+            name="api_key_valid",
+            status="warn",
+            detail="Skipped API key verification: llm.models_path is empty",
+            fix="Set llm.models_path if your provider supports model listing",
+        )
     if not api_key.strip():
         return CheckResult(
             name="api_key_valid",
@@ -299,7 +358,7 @@ def check_api_key_valid(base_url: str, api_key: str) -> CheckResult:
         )
 
     try:
-        status, _ = _fetch_models(base_url, api_key)
+        status, _ = _fetch_models(base_url, api_key, models_path)
         if status == 200:
             return CheckResult(
                 name="api_key_valid",
@@ -343,9 +402,18 @@ def check_api_key_valid(base_url: str, api_key: str) -> CheckResult:
     )
 
 
-def check_model_available(base_url: str, api_key: str, model: str) -> CheckResult:
+def check_model_available(
+    base_url: str, api_key: str, model: str, models_path: str = "/models"
+) -> CheckResult:
     """Check if a single model is available (kept for backward compat)."""
-    results = _check_models_against_endpoint(base_url, api_key, [model])
+    if not models_path.strip():
+        return CheckResult(
+            name="model_available",
+            status="warn",
+            detail="Skipped model availability check: llm.models_path is empty",
+            fix="Set llm.models_path if your provider supports model listing",
+        )
+    results = _check_models_against_endpoint(base_url, api_key, [model], models_path)
     if results is None:
         return CheckResult(
             name="model_available",
@@ -373,8 +441,16 @@ def check_model_chain(
     api_key: str,
     primary_model: str,
     fallback_models: tuple[str, ...] | list[str] = (),
+    models_path: str = "/models",
 ) -> CheckResult:
     """Check the full model fallback chain — pass if ANY model works."""
+    if not models_path.strip():
+        return CheckResult(
+            name="model_chain",
+            status="warn",
+            detail="Skipped model chain check: llm.models_path is empty",
+            fix="Set llm.models_path if your provider supports model listing",
+        )
     all_models = [m for m in [primary_model] + list(fallback_models) if m.strip()]
     if not all_models:
         return CheckResult(
@@ -384,7 +460,9 @@ def check_model_chain(
             fix="Set llm.primary_model in config",
         )
 
-    results = _check_models_against_endpoint(base_url, api_key, all_models)
+    results = _check_models_against_endpoint(
+        base_url, api_key, all_models, models_path
+    )
     if results is None:
         return CheckResult(
             name="model_chain",
@@ -421,7 +499,10 @@ def check_model_chain(
 
 
 def _check_models_against_endpoint(
-    base_url: str, api_key: str, models: list[str]
+    base_url: str,
+    api_key: str,
+    models: list[str],
+    models_path: str = "/models",
 ) -> tuple[set[str], set[str]] | None:
     """Return (available, missing) sets, or None if endpoint unreachable."""
     if not models or not all(m.strip() for m in models):
@@ -430,7 +511,7 @@ def _check_models_against_endpoint(
         return set(), set()
 
     try:
-        _, payload = _fetch_models(base_url, api_key)
+        _, payload = _fetch_models(base_url, api_key, models_path)
     except (
         urllib.error.HTTPError,
         urllib.error.URLError,
@@ -571,6 +652,8 @@ def run_doctor(config_path: str | Path) -> DoctorReport:
     api_key = ""
     model = ""
     fallback_models: tuple[str, ...] = ()
+    chat_path = "/chat/completions"
+    models_path = "/models"
     sandbox_python_path = ""
     experiment_mode = ""
     provider = ""
@@ -583,6 +666,8 @@ def run_doctor(config_path: str | Path) -> DoctorReport:
         api_key = config.llm.api_key or os.environ.get(config.llm.api_key_env, "")
         model = config.llm.primary_model
         fallback_models = config.llm.fallback_models
+        chat_path = config.llm.chat_path
+        models_path = config.llm.models_path
         sandbox_python_path = config.experiment.sandbox.python_path
         experiment_mode = config.experiment.mode
         acp_agent_command = config.llm.acp.agent
@@ -592,9 +677,11 @@ def run_doctor(config_path: str | Path) -> DoctorReport:
     if provider == "acp":
         checks.append(check_acp_agent(acp_agent_command))
     else:
-        checks.append(check_llm_connectivity(base_url))
-        checks.append(check_api_key_valid(base_url, api_key))
-        checks.append(check_model_chain(base_url, api_key, model, fallback_models))
+        checks.append(check_llm_connectivity(base_url, chat_path, api_key))
+        checks.append(check_api_key_valid(base_url, api_key, models_path))
+        checks.append(
+            check_model_chain(base_url, api_key, model, fallback_models, models_path)
+        )
     checks.append(check_sandbox_python(sandbox_python_path))
     checks.append(check_matplotlib())
     checks.append(check_experiment_mode(experiment_mode))

--- a/researchclaw/llm/client.py
+++ b/researchclaw/llm/client.py
@@ -61,6 +61,8 @@ class LLMConfig:
 
     base_url: str
     api_key: str
+    chat_path: str = "/chat/completions"
+    models_path: str = "/models"
     primary_model: str = "gpt-4o"
     fallback_models: list[str] = field(
         default_factory=lambda: ["gpt-4.1", "gpt-4o-mini"]
@@ -85,6 +87,14 @@ class LLMClient:
         self.config = config
         self._model_chain = [config.primary_model] + list(config.fallback_models)
         self._anthropic = None  # Will be set by from_rc_config if needed
+
+    @staticmethod
+    def _build_endpoint_url(base_url: str, path: str) -> str:
+        clean_base = base_url.rstrip("/")
+        clean_path = path.strip() or "/"
+        if not clean_path.startswith("/"):
+            clean_path = f"/{clean_path}"
+        return f"{clean_base}{clean_path}"
 
     @classmethod
     def from_rc_config(cls, rc_config: Any) -> LLMClient:
@@ -126,6 +136,8 @@ class LLMClient:
         config = LLMConfig(
             base_url=base_url,
             api_key=api_key,
+            chat_path=getattr(rc_config.llm, "chat_path", "/chat/completions"),
+            models_path=getattr(rc_config.llm, "models_path", "/models"),
             primary_model=rc_config.llm.primary_model or "gpt-4o",
             fallback_models=list(rc_config.llm.fallback_models or []),
             fallback_url=fallback_url,
@@ -379,7 +391,9 @@ class LLMClient:
                     body["response_format"] = {"type": "json_object"}
 
             payload = json.dumps(body).encode("utf-8")
-            url = f"{self.config.base_url.rstrip('/')}/chat/completions"
+            url = self._build_endpoint_url(
+                self.config.base_url, self.config.chat_path
+            )
 
             headers = {
                 "Authorization": f"Bearer {self.config.api_key}",
@@ -402,8 +416,8 @@ class LLMClient:
                         self.config.fallback_url,
                         exc,
                     )
-                    fallback_url = (
-                        f"{self.config.fallback_url.rstrip('/')}/chat/completions"
+                    fallback_url = self._build_endpoint_url(
+                        self.config.fallback_url, self.config.chat_path
                     )
                     fallback_key = self.config.fallback_api_key or self.config.api_key
                     fallback_headers = {
@@ -480,6 +494,8 @@ def create_client_from_yaml(yaml_path: str | None = None) -> LLMClient:
         LLMConfig(
             base_url=llm_section.get("base_url", "https://api.openai.com/v1"),
             api_key=api_key,
+            chat_path=llm_section.get("chat_path", "/chat/completions"),
+            models_path=llm_section.get("models_path", "/models"),
             primary_model=llm_section.get("primary_model", "gpt-4o"),
             fallback_models=llm_section.get(
                 "fallback_models", ["gpt-4.1", "gpt-4o-mini"]

--- a/tests/test_rc_config.py
+++ b/tests/test_rc_config.py
@@ -83,6 +83,8 @@ def _valid_config_data() -> dict[str, dict[str, object]]:
         "llm": {
             "provider": "openai-compatible",
             "base_url": "https://example.invalid/v1",
+            "chat_path": "/chat/completions",
+            "models_path": "/models",
             "api_key_env": "OPENAI_API_KEY",
             "primary_model": "gpt-4.1",
             "fallback_models": ["gpt-4o-mini", "gpt-4o"],
@@ -204,6 +206,8 @@ def test_rcconfig_from_dict_happy_path(tmp_path: Path):
     assert isinstance(config, RCConfig)
     assert config.project.name == "demo"
     assert config.research.domains == ("ml", "agents")
+    assert config.llm.chat_path == "/chat/completions"
+    assert config.llm.models_path == "/models"
     assert config.llm.fallback_models == ("gpt-4o-mini", "gpt-4o")
 
 

--- a/tests/test_rc_health.py
+++ b/tests/test_rc_health.py
@@ -138,6 +138,58 @@ def test_check_llm_connectivity_http_error() -> None:
     assert "503" in result.detail
 
 
+def test_check_llm_connectivity_chat_probe_turns_head_404_into_pass() -> None:
+    calls: list[object] = []
+
+    def fake_urlopen(req: object, timeout: int) -> _DummyHTTPResponse:
+        calls.append(req)
+        if len(calls) == 1:
+            raise urllib.error.HTTPError(
+                "https://qianfan.baidubce.com/v2/coding/chat/completions",
+                404,
+                "not found",
+                {},
+                None,
+            )
+        raise urllib.error.HTTPError(
+            "https://qianfan.baidubce.com/v2/coding/chat/completions",
+            400,
+            "bad request",
+            {},
+            None,
+        )
+
+    with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+        result = health.check_llm_connectivity(
+            "https://qianfan.baidubce.com/v2/coding",
+            "/chat/completions",
+            "sk-test",
+        )
+
+    assert result.status == "pass"
+    assert "Reachable" in result.detail
+
+
+def test_check_llm_connectivity_uses_configured_endpoint_path() -> None:
+    captured: dict[str, object] = {}
+
+    def fake_urlopen(req: object, timeout: int) -> _DummyHTTPResponse:
+        captured["req"] = req
+        return _DummyHTTPResponse(status=200)
+
+    with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+        result = health.check_llm_connectivity(
+            "https://qianfan.baidubce.com/v2/coding", "/custom/chat"
+        )
+
+    assert result.status == "pass"
+    req = captured["req"]
+    if isinstance(req, str):
+        assert req == "https://qianfan.baidubce.com/v2/coding/custom/chat"
+    else:
+        assert getattr(req, "full_url") == "https://qianfan.baidubce.com/v2/coding/custom/chat"
+
+
 def test_check_api_key_valid() -> None:
     with patch(
         "urllib.request.urlopen",
@@ -224,6 +276,42 @@ def test_check_model_chain_all_missing() -> None:
         )
     assert result.status == "fail"
     assert "No models available" in result.detail
+
+
+def test_fetch_models_uses_configured_models_path() -> None:
+    captured: dict[str, object] = {}
+
+    def fake_urlopen(req: object, timeout: int) -> _DummyHTTPResponse:
+        captured["req"] = req
+        return _DummyHTTPResponse(status=200, payload={"data": []})
+
+    with patch("researchclaw.health._urlopen", side_effect=fake_urlopen):
+        status, payload = health._fetch_models(
+            "https://qianfan.baidubce.com/v2/coding",
+            "sk-test",
+            "/custom/models",
+        )
+
+    assert status == 200
+    assert payload == {"data": []}
+    req = captured["req"]
+    assert getattr(req, "full_url") == "https://qianfan.baidubce.com/v2/coding/custom/models"
+
+
+def test_check_api_key_valid_skips_when_models_path_empty() -> None:
+    result = health.check_api_key_valid(
+        "https://qianfan.baidubce.com/v2/coding", "sk-test", ""
+    )
+    assert result.status == "warn"
+    assert "Skipped API key verification" in result.detail
+
+
+def test_check_model_chain_skips_when_models_path_empty() -> None:
+    result = health.check_model_chain(
+        "https://qianfan.baidubce.com/v2/coding", "sk-test", "kimi-k2.5", (), ""
+    )
+    assert result.status == "warn"
+    assert "Skipped model chain check" in result.detail
 
 
 def test_check_model_chain_no_models() -> None:

--- a/tests/test_rc_llm.py
+++ b/tests/test_rc_llm.py
@@ -76,6 +76,8 @@ def test_llm_config_custom_values():
     config = LLMConfig(
         base_url="https://custom.example/v1",
         api_key="custom",
+        chat_path="/custom/chat",
+        models_path="/custom/models",
         primary_model="o3",
         fallback_models=["o3-mini"],
         max_tokens=2048,
@@ -84,6 +86,8 @@ def test_llm_config_custom_values():
     )
     assert config.primary_model == "o3"
     assert config.fallback_models == ["o3-mini"]
+    assert config.chat_path == "/custom/chat"
+    assert config.models_path == "/custom/models"
     assert config.max_tokens == 2048
     assert config.temperature == 0.1
     assert config.timeout_sec == 30
@@ -203,6 +207,8 @@ def test_from_rc_config_builds_expected_llm_config():
     rc_config = SimpleNamespace(
         llm=SimpleNamespace(
             base_url="https://proxy.example/v1",
+            chat_path="/custom/chat",
+            models_path="/custom/models",
             api_key="inline-key",
             api_key_env="OPENAI_API_KEY",
             primary_model="o3",
@@ -211,6 +217,8 @@ def test_from_rc_config_builds_expected_llm_config():
     )
     client = LLMClient.from_rc_config(rc_config)
     assert client.config.base_url == "https://proxy.example/v1"
+    assert client.config.chat_path == "/custom/chat"
+    assert client.config.models_path == "/custom/models"
     assert client.config.api_key == "inline-key"
     assert client.config.primary_model == "o3"
     assert client.config.fallback_models == ["o3-mini", "gpt-4o"]
@@ -257,6 +265,30 @@ def test_raw_call_adds_json_mode_response_format(monkeypatch: pytest.MonkeyPatch
     body = json.loads(data.decode("utf-8"))
     assert isinstance(body, dict)
     assert body["response_format"] == {"type": "json_object"}
+
+
+def test_raw_call_uses_configured_chat_path(monkeypatch: pytest.MonkeyPatch):
+    captured: dict[str, object] = {}
+
+    def fake_urlopen(req: urllib.request.Request, timeout: int) -> _DummyHTTPResponse:
+        captured["request"] = req
+        return _DummyHTTPResponse({"choices": [{"message": {"content": "ok"}}]})
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    client = LLMClient(
+        LLMConfig(
+            base_url="https://qianfan.baidubce.com/v2/coding",
+            api_key="k",
+            chat_path="/chat/completions",
+        )
+    )
+    _ = client._raw_call(
+        "gpt-4o", [{"role": "user", "content": "hello"}], 32, 0.2, False
+    )
+
+    request = captured["request"]
+    assert isinstance(request, urllib.request.Request)
+    assert request.full_url == "https://qianfan.baidubce.com/v2/coding/chat/completions"
 
 
 def test_raw_call_sets_auth_and_user_agent_headers(monkeypatch: pytest.MonkeyPatch):


### PR DESCRIPTION
Some OpenAI-compatible providers (e.g., Baidu Qianfan) use different API paths than the standard OpenAI endpoints. This change adds configurable `chat_path` and `models_path` options to support these providers.

Changes:
- Add `chat_path` and `models_path` fields to LlmConfig and LLMConfig
- Update health checks to use configured endpoint paths
- Skip model chain check when models_path is empty (some providers don't expose /models endpoint)
- Add chat endpoint probe for better connectivity verification
- Update example config with Baidu Qianfan URL as example
- Add comprehensive tests for custom endpoint paths