### PR TITLE
fix: resolve 15 Windows test failures across 8 test files

### DIFF
--- a/tests/test_entry_point_validation.py
+++ b/tests/test_entry_point_validation.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import os
+import sys
 from pathlib import Path
 from unittest.mock import patch
 
@@ -10,6 +12,8 @@ from researchclaw.experiment.sandbox import (
     validate_entry_point,
     validate_entry_point_resolved,
 )
+
+import pytest
 
 
 # ── Unit tests: validate_entry_point (syntax) ─────────────────────────
@@ -75,6 +79,10 @@ class TestValidateEntryPointResolved:
         (tmp_path / "main.py").write_text("pass")
         assert validate_entry_point_resolved(tmp_path, "main.py") is None
 
+    @pytest.mark.skipif(
+        sys.platform == "win32" and not os.environ.get("CI"),
+        reason="Creating symlinks on Windows requires admin privileges or Developer Mode",
+    )
     def test_symlink_escape_rejected(self, tmp_path: Path) -> None:
         """A symlink pointing outside staging must be caught."""
         escape_target = tmp_path / "outside" / "secret.py"

--- a/tests/test_figure_agent.py
+++ b/tests/test_figure_agent.py
@@ -415,8 +415,8 @@ class TestRendererAgent:
         # Use a script that creates a valid PNG without matplotlib
         # (creates a minimal 1x1 PNG file directly)
         script = textwrap.dedent("""\
-            import struct, zlib
-            output_path = "{output_dir}/fig_test.png"
+            import struct, zlib, os
+            output_path = os.path.join(r"{output_dir}", "fig_test.png")
             # Minimal valid PNG: 1x1 white pixel
             def write_png(path):
                 sig = b'\\x89PNG\\r\\n\\x1a\\n'

--- a/tests/test_rc_cli.py
+++ b/tests/test_rc_cli.py
@@ -253,7 +253,7 @@ def test_resolve_config_returns_none_when_missing(
 def test_resolve_config_explicit_path_no_search() -> None:
     result = resolve_config_path("/some/explicit/path.yaml")
     assert result is not None
-    assert str(result) == "/some/explicit/path.yaml"
+    assert result == Path("/some/explicit/path.yaml")
 
 
 # --- cmd_init tests ---
@@ -289,7 +289,7 @@ def test_cmd_init_creates_config(
     assert code == 0
     created = tmp_path / "config.arc.yaml"
     assert created.exists()
-    content = created.read_text()
+    content = created.read_text(encoding="utf-8")
     assert 'provider: "openai"' in content
     assert "Created config.arc.yaml" in capsys.readouterr().out
 
@@ -317,7 +317,7 @@ def test_cmd_init_force_overwrites(
     args = argparse.Namespace(force=True)
     code = rc_cli.cmd_init(args)
     assert code == 0
-    assert (tmp_path / "config.arc.yaml").read_text() != "old\n"
+    assert (tmp_path / "config.arc.yaml").read_text(encoding="utf-8") != "old\n"
 
 
 def test_cmd_run_missing_config_shows_init_hint(

--- a/tests/test_rc_docker_sandbox.py
+++ b/tests/test_rc_docker_sandbox.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import subprocess
+import sys
 import threading
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -51,8 +52,9 @@ def test_build_run_command_network_none(tmp_path: Path):
     assert "--memory=8192m" in cmd
     assert "--shm-size=2048m" in cmd
     assert cmd[-1] == "main.py"
-    # Should contain --user (non-root)
-    assert "--user" in cmd
+    # Should contain --user on POSIX (non-root); skipped on Windows
+    if sys.platform != "win32":
+        assert "--user" in cmd
 
 
 def test_build_run_command_setup_only(tmp_path: Path):
@@ -74,8 +76,9 @@ def test_build_run_command_setup_only(tmp_path: Path):
     # Should NOT have --network none (needs network for setup)
     network_indices = [i for i, x in enumerate(cmd) if x == "--network"]
     assert len(network_indices) == 0
-    # Should have --user (runs as host user so experiment can write results.json)
-    assert "--user" in cmd
+    # Should have --user on POSIX (runs as host user so experiment can write results.json)
+    if sys.platform != "win32":
+        assert "--user" in cmd
 
 
 def test_build_run_command_full_network(tmp_path: Path):
@@ -90,8 +93,9 @@ def test_build_run_command_full_network(tmp_path: Path):
     # No --network none
     network_indices = [i for i, x in enumerate(cmd) if x == "--network"]
     assert len(network_indices) == 0
-    # Should have --user (non-root)
-    assert "--user" in cmd
+    # Should have --user on POSIX (non-root)
+    if sys.platform != "win32":
+        assert "--user" in cmd
 
 
 def test_build_run_command_no_gpu(tmp_path: Path):

--- a/tests/test_rc_executor.py
+++ b/tests/test_rc_executor.py
@@ -3355,7 +3355,7 @@ class TestValidateDraftQuality:
         rc_executor._validate_draft_quality(draft, stage_dir=tmp_path)
         assert (tmp_path / "draft_quality.json").exists()
         data = json.loads(
-            (tmp_path / "draft_quality.json").read_text()
+            (tmp_path / "draft_quality.json").read_text(encoding="utf-8")
         )
         assert "section_analysis" in data
         assert "overall_warnings" in data

--- a/tests/test_rc_sentinel.py
+++ b/tests/test_rc_sentinel.py
@@ -117,7 +117,7 @@ class TestSentinelScript:
 
     def test_sentinel_script_has_shebang(self) -> None:
         script = Path(__file__).parent.parent / "sentinel.sh"
-        first_line = script.read_text().splitlines()[0]
+        first_line = script.read_text(encoding="utf-8").splitlines()[0]
         assert first_line.startswith("#!/")
 
     def test_sentinel_prints_usage_on_no_args(self) -> None:

--- a/tests/test_rc_templates.py
+++ b/tests/test_rc_templates.py
@@ -570,7 +570,7 @@ class TestExportConfig:
         import yaml
         from pathlib import Path
 
-        data = yaml.safe_load(Path("config.researchclaw.example.yaml").read_text())
+        data = yaml.safe_load(Path("config.researchclaw.example.yaml").read_text(encoding="utf-8"))
         data["export"] = {
             "target_conference": "icml_2025",
             "authors": "Test Author",
@@ -595,7 +595,7 @@ class TestHitlStageValidation:
         import yaml
         from pathlib import Path
 
-        data = yaml.safe_load(Path("config.researchclaw.example.yaml").read_text())
+        data = yaml.safe_load(Path("config.researchclaw.example.yaml").read_text(encoding="utf-8"))
         data.setdefault("security", {})["hitl_required_stages"] = [1, 22, 23]
         result = validate_config(data, check_paths=False)
         assert result.ok, f"Errors: {result.errors}"
@@ -622,7 +622,7 @@ class TestHitlStageValidation:
         import yaml
         from pathlib import Path
 
-        data = yaml.safe_load(Path("config.researchclaw.example.yaml").read_text())
+        data = yaml.safe_load(Path("config.researchclaw.example.yaml").read_text(encoding="utf-8"))
         data.setdefault("security", {})["hitl_required_stages"] = [24]
         result = validate_config(data, check_paths=False)
         assert not result.ok

--- a/tests/test_universal_codegen_integration.py
+++ b/tests/test_universal_codegen_integration.py
@@ -364,7 +364,7 @@ class TestDockerProfileMapping:
         if not profiles_path.exists():
             pytest.skip("docker_profiles.yaml not found")
 
-        with profiles_path.open() as f:
+        with profiles_path.open(encoding="utf-8") as f:
             docker_config = yaml.safe_load(f)
 
         domain_map = docker_config.get("domain_map", {})
@@ -384,7 +384,7 @@ class TestDockerProfileMapping:
         if not profiles_path.exists():
             pytest.skip("docker_profiles.yaml not found")
 
-        with profiles_path.open() as f:
+        with profiles_path.open(encoding="utf-8") as f:
             docker_config = yaml.safe_load(f)
 
         domain_map = docker_config.get("domain_map", {})


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                    

  Following up on the CI workflow added in #176, the Windows job revealed 18 test failures. This PR fixes 15 of them across 8 test files — all changes are in test code only, no production code modified.      

  ### Root causes addressed

  | Category | Tests fixed | Fix |
  |----------|------------|-----|
  | **UTF-8 encoding** | 9 | Add `encoding="utf-8"` to `.read_text()` / `.open()` — Windows defaults to system locale (GBK, Shift-JIS, CP1252, etc.) which can't decode UTF-8 files |
  | **Docker `--user` flag** | 3 | Source correctly skips `--user` on Windows (`os.getuid` is POSIX-only); update assertions to match |
  | **Path separator** | 1 | Compare as `Path` objects instead of string literals (`\` vs `/`) |
  | **Backslash in generated scripts** | 1 | Use `os.path.join(r"...", ...)` to avoid `\U` unicode escape errors |
  | **Symlink privilege** | 1 | Skip on Windows where symlinks require admin or Developer Mode |


  ### Not addressed (upstream issue)
The remaining 3 failures (test_skills_library) are an upstream count mismatch (16 SKILL.md files on disk vs 19 asserted) and fail on all platforms — not addressed here.