### PR TITLE
Fix ACP prompt overflow on Windows

### DIFF
--- a/researchclaw/llm/acp_client.py
+++ b/researchclaw/llm/acp_client.py
@@ -228,6 +228,10 @@ class ACPClient:
     # several fixed arguments plus quoting overhead, so leave generous headroom
     # on Windows and switch to temp-file transport earlier.
     _MAX_CLI_PROMPT_BYTES = 20_000 if sys.platform == "win32" else 100_000
+    # On Windows, npm-installed CLIs usually resolve to ``.cmd`` launchers,
+    # which are routed through ``cmd.exe`` and hit a much smaller practical
+    # command-line limit (~8 KB). Use file transport much earlier there.
+    _MAX_CMD_WRAPPER_PROMPT_BYTES = 6_000 if sys.platform == "win32" else 100_000
 
     # Localized error snippets for "command line too long" (may be in any OS language)
     _CMD_TOO_LONG_HINTS = (
@@ -246,6 +250,16 @@ class ACPClient:
     )
     _MAX_RECONNECT_ATTEMPTS = 2
 
+    @classmethod
+    def _cli_prompt_limit(cls, acpx: str | None) -> int:
+        """Return the safe inline-prompt size for the resolved ACP launcher."""
+        limit = cls._MAX_CLI_PROMPT_BYTES
+        if sys.platform == "win32" and acpx:
+            lower = acpx.lower()
+            if lower.endswith((".cmd", ".bat")):
+                return min(limit, cls._MAX_CMD_WRAPPER_PROMPT_BYTES)
+        return limit
+
     def _send_prompt(self, prompt: str) -> str:
         """Send a prompt via acpx and return the response text.
 
@@ -261,11 +275,13 @@ class ACPClient:
             raise RuntimeError("acpx not found")
 
         prompt_bytes = len(prompt.encode("utf-8"))
-        use_file = prompt_bytes > self._MAX_CLI_PROMPT_BYTES
+        prompt_limit = self._cli_prompt_limit(acpx)
+        use_file = prompt_bytes > prompt_limit
         if use_file:
             logger.info(
-                "Prompt too large for CLI arg (%d bytes). Using temp file.",
+                "Prompt too large for CLI arg (%d bytes > %d). Using temp file.",
                 prompt_bytes,
+                prompt_limit,
             )
 
         last_exc: RuntimeError | None = None

--- a/tests/test_rc_llm.py
+++ b/tests/test_rc_llm.py
@@ -239,7 +239,8 @@ def test_acp_large_prompt_uses_file_transport_before_cli_limit():
     client = ACPClient(ACPConfig(agent="codex"))
     client._acpx = "acpx"
     client._session_ready = True
-    client._MAX_CLI_PROMPT_BYTES = 10  # type: ignore[attr-defined]
+    original_limit = ACPClient._MAX_CLI_PROMPT_BYTES
+    ACPClient._MAX_CLI_PROMPT_BYTES = 10
     client._ensure_session = lambda: None  # type: ignore[assignment]
 
     def fail_cli(acpx: str, prompt: str) -> str:
@@ -248,8 +249,11 @@ def test_acp_large_prompt_uses_file_transport_before_cli_limit():
     client._send_prompt_cli = fail_cli  # type: ignore[assignment]
     client._send_prompt_via_file = lambda acpx, prompt: "ok-from-file"  # type: ignore[assignment]
 
-    result = client._send_prompt("x" * 11)
-    assert result == "ok-from-file"
+    try:
+        result = client._send_prompt("x" * 11)
+        assert result == "ok-from-file"
+    finally:
+        ACPClient._MAX_CLI_PROMPT_BYTES = original_limit
 
 
 def test_acp_command_line_too_long_falls_back_to_file_transport():
@@ -274,6 +278,14 @@ def test_acp_command_line_too_long_falls_back_to_file_transport():
     result = client._send_prompt("short prompt")
     assert result == "ok-from-file"
     assert call_count == 1
+
+
+def test_acp_windows_cmd_wrapper_uses_lower_inline_limit(monkeypatch: pytest.MonkeyPatch):
+    from researchclaw.llm.acp_client import ACPClient
+
+    monkeypatch.setattr("researchclaw.llm.acp_client.sys.platform", "win32")
+    limit = ACPClient._cli_prompt_limit(r"C:\Users\test\AppData\Roaming\npm\acpx.CMD")
+    assert limit == ACPClient._MAX_CMD_WRAPPER_PROMPT_BYTES
 
 
 def test_new_param_models_contains_expected_models():


### PR DESCRIPTION
## Summary

  Fixes a Windows-specific ACP failure where Stage SYNTHESIS and other long-context stages could fail with an error
  equivalent to "The command line is too long".

  The issue was not token exhaustion. It was caused by prompt text being passed inline through the ACP CLI on Windows.

  ## Root cause

  On Windows, `acpx` often resolves to an npm-installed `.cmd` launcher such as `acpx.CMD`.

  That launcher goes through `cmd.exe`, which has a much smaller practical command-line limit than the normal Windows
  process limit. As a result, prompts that were still below the previous inline threshold could still fail before the
  existing fallback logic had a chance to help.

  ## What changed

  - Keep the existing fallback-to-file behavior for oversized ACP prompts
  - Add a stricter inline prompt limit on Windows when the resolved ACP launcher is a `.cmd` or `.bat` wrapper
  - Continue using file-based prompt transport automatically once that safer limit is exceeded
  - Add regression tests for:
    - oversized prompts switching to file transport before inline execution
    - "command line too long" failures falling back to file transport
    - Windows `.cmd` ACP launchers using the lower safe inline limit

  ## Why this helps

  This makes ACP prompt handling match the real behavior of Windows launcher wrappers instead of assuming the higher
  process-level limit is always usable.

  That prevents failures in stages that assemble large literature or synthesis context, especially when using Codex
  CLI / Gemini CLI through npm-installed ACP commands.

  ## Validation

  - Reproduced the failure locally on Windows during Stage SYNTHESIS
  - Measured a failing prompt at about 17.9 KB, which was still small enough to bypass the old threshold but too large
  for the actual `.cmd` launcher path
  - Verified the updated logic now routes such prompts through file transport instead
  - Ran tests successfully:

  ```bash
  .\.venv\Scripts\python.exe -m pytest tests\test_rc_llm.py -q

  Result: 24 passed
