### PR TITLE
feat(llm): support responses API endpoints

### DIFF
--- a/config.researchclaw.example.yaml
+++ b/config.researchclaw.example.yaml
@@ -37,6 +37,7 @@ openclaw_bridge:
 llm:
   provider: "openai-compatible"
   base_url: "https://api.openai.com/v1"
+  wire_api: "chat_completions"  # Set to "responses" for Responses-only gateways
   api_key_env: "OPENAI_API_KEY"
   api_key: ""
   primary_model: "gpt-4o"

--- a/researchclaw/config.py
+++ b/researchclaw/config.py
@@ -9,7 +9,9 @@ from typing import Any
 import sys
 import yaml
 
-DEFAULT_PYTHON_PATH = ".venv/Scripts/python.exe" if sys.platform == "win32" else ".venv/bin/python3"
+DEFAULT_PYTHON_PATH = (
+    ".venv/Scripts/python.exe" if sys.platform == "win32" else ".venv/bin/python3"
+)
 
 CONFIG_SEARCH_ORDER: tuple[str, ...] = ("config.arc.yaml", "config.yaml")
 
@@ -32,8 +34,11 @@ def _validate_network_policy(val: object, default: str = "setup_only") -> str:
     s = str(val).strip().lower() if val else default
     if s not in _VALID_NETWORK_POLICIES:
         import logging as _cfg_log
+
         _cfg_log.getLogger(__name__).warning(
-            "Invalid network_policy %r, using %r", val, default,
+            "Invalid network_policy %r, using %r",
+            val,
+            default,
         )
         return default
     return s
@@ -47,6 +52,8 @@ def _safe_float(val: Any, default: float) -> float:
         return float(val)
     except (ValueError, TypeError):
         return default
+
+
 EXAMPLE_CONFIG = "config.researchclaw.example.yaml"
 
 
@@ -167,6 +174,7 @@ class AcpConfig:
 class LlmConfig:
     provider: str
     base_url: str = ""
+    wire_api: str = "chat_completions"
     api_key_env: str = ""
     api_key: str = ""
     primary_model: str = ""
@@ -433,11 +441,14 @@ class ExportConfig:
     authors: str = "Anonymous"
     bib_file: str = "references"
 
+
 @dataclass(frozen=True)
 class PromptsConfig:
     """Configuration for prompt externalization."""
 
     custom_file: str = ""  # Path to custom prompts YAML (empty = use defaults)
+
+
 @dataclass(frozen=True)
 class RCConfig:
     project: ProjectConfig
@@ -452,9 +463,7 @@ class RCConfig:
     export: ExportConfig = field(default_factory=ExportConfig)
     prompts: PromptsConfig = field(default_factory=PromptsConfig)
     web_search: WebSearchConfig = field(default_factory=WebSearchConfig)
