### PR TITLE
Unify pipeline domain checks on the profile detector

### DIFF
--- a/researchclaw/pipeline/_domain.py
+++ b/researchclaw/pipeline/_domain.py
@@ -1,115 +1,123 @@
-"""Domain detection — maps research topic to academic domain & venue context."""
+"""Compatibility wrapper around the canonical domain profile detector.
+
+Historically the pipeline used a coarse keyword-based detector that returned
+``(domain_id, display_name, top_venues)`` tuples such as ``("ml", ...)``.
+The newer domain system in :mod:`researchclaw.domains.detector` is more
+expressive (for example ``ml_vision`` vs ``ml_tabular``) and should be treated
+as the source of truth.
+
+This module now exists only to preserve the legacy tuple API for older call
+sites while routing every decision through the newer detector.
+"""
 
 from __future__ import annotations
 
-_DOMAIN_KEYWORDS: dict[str, tuple[list[str], str, str]] = {
-    # domain_id: (keywords, display_name, top_venues)
-    "ml": (
-        ["machine learning", "deep learning", "neural network", "transformer",
-         "reinforcement learning", "GAN", "diffusion model", "LLM", "language model",
-         "computer vision", "NLP", "representation learning", "self-supervised",
-         "federated learning", "meta-learning", "continual learning", "few-shot",
-         "knowledge distillation", "attention mechanism", "fine-tuning", "RLHF",
-         "vision transformer", "ViT", "BERT", "GPT", "autoencoder"],
-        "machine learning",
-        "NeurIPS, ICML, ICLR",
-    ),
-    "physics": (
-        ["quantum", "thermodynamic", "electrodynamic", "particle physics",
-         "condensed matter", "statistical mechanics", "cosmology", "astrophysics",
-         "plasma", "optics", "photonics", "relativity", "gravitational",
-         "PDE", "PINN", "physics-informed", "Burgers", "Navier-Stokes",
-         "Darcy flow", "Schrödinger", "scientific computing", "operator learning",
-         "neural operator", "Fourier neural", "DeepONet"],
-        "physics",
-        "Physical Review Letters, Nature Physics, JHEP",
-    ),
-    "chemistry": (
-        ["molecular", "catalysis", "polymer", "organic chemistry", "inorganic",
-         "electrochemistry", "spectroscopy", "crystallography", "drug discovery",
-         "protein folding", "computational chemistry", "DFT", "force field"],
-        "chemistry",
-        "JACS, Nature Chemistry, Angewandte Chemie",
-    ),
-    "economics": (
-        ["econometric", "macroeconomic", "microeconomic", "game theory",
-         "market", "fiscal policy", "monetary", "behavioral economics",
-         "causal inference", "panel data", "regression discontinuity",
-         "instrumental variable", "supply chain", "auction"],
-        "economics",
-        "AER, Econometrica, QJE, Review of Economic Studies",
-    ),
-    "mathematics": (
-        ["theorem", "proof", "prove", "conjecture", "topology", "algebra",
-         "number theory", "combinatorics", "differential equation",
-         "stochastic process", "functional analysis", "manifold",
-         "Riemannian", "category theory", "graph theory",
-         "neural ODE", "dynamical system", "Lorenz", "chaotic",
-         "Lyapunov", "attractor", "ODE solver", "trajectory prediction",
-         "mathematical formulation", "mathematical proof", "derivation",
-         "Brownian motion", "branching process", "Galton-Watson",
-         "Markov chain", "martingale", "ergodic", "convergence theorem",
-         "marginal distribution", "extinction probability", "Feynman-Kac",
-         "measure theory", "Hilbert space", "Banach space", "operator theory",
-         "variational", "Euler-Lagrange", "calculus of variations"],
-        "mathematics",
-        "Annals of Mathematics, Inventiones Mathematicae, JAMS",
-    ),
-    "engineering": (
-        ["robotics", "control system", "signal processing", "FPGA",
-         "embedded system", "VLSI", "antenna", "fluid dynamics", "CFD",
-         "finite element", "structural", "mechatronics", "autonomous"],
-        "engineering",
-        "IEEE Transactions, ASME journals, AIAA",
-    ),
-    "biology": (
-        ["genomics", "proteomics", "transcriptomics", "CRISPR",
-         "single-cell", "phylogenetic", "ecology", "neuroscience",
-         "bioinformatics", "sequencing", "gene expression", "epigenetic"],
-        "biology",
-        "Nature, Science, Cell, PNAS",
-    ),
+from researchclaw.domains.detector import DomainProfile, detect_domain as _detect_profile
+
+_TOP_VENUES_BY_PARENT: dict[str, str] = {
+    "ml": "NeurIPS, ICML, ICLR",
+    "physics": "Physical Review Letters, Nature Physics, JHEP",
+    "chemistry": "JACS, Nature Chemistry, Angewandte Chemie",
+    "economics": "AER, Econometrica, QJE, Review of Economic Studies",
+    "mathematics": "Annals of Mathematics, Inventiones Mathematicae, JAMS",
+    "engineering": "IEEE Transactions, ASME journals, AIAA",
+    "biology": "Nature, Science, Cell, PNAS",
+    "security": "IEEE S&P, USENIX Security, CCS",
+    "neuroscience": "Neuron, Nature Neuroscience, eLife",
+    "robotics": "ICRA, RSS, CoRL",
+    "generic": "ArXiv, workshop venues",
 }
+
+_DISPLAY_NAME_BY_PARENT: dict[str, str] = {
+    "ml": "machine learning",
+    "physics": "physics",
+    "chemistry": "chemistry",
+    "economics": "economics",
+    "mathematics": "mathematics",
+    "engineering": "engineering",
+    "biology": "biology",
+    "security": "security",
+    "neuroscience": "neuroscience",
+    "robotics": "robotics",
+    "generic": "generic research",
+}
+
+_COARSE_DOMAIN_ALIASES: tuple[tuple[str, str], ...] = (
+    ("ml_", "ml"),
+    ("physics_", "physics"),
+    ("chemistry_", "chemistry"),
+    ("biology_", "biology"),
+    ("economics_", "economics"),
+    ("mathematics_", "mathematics"),
+    ("security_", "security"),
+    ("neuroscience_", "neuroscience"),
+    ("robotics_", "robotics"),
+)
+
+
+def _coarse_domain_id(profile: DomainProfile) -> str:
+    """Map a detailed domain profile back to the legacy coarse ID space."""
+    domain_id = str(profile.domain_id).strip()
+    if not domain_id:
+        return "generic"
+
+    for prefix, coarse in _COARSE_DOMAIN_ALIASES:
+        if domain_id.startswith(prefix):
+            return coarse
+
+    parent = str(profile.parent_domain or "").strip().lower()
+    if parent:
+        return parent
+
+    return domain_id
+
+
+def _coarse_display_name(profile: DomainProfile, coarse_domain_id: str) -> str:
+    """Choose a stable human-facing display name for legacy call sites."""
+    parent = str(profile.parent_domain or "").strip()
+    if parent:
+        return _DISPLAY_NAME_BY_PARENT.get(parent, parent.replace("_", " "))
+    return _DISPLAY_NAME_BY_PARENT.get(
+        coarse_domain_id,
+        coarse_domain_id.replace("_", " "),
+    )
+
+
+def _top_venues_for_profile(profile: DomainProfile, coarse_domain_id: str) -> str:
+    """Best-effort venue context for old tuple-based consumers."""
+    parent = str(profile.parent_domain or "").strip().lower()
+    if parent in _TOP_VENUES_BY_PARENT:
+        return _TOP_VENUES_BY_PARENT[parent]
+    if coarse_domain_id in _TOP_VENUES_BY_PARENT:
+        return _TOP_VENUES_BY_PARENT[coarse_domain_id]
+    return _TOP_VENUES_BY_PARENT["generic"]
 
 
 def _detect_domain(topic: str, domains: tuple[str, ...] = ()) -> tuple[str, str, str]:
-    """Detect research domain from topic string and config domains.
+    """Detect domain via the canonical domain-profile system.
 
-    Returns ``(domain_id, display_name, top_venues)``.
-    Falls back to ``("ml", "machine learning", "NeurIPS, ICML, ICLR")``.
+    Returns the historical ``(domain_id, display_name, top_venues)`` tuple so
+    older pipeline stages can remain unchanged while sharing one detector.
     """
-    # If user explicitly specified domains, check them first
-    for d in domains:
-        d_lower = d.lower().strip()
-        for did, (kws, dname, venues) in _DOMAIN_KEYWORDS.items():
-            if d_lower in (did, dname) or any(k in d_lower for k in kws[:3]):
-                return did, dname, venues
-
-    # Auto-detect from topic text
-    topic_lower = topic.lower()
-    best_did, best_score = "ml", 0
-    # BUG-101: Explicit theoretical intent words boost non-empirical domain scores.
-    # Topics like "derive the mathematical formulation of X diffusion model"
-    # should classify as math, not ML, even if "diffusion model" is an ML keyword.
-    _theoretical_intent = any(
-        w in topic_lower
-        for w in ("derive", "prove", "mathematical formulation",
-                  "mathematical proof", "formal proof", "formalism")
+    domain_hints = ", ".join(
+        str(d).strip().replace("-", " ").replace("_", " ")
+        for d in domains
+        if str(d).strip()
     )
-    for did, (kws, dname, venues) in _DOMAIN_KEYWORDS.items():
-        score = sum(1 for k in kws if k.lower() in topic_lower)
-        # Boost non-empirical domains when theoretical intent is detected
-        if _theoretical_intent and did in ("mathematics", "physics", "economics"):
-            score += 1
-        if score > best_score:
-            best_score = score
-            best_did = did
-
-    did = best_did
-    _, dname, venues = _DOMAIN_KEYWORDS[did]
-    return did, dname, venues
+    hypotheses = (
+        f"Configured domains: {domain_hints}."
+        if domain_hints
+        else ""
+    )
+    profile = _detect_profile(topic=topic, hypotheses=hypotheses)
+    coarse_domain_id = _coarse_domain_id(profile)
+    return (
+        coarse_domain_id,
+        _coarse_display_name(profile, coarse_domain_id),
+        _top_venues_for_profile(profile, coarse_domain_id),
+    )
 
 
 def _is_ml_domain(domain_id: str) -> bool:
-    """Check if the detected domain is ML/AI."""
+    """Check if the detected legacy coarse domain is ML/AI."""
     return domain_id == "ml"

--- a/researchclaw/pipeline/stage_impls/_experiment_design.py
+++ b/researchclaw/pipeline/stage_impls/_experiment_design.py
@@ -13,7 +13,6 @@ import yaml
 from researchclaw.adapters import AdapterBundle
 from researchclaw.config import RCConfig
 from researchclaw.llm.client import LLMClient
-from researchclaw.pipeline._domain import _detect_domain
 from researchclaw.pipeline._helpers import (
     StageResult,
     _build_context_preamble,
@@ -275,14 +274,25 @@ def _execute_experiment_design(
     # BUG-40: Skip BenchmarkAgent for non-ML domains — it has no relevant
     # benchmarks for physics/chemistry/mathematics/etc. and would inject
     # wrong datasets (e.g., CIFAR-10 for PDE topics).
-    _ba_domain_id, _, _ = _detect_domain(
-        config.research.topic,
-        tuple(config.research.domains) if config.research.domains else (),
+    _ba_domain_profile = _domain_profile
+    if _ba_domain_profile is None:
+        try:
+            from researchclaw.domains.detector import detect_domain as _detect_domain_adv
+            _ba_domain_profile = _detect_domain_adv(
+                topic=config.research.topic,
+                hypotheses=hypotheses,
+            )
+        except Exception:  # noqa: BLE001
+            logger.debug("BenchmarkAgent domain detection unavailable", exc_info=True)
+    _ba_domain_id = (
+        _ba_domain_profile.domain_id
+        if _ba_domain_profile is not None
+        else "generic"
     )
-    _ba_domain_ok = _ba_domain_id == "ml"
+    _ba_domain_ok = _ba_domain_id.startswith("ml_")
     if not _ba_domain_ok:
         logger.info(
-            "BenchmarkAgent skipped: domain '%s' is not ML (topic: %s)",
+            "BenchmarkAgent skipped: domain profile '%s' is not an ML profile (topic: %s)",
             _ba_domain_id, config.research.topic[:80],
         )
     if (


### PR DESCRIPTION
## Summary
- route the legacy `researchclaw.pipeline._domain` helper through the newer `researchclaw.domains.detector` profile system
- make Stage 9's BenchmarkAgent gating reuse the same detected `DomainProfile` instead of re-running the old coarse detector
- keep the old tuple API for existing callers while removing split-brain behavior between old and new domain logic

## Why
AutoResearchClaw currently has two domain-detection paths in the pipeline:
- the newer profile-based detector used to write `stage-09/domain_profile.json`
- the older coarse `_detect_domain()` helper still used by some pipeline call sites, including the BenchmarkAgent gate in Stage 9

That split can lead to contradictory behavior inside the same run. In one recent repair workflow for an engineering-drawing circle-localization project, Stage 9 persisted a detailed domain profile while BenchmarkAgent still followed the coarse path and proceeded under a different detector path. The root issue was that the pipeline was not actually using one shared detector.

This PR makes the old helper a compatibility wrapper around the canonical profile detector, then updates Stage 9 to reuse the already-computed profile when deciding whether BenchmarkAgent should run.

## Changes
- replace the old keyword-based implementation in `researchclaw/pipeline/_domain.py` with a compatibility wrapper around `researchclaw.domains.detector`
- map detailed profile ids like `ml_vision` / `ml_tabular` back to the legacy coarse tuple interface for older call sites
- reuse the Stage 9 `DomainProfile` for BenchmarkAgent gating in `researchclaw/pipeline/stage_impls/_experiment_design.py`

## Validation
- `python -m compileall researchclaw/pipeline/_domain.py researchclaw/pipeline/stage_impls/_experiment_design.py`
- smoke check that legacy `_detect_domain(...)` now returns a coarse tuple derived from the same detector used by the profile system
