### PR TITLE
fix: enforce `utf-8` encoding for `results.json` writes to prevent crashes

### DIFF
--- a/researchclaw/experiment/harness_template.py
+++ b/researchclaw/experiment/harness_template.py
@@ -97,7 +97,7 @@ class ExperimentHarness:
             output["results"] = self._partial_results
 
         try:
-            with open("results.json", "w") as f:
+            with open("results.json", "w", encoding="utf-8") as f:
                 json.dump(output, f, indent=2, default=str)
         except OSError as e:
             print(f"WARNING: Could not write results.json: {e}", file=sys.stderr)

--- a/researchclaw/prompts.py
+++ b/researchclaw/prompts.py
@@ -527,7 +527,7 @@ _DEFAULT_BLOCKS: dict[str, str] = {
         "```python\n"
         "import json\n"
         "results = {'hyperparameters': HYPERPARAMETERS, 'metrics': collected_metrics}\n"
-        "with open('results.json', 'w') as f:\n"
+        "with open('results.json', 'w', encoding='utf-8') as f:\n"
         "    json.dump(results, f, indent=2)\n"
         "```\n"
         "EVERY hyperparameter must be used in the code — no dead parameters.\n"


### PR DESCRIPTION
When agents generate responses containing non-ASCII characters (e.g. Unicode math symbols, citations, or CJK characters) as part of their metrics or parameters, dumping the output directly via `with open("results.json", "w") as f` risks raising a `UnicodeEncodeError` on systems where the default locale encoding is not UTF-8 (such as Windows, which defaults to `cp1252`).

This PR adds `encoding='utf-8'` to the `open()` calls in `harness_template.py` and the agent LLM prompt instructions in `prompts.py` to guarantee deterministic and safe serialization.