-    metaclaw_bridge: MetaClawBridgeConfig = field(
-        default_factory=MetaClawBridgeConfig
-    )
+    metaclaw_bridge: MetaClawBridgeConfig = field(default_factory=MetaClawBridgeConfig)
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -546,10 +555,14 @@ class RCConfig:
             web_search=WebSearchConfig(
                 enabled=bool(web_search.get("enabled", True)),
                 tavily_api_key=str(web_search.get("tavily_api_key", "")),
-                tavily_api_key_env=str(web_search.get("tavily_api_key_env", "TAVILY_API_KEY")),
+                tavily_api_key_env=str(
+                    web_search.get("tavily_api_key_env", "TAVILY_API_KEY")
+                ),
                 enable_scholar=bool(web_search.get("enable_scholar", True)),
                 enable_crawling=bool(web_search.get("enable_crawling", True)),
-                enable_pdf_extraction=bool(web_search.get("enable_pdf_extraction", True)),
+                enable_pdf_extraction=bool(
+                    web_search.get("enable_pdf_extraction", True)
+                ),
                 max_web_results=int(web_search.get("max_web_results", 10)),
                 max_scholar_results=int(web_search.get("max_scholar_results", 10)),
                 max_crawl_urls=int(web_search.get("max_crawl_urls", 5)),
@@ -607,6 +620,13 @@ def validate_config(
     if not _is_blank(kb_backend) and kb_backend not in KB_BACKENDS:
         errors.append(f"Invalid knowledge_base.backend: {kb_backend}")
 
+    llm_wire_api = _get_by_path(data, "llm.wire_api")
+    if not _is_blank(llm_wire_api) and llm_wire_api not in (
+        "chat_completions",
+        "responses",
+    ):
+        errors.append(f"Invalid llm.wire_api: {llm_wire_api}")
+
     hitl_required_stages = _get_by_path(data, "security.hitl_required_stages")
     if hitl_required_stages is not None:
         if not isinstance(hitl_required_stages, list):
@@ -647,6 +667,7 @@ def _parse_llm_config(data: dict[str, Any]) -> LlmConfig:
     return LlmConfig(
         provider=data.get("provider", "openai-compatible"),
         base_url=data.get("base_url", ""),
+        wire_api=data.get("wire_api", "chat_completions"),
         api_key_env=data.get("api_key_env", ""),
         api_key=data.get("api_key", ""),
         primary_model=data.get("primary_model", ""),
@@ -687,9 +708,7 @@ def _parse_experiment_config(data: dict[str, Any]) -> ExperimentConfig:
         docker=DockerSandboxConfig(
             image=docker_data.get("image", "researchclaw/experiment:latest"),
             gpu_enabled=bool(docker_data.get("gpu_enabled", True)),
-            gpu_device_ids=tuple(
-                int(g) for g in docker_data.get("gpu_device_ids", ())
-            ),
+            gpu_device_ids=tuple(int(g) for g in docker_data.get("gpu_device_ids", ())),
             memory_limit_mb=_safe_int(docker_data.get("memory_limit_mb"), 8192),
             network_policy=_validate_network_policy(
                 docker_data.get("network_policy", "setup_only"),
@@ -716,7 +735,9 @@ def _parse_experiment_config(data: dict[str, Any]) -> ExperimentConfig:
             docker_network_policy=_validate_network_policy(
                 ssh_data.get("docker_network_policy", "none"),
             ),
-            docker_memory_limit_mb=_safe_int(ssh_data.get("docker_memory_limit_mb"), 8192),
+            docker_memory_limit_mb=_safe_int(
+                ssh_data.get("docker_memory_limit_mb"), 8192
+            ),
             docker_shm_size_mb=_safe_int(ssh_data.get("docker_shm_size_mb"), 2048),
             timeout_sec=_safe_int(ssh_data.get("timeout_sec"), 600),
             scp_timeout_sec=_safe_int(ssh_data.get("scp_timeout_sec"), 300),
@@ -766,9 +787,7 @@ def _parse_figure_agent_config(data: dict[str, Any]) -> FigureAgentConfig:
         max_figures=_safe_int(data.get("max_figures"), 8),
         max_iterations=_safe_int(data.get("max_iterations"), 3),
         render_timeout_sec=_safe_int(data.get("render_timeout_sec"), 30),
-        use_docker=(
-            None if use_docker_raw is None else bool(use_docker_raw)
-        ),
+        use_docker=(None if use_docker_raw is None else bool(use_docker_raw)),
         docker_image=data.get("docker_image", "researchclaw/experiment:latest"),
         output_format=data.get("output_format", "python"),
         gemini_api_key=data.get("gemini_api_key", ""),
@@ -800,7 +819,9 @@ def _parse_code_agent_config(data: dict[str, Any]) -> CodeAgentConfig:
         architecture_planning=bool(data.get("architecture_planning", True)),
         sequential_generation=bool(data.get("sequential_generation", True)),
         hard_validation=bool(data.get("hard_validation", True)),
-        hard_validation_max_repairs=_safe_int(data.get("hard_validation_max_repairs"), 2),
+        hard_validation_max_repairs=_safe_int(
+            data.get("hard_validation_max_repairs"), 2
+        ),
         exec_fix_max_iterations=_safe_int(data.get("exec_fix_max_iterations"), 3),
         exec_fix_timeout_sec=_safe_int(data.get("exec_fix_timeout_sec"), 60),
         tree_search_enabled=bool(data.get("tree_search_enabled", False)),

--- a/researchclaw/llm/client.py
+++ b/researchclaw/llm/client.py
@@ -35,6 +35,8 @@ _NEW_PARAM_MODELS = frozenset(
     }
 )
 
+_NO_TEMPERATURE_MODELS = _NEW_PARAM_MODELS
+
 _DEFAULT_USER_AGENT = (
     "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
     "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
@@ -61,6 +63,7 @@ class LLMConfig:
 
     base_url: str
     api_key: str
+    wire_api: str = "chat_completions"
     primary_model: str = "gpt-4o"
     fallback_models: list[str] = field(
         default_factory=lambda: ["gpt-4.1", "gpt-4o-mini"]
@@ -86,6 +89,27 @@ class LLMClient:
         self._model_chain = [config.primary_model] + list(config.fallback_models)
         self._anthropic = None  # Will be set by from_rc_config if needed
 
+    @staticmethod
+    def _normalize_wire_api(wire_api: str) -> str:
+        normalized = (wire_api or "").strip().lower().replace("-", "_")
+        if normalized in ("", "chat/completions", "chat_completions"):
+            return "chat_completions"
+        if normalized == "responses":
+            return "responses"
+        return normalized
+
+    def _endpoint_path(self) -> str:
+        if self._normalize_wire_api(self.config.wire_api) == "responses":
+            return "/responses"
+        return "/chat/completions"
+
+    def _endpoint_url(self, base_url: str) -> str:
+        return f"{base_url.rstrip('/')}{self._endpoint_path()}"
+
+    @staticmethod
+    def _supports_temperature(model: str) -> bool:
+        return not any(model.startswith(prefix) for prefix in _NO_TEMPERATURE_MODELS)
+
     @classmethod
     def from_rc_config(cls, rc_config: Any) -> LLMClient:
         from researchclaw.llm import PROVIDER_PRESETS
@@ -95,9 +119,7 @@ class LLMClient:
         preset_base_url = preset.get("base_url")
 
         api_key = str(
-            rc_config.llm.api_key
-            or os.environ.get(rc_config.llm.api_key_env, "")
-            or ""
+            rc_config.llm.api_key or os.environ.get(rc_config.llm.api_key_env, "") or ""
         )
 
         # Use preset base_url if available and config doesn't override
@@ -126,6 +148,7 @@ class LLMClient:
         config = LLMConfig(
             base_url=base_url,
             api_key=api_key,
+            wire_api=getattr(rc_config.llm, "wire_api", "chat_completions"),
             primary_model=rc_config.llm.primary_model or "gpt-4o",
             fallback_models=list(rc_config.llm.fallback_models or []),
             fallback_url=fallback_url,
@@ -186,6 +209,7 @@ class LLMClient:
                 resp = self._call_with_retry(m, messages, max_tok, temp, json_mode)
                 if strip_thinking:
                     from researchclaw.utils.thinking_tags import strip_thinking_tags
+
                     resp = LLMResponse(
                         content=strip_thinking_tags(resp.content),
                         model=resp.model,
@@ -227,7 +251,7 @@ class LLMClient:
             status_map = {
                 401: "Invalid API key",
                 403: f"Model {self.config.primary_model} not allowed for this key",
-                404: f"Endpoint not found: {self.config.base_url}",
+                404: f"Endpoint not found: {self._endpoint_url(self.config.base_url)}",
                 429: "Rate limited - try again in a moment",
             }
             msg = status_map.get(e.code, f"HTTP {e.code}")
@@ -241,7 +265,7 @@ class LLMClient:
                 status_map = {
                     401: "Invalid API key",
                     403: f"Model {self.config.primary_model} not allowed for this key",
-                    404: f"Endpoint not found: {self.config.base_url}",
+                    404: f"Endpoint not found: {self._endpoint_url(self.config.base_url)}",
                     429: "Rate limited - try again in a moment",
                 }
                 msg = status_map.get(cause.code, f"HTTP {cause.code}")
@@ -280,9 +304,16 @@ class LLMClient:
                 if status == 400:
                     _transient_400 = any(
                         kw in body.lower()
-                        for kw in ("rate limit", "ratelimit", "overloaded",
-                                   "temporarily", "capacity", "throttl",
-                                   "too many", "retry")
+                        for kw in (
+                            "rate limit",
+                            "ratelimit",
+                            "overloaded",
+                            "temporarily",
+                            "capacity",
+                            "throttl",
+                            "too many",
+                            "retry",
+                        )
                     )
                     if not _transient_400:
                         raise  # Genuine bad request — don't retry
@@ -328,10 +359,12 @@ class LLMClient:
         json_mode: bool,
     ) -> LLMResponse:
         """Make a single API call."""
-        
+
         # Use Anthropic adapter if configured
         if self._anthropic:
-            data = self._anthropic.chat_completion(model, messages, max_tokens, temperature, json_mode)
+            data = self._anthropic.chat_completion(
+                model, messages, max_tokens, temperature, json_mode
+            )
         else:
             # Original OpenAI logic
             # Copy messages to avoid mutating the caller's list (important for
@@ -344,42 +377,45 @@ class LLMClient:
             if "api.minimax.io" in self.config.base_url:
                 _temp = max(0.0, min(_temp, 1.0))
 
-            body: dict[str, Any] = {
-                "model": model,
-                "messages": msgs,
-                "temperature": _temp,
-            }
-
-            # Use correct token parameter based on model
-            if any(model.startswith(prefix) for prefix in _NEW_PARAM_MODELS):
-                reasoning_min = 32768
-                body["max_completion_tokens"] = max(max_tokens, reasoning_min)
+            if self._normalize_wire_api(self.config.wire_api) == "responses":
+                body = self._build_responses_body(model, msgs, max_tokens, _temp)
             else:
-                body["max_tokens"] = max_tokens
+                body = {
+                    "model": model,
+                    "messages": msgs,
+                }
+                if self._supports_temperature(model):
+                    body["temperature"] = _temp
+
+                # Use correct token parameter based on model
+                if any(model.startswith(prefix) for prefix in _NEW_PARAM_MODELS):
+                    reasoning_min = 32768
+                    body["max_completion_tokens"] = max(max_tokens, reasoning_min)
+                else:
+                    body["max_tokens"] = max_tokens
 
             if json_mode:
                 # Many OpenAI-compatible proxies serving Claude models don't
                 # support the response_format parameter and return HTTP 400.
                 # Fall back to a system-prompt injection for non-OpenAI models.
-                if model.startswith("claude"):
+                if (
+                    model.startswith("claude")
+                    or self._normalize_wire_api(self.config.wire_api) == "responses"
+                ):
                     _json_hint = (
                         "You MUST respond with valid JSON only. "
                         "Do not include any text outside the JSON object."
                     )
                     # Prepend to existing system message or add as new one
                     if msgs and msgs[0]["role"] == "system":
-                        msgs[0]["content"] = (
-                            _json_hint + "\n\n" + msgs[0]["content"]
-                        )
+                        msgs[0]["content"] = _json_hint + "\n\n" + msgs[0]["content"]
                     else:
-                        msgs.insert(
-                            0, {"role": "system", "content": _json_hint}
-                        )
+                        msgs.insert(0, {"role": "system", "content": _json_hint})
                 else:
                     body["response_format"] = {"type": "json_object"}
 
             payload = json.dumps(body).encode("utf-8")
-            url = f"{self.config.base_url.rstrip('/')}/chat/completions"
+            url = self._endpoint_url(self.config.base_url)
 
             headers = {
                 "Authorization": f"Bearer {self.config.api_key}",
@@ -392,7 +428,9 @@ class LLMClient:
             req = urllib.request.Request(url, data=payload, headers=headers)
 
             try:
-                with urllib.request.urlopen(req, timeout=self.config.timeout_sec) as resp:
+                with urllib.request.urlopen(
+                    req, timeout=self.config.timeout_sec
+                ) as resp:
                     data = json.loads(resp.read())
             except (urllib.error.URLError, OSError) as exc:
                 # MetaClaw bridge: fallback to direct LLM if proxy unreachable
@@ -402,9 +440,7 @@ class LLMClient:
                         self.config.fallback_url,
                         exc,
                     )
-                    fallback_url = (
-                        f"{self.config.fallback_url.rstrip('/')}/chat/completions"
-                    )
+                    fallback_url = self._endpoint_url(self.config.fallback_url)
                     fallback_key = self.config.fallback_api_key or self.config.api_key
                     fallback_headers = {
                         "Authorization": f"Bearer {fallback_key}",
@@ -421,18 +457,68 @@ class LLMClient:
                 else:
                     raise
 
+        if not isinstance(data, dict):
+            raise ValueError(
+                f"Malformed API response: expected JSON object, got {type(data).__name__}: {data}"
+            )
+
         # Handle API error responses
-        if "error" in data:
+        if "error" in data and data["error"] is not None:
             error_info = data["error"]
-            error_msg = error_info.get("message", str(error_info))
-            error_type = error_info.get("type", "api_error")
+            if isinstance(error_info, dict):
+                error_msg = str(error_info.get("message", str(error_info)))
+                error_type = str(error_info.get("type", "api_error"))
+            else:
+                error_msg = str(error_info)
+                error_type = "api_error"
             import io
+
             raise urllib.error.HTTPError(
-                "", 500, f"{error_type}: {error_msg}", {},
+                "",
+                500,
+                f"{error_type}: {error_msg}",
+                None,
                 io.BytesIO(error_msg.encode()),
             )
 
-        # Validate response structure
+        if self._normalize_wire_api(self.config.wire_api) == "responses":
+            return self._parse_responses_response(data, model)
+        return self._parse_chat_completions_response(data, model)
+
+    def _build_responses_body(
+        self,
+        model: str,
+        messages: list[dict[str, str]],
+        max_tokens: int,
+        temperature: float,
+    ) -> dict[str, Any]:
+        body: dict[str, Any] = {
+            "model": model,
+            "input": self._messages_to_responses_input(messages),
+        }
+        if self._supports_temperature(model):
+            body["temperature"] = temperature
+        body["max_output_tokens"] = max_tokens
+        return body
+
+    def _messages_to_responses_input(
+        self, messages: list[dict[str, str]]
+    ) -> list[dict[str, Any]]:
+        items: list[dict[str, Any]] = []
+        for message in messages:
+            role = str(message.get("role", "user") or "user")
+            content = str(message.get("content", "") or "")
+            items.append(
+                {
+                    "role": role,
+                    "content": [{"type": "input_text", "text": content}],
+                }
+            )
+        return items
+
+    def _parse_chat_completions_response(
+        self, data: dict[str, Any], model: str
+    ) -> LLMResponse:
         if "choices" not in data or not data["choices"]:
             raise ValueError(f"Malformed API response: missing choices. Got: {data}")
 
@@ -450,6 +536,64 @@ class LLMClient:
             total_tokens=usage.get("total_tokens", 0),
             finish_reason=choice.get("finish_reason", ""),
             truncated=(choice.get("finish_reason", "") == "length"),
+            raw=data,
+        )
+
+    def _parse_responses_response(
+        self, data: dict[str, Any], model: str
+    ) -> LLMResponse:
+        output_items = data.get("output")
+        if not isinstance(output_items, list) or not output_items:
+            raise ValueError(
+                f"Malformed responses API payload: missing output. Got: {data}"
+            )
+
+        chunks: list[str] = []
+        finish_reason = str(data.get("status", "") or "")
+        truncated = False
+
+        for item in output_items:
+            if not isinstance(item, dict):
+                continue
+            if item.get("type") != "message":
+                continue
+            content_items = item.get("content")
+            if not isinstance(content_items, list):
+                continue
+            for content_item in content_items:
+                if not isinstance(content_item, dict):
+                    continue
+                if content_item.get("type") == "output_text":
+                    text = content_item.get("text")
+                    if isinstance(text, str):
+                        chunks.append(text)
+
+        incomplete_details = data.get("incomplete_details")
+        if isinstance(incomplete_details, dict):
+            reason = incomplete_details.get("reason")
+            if isinstance(reason, str) and reason:
+                finish_reason = reason
+                truncated = reason in ("max_output_tokens", "content_filter")
+
+        usage = data.get("usage", {})
+        prompt_tokens = 0
+        completion_tokens = 0
+        total_tokens = 0
+        if isinstance(usage, dict):
+            prompt_tokens = int(usage.get("input_tokens", 0) or 0)
+            completion_tokens = int(usage.get("output_tokens", 0) or 0)
+            total_tokens = int(
+                usage.get("total_tokens", prompt_tokens + completion_tokens) or 0
+            )
+
+        return LLMResponse(
+            content="".join(chunks),
+            model=data.get("model", model),
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            total_tokens=total_tokens,
+            finish_reason=finish_reason,
+            truncated=truncated,
             raw=data,
         )
 
@@ -480,6 +624,7 @@ def create_client_from_yaml(yaml_path: str | None = None) -> LLMClient:
         LLMConfig(
             base_url=llm_section.get("base_url", "https://api.openai.com/v1"),
             api_key=api_key,
+            wire_api=llm_section.get("wire_api", "chat_completions"),
             primary_model=llm_section.get("primary_model", "gpt-4o"),
             fallback_models=llm_section.get(
                 "fallback_models", ["gpt-4.1", "gpt-4o-mini"]

--- a/tests/test_rc_config.py
+++ b/tests/test_rc_config.py
@@ -142,6 +142,25 @@ def test_validate_config_rejects_invalid_knowledge_base_backend(tmp_path: Path):
     assert "Invalid knowledge_base.backend: sqlite" in result.errors
 
 
+def test_validate_config_accepts_llm_wire_api_responses(tmp_path: Path):
+    data = _valid_config_data()
+    data["llm"]["wire_api"] = "responses"
+
+    result = validate_config(data, project_root=tmp_path, check_paths=False)
+
+    assert result.ok is True
+
+
+def test_validate_config_rejects_invalid_llm_wire_api(tmp_path: Path):
+    data = _valid_config_data()
+    data["llm"]["wire_api"] = "responses_only"
+
+    result = validate_config(data, project_root=tmp_path, check_paths=False)
+
+    assert result.ok is False
+    assert "Invalid llm.wire_api: responses_only" in result.errors
+
+
 @pytest.mark.parametrize("entry", [0, 24, "5", 9.1])
 def test_validate_config_rejects_invalid_hitl_required_stages_entries(
     tmp_path: Path, entry: object
@@ -207,6 +226,15 @@ def test_rcconfig_from_dict_happy_path(tmp_path: Path):
     assert config.llm.fallback_models == ("gpt-4o-mini", "gpt-4o")
 
 
+def test_rcconfig_from_dict_parses_llm_wire_api(tmp_path: Path):
+    data = _valid_config_data()
+    data["llm"]["wire_api"] = "responses"
+
+    config = RCConfig.from_dict(data, project_root=tmp_path, check_paths=False)
+
+    assert config.llm.wire_api == "responses"
+
+
 def test_rcconfig_from_dict_missing_fields_raises_value_error(tmp_path: Path):
     data = _valid_config_data()
     del data["runtime"]
@@ -249,6 +277,7 @@ def test_experiment_config_defaults_mode_is_simulated():
 
 def test_sandbox_config_defaults_match_expected_values():
     from researchclaw.config import DEFAULT_PYTHON_PATH
+
     defaults = SandboxConfig()
 
     assert defaults.python_path == DEFAULT_PYTHON_PATH

--- a/tests/test_rc_llm.py
+++ b/tests/test_rc_llm.py
@@ -29,11 +29,13 @@ def _make_client(
     api_key: str = "test-key",
     primary_model: str = "gpt-5.2",
     fallback_models: list[str] | None = None,
+    wire_api: str = "chat_completions",
     timeout_sec: int = 120,
 ) -> LLMClient:
     config = LLMConfig(
         base_url="https://api.example.com/v1",
         api_key=api_key,
+        wire_api=wire_api,
         primary_model=primary_model,
         fallback_models=fallback_models or ["gpt-5.1", "gpt-4.1", "gpt-4o"],
         timeout_sec=timeout_sec,
@@ -205,6 +207,7 @@ def test_from_rc_config_builds_expected_llm_config():
             base_url="https://proxy.example/v1",
             api_key="inline-key",
             api_key_env="OPENAI_API_KEY",
+            wire_api="responses",
             primary_model="o3",
             fallback_models=("o3-mini", "gpt-4o"),
         )
@@ -212,8 +215,108 @@ def test_from_rc_config_builds_expected_llm_config():
     client = LLMClient.from_rc_config(rc_config)
     assert client.config.base_url == "https://proxy.example/v1"
     assert client.config.api_key == "inline-key"
+    assert client.config.wire_api == "responses"
     assert client.config.primary_model == "o3"
     assert client.config.fallback_models == ["o3-mini", "gpt-4o"]
+
+
+def test_responses_wire_api_uses_responses_endpoint(monkeypatch: pytest.MonkeyPatch):
+    captured: dict[str, object] = {}
+
+    def fake_urlopen(req: urllib.request.Request, timeout: int) -> _DummyHTTPResponse:
+        captured["request"] = req
+        captured["timeout"] = timeout
+        return _DummyHTTPResponse(
+            {
+                "model": "gpt-4.1",
+                "output": [
+                    {
+                        "type": "message",
+                        "content": [{"type": "output_text", "text": "hello"}],
+                    }
+                ],
+                "usage": {"input_tokens": 11, "output_tokens": 7, "total_tokens": 18},
+                "status": "completed",
+            }
+        )
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    client = _make_client(primary_model="gpt-4.1", wire_api="responses")
+    resp = client._raw_call(
+        "gpt-4.1", [{"role": "user", "content": "hello"}], 123, 0.2, False
+    )
+
+    request = captured["request"]
+    assert isinstance(request, urllib.request.Request)
+    assert request.full_url == "https://api.example.com/v1/responses"
+    assert captured["timeout"] == 120
+
+    data = request.data
+    assert isinstance(data, bytes)
+    body = json.loads(data.decode("utf-8"))
+    assert body["model"] == "gpt-4.1"
+    assert body["input"] == [
+        {"role": "user", "content": [{"type": "input_text", "text": "hello"}]}
+    ]
+    assert body["max_output_tokens"] == 123
+    assert resp.content == "hello"
+    assert resp.prompt_tokens == 11
+    assert resp.completion_tokens == 7
+    assert resp.total_tokens == 18
+
+
+def test_responses_wire_api_omits_temperature_for_reasoning_models(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    captured: dict[str, object] = {}
+
+    def fake_urlopen(req: urllib.request.Request, timeout: int) -> _DummyHTTPResponse:
+        captured["request"] = req
+        return _DummyHTTPResponse(
+            {
+                "model": "gpt-5.2",
+                "output": [
+                    {
+                        "type": "message",
+                        "content": [{"type": "output_text", "text": "ok"}],
+                    }
+                ],
+                "usage": {},
+                "status": "completed",
+            }
+        )
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    client = _make_client(primary_model="gpt-5.2", wire_api="responses")
+    _ = client._raw_call(
+        "gpt-5.2", [{"role": "user", "content": "hello"}], 55, 0.2, False
+    )
+
+    request = captured["request"]
+    assert isinstance(request, urllib.request.Request)
+    data = request.data
+    assert isinstance(data, bytes)
+    body = json.loads(data.decode("utf-8"))
+    assert "temperature" not in body
+
+
+def test_preflight_404_reports_responses_endpoint():
+    client = _make_client(primary_model="gpt-4.1", wire_api="responses")
+
+    def fake_chat(*args: Any, **kwargs: Any) -> LLMResponse:
+        raise urllib.error.HTTPError(
+            url="https://api.example.com/v1/responses",
+            code=404,
+            msg="Not Found",
+            hdrs=None,
+            fp=None,
+        )
+
+    client.chat = fake_chat  # type: ignore[method-assign]
+    ok, msg = client.preflight()
+
+    assert ok is False
+    assert msg == "Endpoint not found: https://api.example.com/v1/responses"
 
 
 def test_from_rc_config_reads_api_key_from_env_when_missing(


### PR DESCRIPTION
## Summary
- add `llm.wire_api` to select between `chat_completions` and `responses`
- support `/responses` request formatting and response parsing in `LLMClient`
- add focused tests for config validation, endpoint selection, and Responses API parsing
## Why
Some OpenAI-compatible providers expose the Responses API instead of the legacy Chat Completions API. This change makes the transport format configurable so ResearchClaw can work with Responses-only gateways.
## Testing
- `.venv/bin/python -m pytest tests/`