### PR TITLE
fix: --resume now reuses existing run directory

### DIFF
--- a/researchclaw/cli.py
+++ b/researchclaw/cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import json
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -47,6 +48,22 @@ def _generate_run_id(topic: str) -> str:
     return f"rc-{ts}-{topic_hash}"
 
 
+def _find_latest_run(artifacts_dir: str = "artifacts") -> Path | None:
+    """Find the most recent run directory that contains a checkpoint."""
+    base = Path(artifacts_dir)
+    if not base.is_dir():
+        return None
+    candidates = sorted(
+        (d for d in base.iterdir() if d.is_dir() and d.name.startswith("rc-")),
+        key=lambda d: d.stat().st_mtime,
+        reverse=True,
+    )
+    for d in candidates:
+        if (d / "checkpoint.json").exists():
+            return d
+    return None
+
+
 def cmd_run(args: argparse.Namespace) -> int:
     resolved = _resolve_config_or_exit(args)
     if resolved is None:
@@ -82,28 +99,54 @@ def cmd_run(args: argparse.Namespace) -> int:
             print(f"FAILED — {msg}", file=sys.stderr)
             return 1
 
-    run_id = _generate_run_id(config.research.topic)
-    run_dir = Path(output or f"artifacts/{run_id}")
-    run_dir.mkdir(parents=True, exist_ok=True)
+    from researchclaw.pipeline.runner import execute_pipeline, read_checkpoint
+    from researchclaw.pipeline.stages import Stage
+
+    # --- Resolve run directory and start stage ---
+    from_stage = Stage.TOPIC_INIT
+
+    if resume:
+        # Resolve existing run directory
+        if output:
+            run_dir = Path(output)
+        else:
+            run_dir = _find_latest_run()  # type: ignore[assignment]
+            if run_dir is None:
+                print(
+                    "No resumable run found in artifacts/. "
+                    "Use --output to specify a run directory.",
+                    file=sys.stderr,
+                )
+                return 1
+
+        if not run_dir.exists():
+            print(f"Run directory not found: {run_dir}", file=sys.stderr)
+            return 1
+
+        resumed = read_checkpoint(run_dir)
+        if resumed is None:
+            print(f"No checkpoint found in {run_dir}", file=sys.stderr)
+            return 1
+
+        from_stage = resumed
+        # Read run_id from checkpoint instead of generating a new one
+        cp_data = json.loads(
+            (run_dir / "checkpoint.json").read_text(encoding="utf-8")
+        )
+        run_id = cp_data.get("run_id", run_dir.name)
+        print(f"Resuming from checkpoint: Stage {int(from_stage)}: {from_stage.name}")
+    else:
+        if from_stage_name:
+            from_stage = Stage[from_stage_name.upper()]
+        run_id = _generate_run_id(config.research.topic)
+        run_dir = Path(output or f"artifacts/{run_id}")
+        run_dir.mkdir(parents=True, exist_ok=True)
 
     if config.knowledge_base.root:
         kb_root_path = Path(config.knowledge_base.root)
         kb_root_path.mkdir(parents=True, exist_ok=True)
 
     adapters = AdapterBundle()
-
-    from researchclaw.pipeline.runner import execute_pipeline, read_checkpoint
-    from researchclaw.pipeline.stages import Stage
-
-    # --- Determine start stage ---
-    from_stage = Stage.TOPIC_INIT
-    if from_stage_name:
-        from_stage = Stage[from_stage_name.upper()]
-    elif resume:
-        resumed = read_checkpoint(run_dir)
-        if resumed is not None:
-            from_stage = resumed
-            print(f"Resuming from checkpoint: Stage {int(from_stage)}: {from_stage.name}")
 
     print(f"ResearchClaw v0.1.0 — Starting pipeline")
     print(f"  Run ID:  {run_id}")

--- a/researchclaw/config.py
+++ b/researchclaw/config.py
@@ -121,7 +121,7 @@ class AcpConfig:
     cwd: str = "."
     acpx_command: str = ""
     session_name: str = "researchclaw"
-    timeout_sec: int = 600
+    timeout_sec: int = 1200
 
 
 @dataclass(frozen=True)

