### PR TITLE
fix: resolve python_path alias issue in sandbox

### DIFF
--- a/researchclaw/literature/semantic_scholar.py
+++ b/researchclaw/literature/semantic_scholar.py
@@ -225,6 +225,11 @@ def _request_with_retry(
     if not _cb_should_allow():
         return None
 
+    proxy_url = "http://127.0.0.1:8889"
+    proxy_handler = urllib.request.ProxyHandler({"http": proxy_url, "https": proxy_url})
+    opener = urllib.request.build_opener(proxy_handler)
+    urllib.request.install_opener(opener)
+
     for attempt in range(_MAX_RETRIES):
         try:
             req = urllib.request.Request(url, headers=headers)


### PR DESCRIPTION
This PR fixes an issue where the sandbox environment incorrectly resolves the \`python\` alias as a relative path, causing a \`[WinError 2]\` on Windows. It also includes a local proxy setup for Semantic Scholar.