### PR TITLE
fix: wire LLM client into HITL collaboration chat loop

### DIFF
--- a/researchclaw/pipeline/executor.py
+++ b/researchclaw/pipeline/executor.py
@@ -242,7 +242,8 @@ def _run_hitl_pre_stage(
 
 
 def _run_hitl_post_stage(
-    stage: Stage, result: StageResult, run_dir: Path, adapters: AdapterBundle
+    stage: Stage, result: StageResult, run_dir: Path, adapters: AdapterBundle,
+    config: RCConfig | None = None,
 ) -> StageResult:
     """HITL post-stage hook: pause after execution for review.
 
@@ -406,7 +407,7 @@ def _run_hitl_post_stage(
         session.enter_collaboration(stage_num, stage.name)
         try:
             result = _run_collaboration_loop(
-                stage, result, run_dir, adapters, session
+                stage, result, run_dir, adapters, session, config=config
             )
         except Exception as _collab_exc:
             logger.warning("Collaboration failed: %s", _collab_exc)
@@ -429,6 +430,8 @@ def _run_collaboration_loop(
     run_dir: Path,
     adapters: AdapterBundle,
     session: Any,
+    *,
+    config: RCConfig | None = None,
 ) -> StageResult:
     """Run an interactive collaboration loop for a stage.
 
@@ -448,13 +451,13 @@ def _run_collaboration_loop(
     llm_client = None
     topic = ""
     try:
-        from researchclaw.llm.client import LLMClient
-        # LLM client is created fresh for collaboration
-        llm_client = None  # Will use chat without LLM if unavailable
-        topic = getattr(
-            getattr(adapters, "_config", None), "research", None
-        )
-        topic = topic.topic if topic else "Research"
+        if config is not None:
+            from researchclaw.llm import create_llm_client
+            llm_client = create_llm_client(config)
+            topic_obj = getattr(config, "research", None)
+            topic = topic_obj.topic if topic_obj else "Research"
+        else:
+            topic = "Research"
     except Exception:
         topic = "Research"
 
@@ -735,6 +738,6 @@ def execute_stage(
         pass
 
     # --- HITL post-stage hook ---
-    result = _run_hitl_post_stage(stage, result, run_dir, adapters)
+    result = _run_hitl_post_stage(stage, result, run_dir, adapters, config=config)
 
     return result


### PR DESCRIPTION
## Summary

The HITL (Human-in-the-Loop) collaborative chat mode (`[c]` action during post-stage review) never initializes an LLM client, making it impossible for the AI to respond during collaboration. Users always see:

```
AI > [LLM not available for chat — your input is recorded]
```

**Root cause:** `_run_collaboration_loop()` in `executor.py` hardcodes `llm_client = None` on [line 453](https://github.com/aiming-lab/AutoResearchClaw/blob/08d9d2c/researchclaw/pipeline/executor.py#L453) despite having the import ready. The `RCConfig` (which holds LLM provider settings) is available in the calling `execute_stage()` function but was never threaded through to the collaboration loop.

This also means users cannot use the collaboration interface to re-trigger failed stages (e.g., `PROBLEM_DECOMPOSE` producing empty output), since the AI side of the conversation is completely non-functional.

## Changes

- Thread `config: RCConfig` from `execute_stage()` → `_run_hitl_post_stage()` → `_run_collaboration_loop()` (keyword-only, optional, backward-compatible)
- Replace the hardcoded `llm_client = None` with `create_llm_client(config)` using the same factory used by `execute_stage()` itself
- Remove the unused `from researchclaw.llm.client import LLMClient` import that was a leftover from the incomplete implementation

## Test plan

- [x] Run pipeline with `--mode co-pilot`, trigger collaborative chat (`[c]`) on any stage — AI should now respond
- [x] Verify non-HITL mode (`--mode full-auto`) is unaffected (the new `config` param defaults to `None`)
- [ ] Verify LLM creation failure is handled gracefully (falls back to `"Research"` topic, `llm_client` stays `None`)