### PR TITLE
feat: add Kimi (Moonshot) API support via anthropic-messages protocol

### DIFF
--- a/researchclaw/llm/__init__.py
+++ b/researchclaw/llm/__init__.py
@@ -23,6 +23,9 @@ PROVIDER_PRESETS = {
     "anthropic": {
         "base_url": "https://api.anthropic.com",
     },
+    "kimi-anthropic": {
+        "base_url": "https://api.kimi.com/coding/",
+    },
     "novita": {
         "base_url": "https://api.novita.ai/openai",
     },
@@ -40,6 +43,7 @@ def create_llm_client(config: RCConfig) -> LLMClient | ACPClient:
 
     - ``"acp"`` → :class:`ACPClient` (spawns an ACP-compatible agent)
     - ``"anthropic"`` → :class:`LLMClient` with Anthropic Messages API adapter
+    - ``"kimi-anthropic"`` → :class:`LLMClient` with Kimi Coding Anthropic adapter
     - ``"openrouter"`` → :class:`LLMClient` with OpenRouter base URL
     - ``"openai"`` → :class:`LLMClient` with OpenAI base URL
     - ``"deepseek"`` → :class:`LLMClient` with DeepSeek base URL

--- a/researchclaw/llm/client.py
+++ b/researchclaw/llm/client.py
@@ -133,9 +133,9 @@ class LLMClient:
         )
         client = cls(config)
 
-        # Detect Anthropic provider — use original URL/key (not the
+        # Detect Anthropic or Kimi-Anthropic provider — use original URL/key (not the
         # MetaClaw proxy URL which is OpenAI-compatible only).
-        if provider == "anthropic":
+        if provider in ("anthropic", "kimi-anthropic"):
             from .anthropic_adapter import AnthropicAdapter
 
             client._anthropic = AnthropicAdapter(


### PR DESCRIPTION
## Summary
Add new provider 'kimi-anthropic' to support Kimi Code API using anthropic-messages protocol.

## Changes
- Add 'kimi-anthropic' to PROVIDER_PRESETS
- Update client.py to detect kimi-anthropic provider  
- Update docstrings

## Usage

```yaml
llm:
  provider: "kimi-anthropic"
  base_url: "https://api.kimi.com/coding/"
  api_key_env: "KIMI_API_KEY"
  primary_model: "kimi-for-coding"
```

## Testing
- [x] Verified API connectivity with Kimi Code API
- [x] Tested with researchclaw run command
