### PR TITLE
fix: Windows cp1252 encoding crash, UnboundLocalError in Stage 22, stale paper_final_verified.md

### DIFF
--- a/researchclaw/pipeline/runner.py
+++ b/researchclaw/pipeline/runner.py
@@ -456,10 +456,10 @@ def execute_pipeline(
             if result.decision == "degraded":
                 print(
                     f"{prefix} {stage.name} — DEGRADED ({elapsed:.1f}s) "
-                    f"— continuing with sanitization → {arts}"
+                    f"— continuing with sanitization -> {arts}"
                 )
             else:
-                print(f"{prefix} {stage.name} — done ({elapsed:.1f}s) → {arts}")
+                print(f"{prefix} {stage.name} — done ({elapsed:.1f}s) -> {arts}")
         elif result.status == StageStatus.FAILED:
             err = result.error or "unknown error"
             print(f"{prefix} {stage.name} — FAILED ({elapsed:.1f}s) — {err}")
@@ -636,7 +636,7 @@ def execute_pipeline(
     try:
         deliverables_dir = _package_deliverables(run_dir, run_id, config)
         if deliverables_dir is not None:
-            print(f"[{run_id}] Deliverables packaged → {deliverables_dir}")
+            print(f"[{run_id}] Deliverables packaged -> {deliverables_dir}")
     except Exception:  # noqa: BLE001
         logger.warning("Deliverables packaging failed (non-blocking)")
 
@@ -1389,7 +1389,7 @@ def execute_iterative_pipeline(
     try:
         deliverables_dir = _package_deliverables(run_dir, run_id, config)
         if deliverables_dir is not None:
-            print(f"[{run_id}] Deliverables packaged → {deliverables_dir}")
+            print(f"[{run_id}] Deliverables packaged -> {deliverables_dir}")
     except Exception:  # noqa: BLE001
         logger.warning("Deliverables packaging failed (non-blocking)")
 

--- a/researchclaw/pipeline/stage_impls/_review_publish.py
+++ b/researchclaw/pipeline/stage_impls/_review_publish.py
@@ -1727,6 +1727,7 @@ def _execute_export_publish(
     # F2.7: Post-process citations — [cite_key] → \cite{cite_key}
     # and copy final references.bib to export stage
     _ay_map: dict[str, str] = {}  # BUG-102: author-year → cite_key map
+    final_paper_latex = final_paper  # default when no bib_text available
     bib_text = _read_prior_artifact(run_dir, "references.bib")
     if bib_text:
         # Replace [cite_key] patterns in the final paper with \cite{cite_key}
@@ -2627,6 +2628,12 @@ def _execute_citation_verify(
         (stage_dir / "references_verified.bib").write_text(
             "% No references to verify\n", encoding="utf-8"
         )
+        # Always write paper_final_verified.md so deliverables packaging gets
+        # the latest paper (not a stale copy from a previous run)
+        if paper_text.strip():
+            (stage_dir / "paper_final_verified.md").write_text(
+                paper_text, encoding="utf-8"
+            )
         return StageResult(
             stage=Stage.CITATION_VERIFY,
             status=StageStatus.DONE,


### PR DESCRIPTION
## Summary

Three independent bugs found during a pipeline run on Windows 10 (Python 3.14, cp1252 stdout):

### Bug 1 — `UnicodeEncodeError` on Windows (`runner.py`)

Stage completion `print()` statements contained U+2192 (`→`) which is not encodable in the default Windows cp1252 stdout codec. The pipeline crashes immediately after any stage completes.

**Fix:** Replaced `→` with ASCII `->` in all `print()` calls. `logger.*` calls are unaffected (they write to UTF-8 log files and are fine as-is).

### Bug 2 — `UnboundLocalError: cannot access local variable 'final_paper_latex'` (`_review_publish.py` Stage 22)

`final_paper_latex` was assigned only inside `if bib_text:` but referenced unconditionally later (`tex_source = final_paper_latex`). When `references.bib` is empty or absent — which happens on any run without BibTeX citations — the variable is never set and Stage 22 crashes with an `UnboundLocalError`.

**Fix:** Initialise `final_paper_latex = final_paper` before the `if bib_text:` block.

### Bug 3 — Stale `paper_final_verified.md` in deliverables (`_review_publish.py` Stage 23)

When `references.bib` is empty, Stage 23's early-return path wrote `verification_report.json` and `references_verified.bib` but skipped writing `paper_final_verified.md`. The deliverables packager in `runner.py` prefers `stage-23/paper_final_verified.md` over `stage-22/paper_final.md`, so on any subsequent run it served the stale file from a previous run instead of the freshly generated paper.

**Fix:** Always write `paper_final_verified.md` (copying `paper_final.md`) in the early-return path.

## Test plan

- [ ] Run pipeline on Windows with cp1252 stdout — stage completion lines print without `UnicodeEncodeError`
- [ ] Run pipeline with empty/absent `references.bib` — Stage 22 completes without `UnboundLocalError`
- [ ] Run pipeline twice consecutively — `deliverables/paper_final.md` matches `stage-22/paper_final.md` from the second run, not the first

🤖 Generated with [Claude Code](https://claude.com/claude-code)