--- a/researchclaw/llm/acp_client.py
+++ b/researchclaw/llm/acp_client.py
@@ -36,7 +36,7 @@ class ACPConfig:
     cwd: str = "."
     acpx_command: str = ""  # auto-detect if empty
     session_name: str = "researchclaw"
-    timeout_sec: int = 600  # per-prompt timeout
+    timeout_sec: int = 1200  # per-prompt timeout (code generation needs >600s)
 
 
 def _find_acpx() -> str | None:

--- a/tests/test_rc_cli.py
+++ b/tests/test_rc_cli.py
@@ -299,3 +299,70 @@ def test_main_dispatches_init(monkeypatch: pytest.MonkeyPatch) -> None:
     code = rc_cli.main(["init", "--force"])
     assert code == 0
     assert captured["args"].force is True
+
+
+# --- _find_latest_run tests ---
+
+
+def _make_checkpoint(run_dir: Path, stage: int = 4, run_id: str = "test") -> None:
+    """Write a minimal checkpoint.json."""
+    import json
+
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / "checkpoint.json").write_text(
+        json.dumps({"last_completed_stage": stage, "run_id": run_id}),
+        encoding="utf-8",
+    )
+
+
+def test_find_latest_run_returns_newest(tmp_path: Path) -> None:
+    import time
+
+    old_run = tmp_path / "rc-20260101-000000-aaaaaa"
+    _make_checkpoint(old_run, stage=3, run_id="old")
+    time.sleep(0.05)  # ensure different mtime
+    new_run = tmp_path / "rc-20260102-000000-bbbbbb"
+    _make_checkpoint(new_run, stage=6, run_id="new")
+
+    result = rc_cli._find_latest_run(str(tmp_path))
+    assert result == new_run
+
+
+def test_find_latest_run_skips_dirs_without_checkpoint(tmp_path: Path) -> None:
+    no_cp = tmp_path / "rc-20260103-000000-cccccc"
+    no_cp.mkdir()
+    with_cp = tmp_path / "rc-20260101-000000-aaaaaa"
+    _make_checkpoint(with_cp, stage=3, run_id="ok")
+
+    result = rc_cli._find_latest_run(str(tmp_path))
+    assert result == with_cp
+
+
+def test_find_latest_run_no_runs_returns_none(tmp_path: Path) -> None:
+    assert rc_cli._find_latest_run(str(tmp_path)) is None
+
+
+def test_find_latest_run_missing_dir_returns_none() -> None:
+    assert rc_cli._find_latest_run("/nonexistent/path") is None
+
+
+def test_cmd_run_resume_no_run_returns_one(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    config_path = tmp_path / "config.yaml"
+    _write_valid_config(config_path)
+    # Point _find_latest_run at an empty directory
+    monkeypatch.setattr(rc_cli, "_find_latest_run", lambda artifacts_dir="artifacts": None)
+    args = argparse.Namespace(
+        config=str(config_path),
+        topic=None,
+        output=None,
+        from_stage=None,
+        auto_approve=False,
+        skip_preflight=True,
+        resume=True,
+        skip_noncritical_stage=False,
+    )
+    code = rc_cli.cmd_run(args)
+    assert code == 1
+    assert "No resumable run found" in capsys.readouterr().err


### PR DESCRIPTION
## Summary
- **Fixed `--resume` creating a new run directory** instead of reusing the existing one. Previously, `cmd_run()` always generated a fresh `run_id`/`run_dir` before checking checkpoints, so `--resume` without `--output` would always start from scratch.
- **Added `_find_latest_run()` helper** that auto-detects the most recent run in `artifacts/` with a `checkpoint.json`, reads the original `run_id` from it, and resumes from the correct stage.
- **Increased ACP timeout from 600s to 1200s** to prevent `CODE_GENERATION` stage timeouts on complex experiment prompts.

## Test plan
- [x] 5 new unit tests for `_find_latest_run()` and resume error handling
- [x] All 1264 existing tests pass (1 pre-existing failure in `test_search_arxiv_mock` unrelated to this change)
- [ ] Manual: `researchclaw run --resume` finds latest run and resumes from checkpoint
- [ ] Manual: `researchclaw run --resume` with no existing runs prints clear error

🤖 Generated with [Claude Code](https://claude.com/claude-code)