### PR TITLE
fix: resolve python_path alias issue in sandbox on Windows

### DIFF
--- a/researchclaw/experiment/sandbox.py
+++ b/researchclaw/experiment/sandbox.py
@@ -463,7 +463,7 @@ class ExperimentSandbox:
         # which loses the venv context (site-packages like numpy become unavailable).
         python = self.config.python_path
         python_path = Path(python)
-        if not python_path.is_absolute():
+        if not python_path.is_absolute() and python != "python":
             python_path = Path.cwd() / python_path
         # -u: unbuffered stdout/stderr so subprocess.run captures all output
         return [str(python_path), "-u", str(script_path)]


### PR DESCRIPTION
This PR fixes an issue where the sandbox environment incorrectly resolves the `python` alias as a relative path, causing a `[WinError 2]` on Windows.