### PR TITLE
fix: stage ACP prompt files inside workspace

### DIFF
--- a/researchclaw/llm/acp_client.py
+++ b/researchclaw/llm/acp_client.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import atexit
 import logging
 import os
+from pathlib import Path
 import re
 import shutil
 import subprocess
@@ -373,15 +374,18 @@ class ACPClient:
 
     def _send_prompt_via_file(self, acpx: str, prompt: str) -> str:
         """Write prompt to a temp file, ask the agent to read and respond."""
+        prompt_dir = Path(self._abs_cwd()) / ".researchclaw" / "acp_prompts"
+        prompt_dir.mkdir(parents=True, exist_ok=True)
         fd, prompt_path = tempfile.mkstemp(
-            suffix=".md", prefix="rc_prompt_",
+            suffix=".md", prefix="rc_prompt_", dir=str(prompt_dir),
         )
         try:
             with os.fdopen(fd, "w", encoding="utf-8") as f:
                 f.write(prompt)
 
+            prompt_ref = os.path.relpath(prompt_path, self._abs_cwd())
             short_prompt = (
-                f"Read the file at {prompt_path} in its entirety. "
+                f"Read the file at {prompt_ref} in its entirety. "
                 f"Follow ALL instructions contained in that file and "
                 f"respond exactly as requested. Do NOT summarize, "
                 f"just produce the requested output."
@@ -401,7 +405,7 @@ class ACPClient:
                 ) from exc
 
             if result.returncode != 0:
-                stderr = (result.stderr or "").strip()
+                stderr = self._format_failure_output(result)
                 raise RuntimeError(
                     f"ACP prompt failed (exit {result.returncode}): {stderr}"
                 )
@@ -412,6 +416,25 @@ class ACPClient:
                 os.unlink(prompt_path)
             except OSError:
                 pass
+
+    @staticmethod
+    def _format_failure_output(result: subprocess.CompletedProcess[str]) -> str:
+        """Return the most useful available subprocess error text.
+
+        ``acpx`` sometimes emits only session metadata to stderr while the
+        actionable failure details are written to stdout by the underlying
+        agent. Include both streams when needed so retries and debugging have
+        the real error context.
+        """
+        stderr = (result.stderr or "").strip()
+        stdout = (result.stdout or "").strip()
+        if stderr and stdout:
+            return f"{stderr}\n[stdout]\n{stdout}"
+        if stderr:
+            return stderr
+        if stdout:
+            return stdout
+        return "no output"
 
     @staticmethod
     def _extract_response(raw_output: str | None) -> str:

--- a/tests/test_rc_llm.py
+++ b/tests/test_rc_llm.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 import urllib.error
 import urllib.request
 from http.client import HTTPMessage
@@ -423,6 +424,69 @@ def test_acp_command_line_too_long_falls_back_to_file_transport():
     result = client._send_prompt("short prompt")
     assert result == "ok-from-file"
     assert call_count == 1
+
+
+def test_acp_file_transport_stages_prompt_inside_workspace(tmp_path: Path):
+    from researchclaw.llm.acp_client import ACPClient, ACPConfig
+
+    client = ACPClient(ACPConfig(agent="codex", cwd=str(tmp_path)))
+    client._acpx = "acpx"
+    client._session_ready = True
+
+    captured: dict[str, object] = {}
+
+    def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        captured["cmd"] = cmd
+        prompt_dir = tmp_path / ".researchclaw" / "acp_prompts"
+        assert prompt_dir.is_dir()
+        staged = list(prompt_dir.glob("rc_prompt_*.md"))
+        assert len(staged) == 1
+        prompt_file = staged[0]
+        captured["prompt_file"] = prompt_file
+        assert prompt_file.read_text(encoding="utf-8") == "long prompt body"
+        prompt_text = cmd[-1]
+        assert isinstance(prompt_text, str)
+        assert str(prompt_file) not in prompt_text
+        assert ".researchclaw/acp_prompts/" in prompt_text
+
+        class _Result:
+            returncode = 0
+            stdout = "response"
+            stderr = ""
+
+        return _Result()
+
+    import subprocess as _subprocess
+    from unittest import mock
+
+    with mock.patch.object(_subprocess, "run", side_effect=fake_run):
+        result = client._send_prompt_via_file("acpx", "long prompt body")
+
+    assert result == "response"
+    prompt_file = captured["prompt_file"]
+    assert isinstance(prompt_file, Path)
+    assert not prompt_file.exists()
+
+
+def test_acp_file_transport_failure_includes_stdout_context(tmp_path: Path):
+    from researchclaw.llm.acp_client import ACPClient, ACPConfig
+
+    client = ACPClient(ACPConfig(agent="codex", cwd=str(tmp_path)))
+    client._acpx = "acpx"
+    client._session_ready = True
+
+    class _Result:
+        returncode = 1
+        stdout = "codex error: file access denied"
+        stderr = "[acpx] session connected"
+
+    import subprocess as _subprocess
+    from unittest import mock
+    import pytest
+
+    with mock.patch.object(_subprocess, "run", return_value=_Result()):
+        with pytest.raises(RuntimeError, match="file access denied"):
+            client._send_prompt_via_file("acpx", "long prompt body")
 
 
 def test_acp_windows_cmd_wrapper_uses_lower_inline_limit(monkeypatch: pytest.MonkeyPatch):


### PR DESCRIPTION
## Summary
- stage ACP file-transport prompts inside the workspace instead of the system temp directory
- pass a workspace-relative prompt path to the ACP agent
- include stdout context in ACP prompt failures when stderr only contains session metadata
- add regression coverage for workspace file transport and ACP failure formatting

## Validation
- `.venv/bin/python3 -m pytest`
- Result: `2748 passed, 26 skipped, 1 warning`

## Notes
- This PR keeps a single concern: hardening ACP/Codex prompt file transport for workspace-restricted agents.
