### PR TITLE
Add researchclaw skill metadata

### DIFF
--- a/.claude/skills/researchclaw/SKILL.md
+++ b/.claude/skills/researchclaw/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: researchclaw
+description: Run the ResearchClaw autonomous research pipeline from a topic, config, and output directory.
+---
+
 # ResearchClaw — Autonomous Research Pipeline Skill
 
 ## Description


### PR DESCRIPTION
Skill metadata was missing in `.claude/skills/researchclaw/SKILL.md`