### PR TITLE
fix: guard os.getuid/os.getgid for Windows in Docker sandbox

### DIFF
--- a/researchclaw/experiment/docker_sandbox.py
+++ b/researchclaw/experiment/docker_sandbox.py
@@ -18,6 +18,7 @@ import os
 import re
 import shutil
 import subprocess
+import sys
 import threading
 import time
 from pathlib import Path
@@ -370,10 +371,19 @@ class DockerSandbox:
         ]
 
         # --- Network policy ---
+        # On POSIX, run the container as the host user so that files
+        # written to the bind-mounted volume are owned by the caller.
+        # os.getuid / os.getgid are not available on Windows; fall back
+        # to running as the default container user (usually root).
+        def _user_flag() -> list[str]:
+            if sys.platform == "win32":
+                return []
+            return ["--user", f"{os.getuid()}:{os.getgid()}"]
+
         if cfg.network_policy == "none":
             # Fully isolated — no network at any point
             cmd.extend(["--network", "none"])
-            cmd.extend(["--user", f"{os.getuid()}:{os.getgid()}"])
+            cmd.extend(_user_flag())
         elif cfg.network_policy in ("setup_only", "pip_only"):
             # Network during Phase 0+1, disabled via iptables before Phase 2.
             # Run as host user so experiment can write results.json to volume.
@@ -381,11 +391,11 @@ class DockerSandbox:
             # the user lacks root — network remains available but the code
             # has already been validated by the pipeline security check.
             cmd.extend(["-e", "RC_SETUP_ONLY_NETWORK=1"])
-            cmd.extend(["--user", f"{os.getuid()}:{os.getgid()}"])
+            cmd.extend(_user_flag())
             cmd.extend(["--cap-add=NET_ADMIN"])
         elif cfg.network_policy == "full":
             # Full network throughout — for development/debugging
-            cmd.extend(["--user", f"{os.getuid()}:{os.getgid()}"])
+            cmd.extend(_user_flag())
 
         # Mount pre-cached datasets
         # Priority: /opt/datasets (system) > ~/.cache/datasets (user)


### PR DESCRIPTION
## Problem

`os.getuid()` and `os.getgid()` are POSIX-only APIs and raise `AttributeError` on Windows:

```
AttributeError: module 'os' has no attribute 'getuid'
```

This causes `DockerSandbox._build_docker_cmd()` to crash on any Windows host, regardless of the `network_policy` setting. All three code paths (`none`, `setup_only`/`pip_only`, `full`) are affected.

## Fix

Extract a `_user_flag()` helper inside `_build_docker_cmd()` that:
- Returns `[]` on `win32` (falling back to the default container user, usually root)
- Returns `["--user", "<uid>:<gid>"]` on POSIX systems (preserving existing behavior)

## Testing

Verified on Windows (Python 3.11):

**Before fix:**
```python
>>> import os; os.getuid()
AttributeError: module 'os' has no attribute 'getuid'
```

**After fix:**
```python
>>> _user_flag()  # on win32
[]  # no crash, falls back to container default user
```

POSIX behavior is unchanged — `_user_flag()` still returns `["--user", "uid:gid"]` on Linux/macOS.
