### PR TITLE
ci: add GitHub Actions workflow for automated testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Test (Python ${{ matrix.python-version }}, ${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ["3.11", "3.12", "3.13"]
+        include:
+          - os: windows-latest
+            python-version: "3.12"
+            # Some tests use Unix-only APIs (os.getuid, /etc/passwd paths, shebang checks).
+            # Track these failures for visibility but don't block the pipeline.
+            experimental: true
+
+    continue-on-error: ${{ matrix.experimental || false }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Cache pip packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-${{ matrix.python-version }}-
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Run tests
+        run: pytest tests/ -x -q --ignore=tests/e2e_real_llm.py --ignore=tests/e2e_docker_sandbox.py


### PR DESCRIPTION
  ## Summary

  I've been using ResearchClaw for my own literature review workflow and noticed that the repo currently has no CI pipeline — tests are only run locally via `pytest tests/`. This PR adds a GitHub Actions     
  workflow so that every push and PR to `main` is automatically validated.

  **What this adds:**

  - `.github/workflows/ci.yml` — runs the full test suite on push/PR to `main`
  - **Python matrix**: 3.11 / 3.12 / 3.13 on Ubuntu
  - **Windows**: Python 3.12 (marked `experimental` — see note below)
  - **pip caching** for faster CI runs
  - **Concurrency control**: cancels redundant runs on the same branch
  - **E2E exclusion**: `e2e_real_llm.py` and `e2e_docker_sandbox.py` are skipped since they require external services (API keys / Docker)

  ### Note on Windows

  Some existing tests use Unix-only APIs (`os.getuid()`, `/etc/passwd` paths, shebang checks), so the Windows job is set to `continue-on-error: true`. This provides visibility into Windows compatibility      
  without blocking PRs. Fixing those is a separate effort.

  ## Test plan

  - [x] Verified all 2450+ tests pass on Ubuntu locally
  - [x] Confirmed the 23 Windows-only failures are pre-existing (not introduced by this PR)
  - [x] E2E tests with API key guards (`test_anthropic.py`, `test_minimax_provider.py`) self-skip correctly in CI
