### PR TITLE
fix: ACP prompt transport — cold-start greeting, Windows truncation, and tool-use prevention

### DIFF
--- a/researchclaw/llm/acp_client.py
+++ b/researchclaw/llm/acp_client.py
@@ -16,7 +16,7 @@ import re
 import shutil
 import subprocess
 import sys
-import tempfile
+
 import weakref
 from dataclasses import dataclass
 from typing import Any
@@ -232,13 +232,22 @@ class ACPClient:
                     f"Failed to create ACP session: {result.stderr.strip()}"
                 )
 
-        # Warm-up: consume the agent's cold-start greeting so it does not
-        # pollute the first real prompt's response.
+        # Warm-up: consume the agent's cold-start greeting and set
+        # text-only mode so it does not use tools or pollute responses.
+        _warmup = (
+            "You are being used as a text-generation backend for a "
+            "research pipeline. For ALL subsequent prompts in this "
+            "session, you MUST respond with text output ONLY. "
+            "Do NOT use any tools — no file reads, no file writes, "
+            "no searches, no terminal commands. Generate your "
+            "complete response as plain text. Confirm with: OK"
+        )
         try:
             subprocess.run(
-                [acpx, "--approve-all", "--ttl", "0", "--cwd", self._abs_cwd(),
+                [acpx, "--approve-all", "--max-turns", "1",
+                 "--ttl", "0", "--cwd", self._abs_cwd(),
                  self.config.agent, "-s", self.config.session_name,
-                 "Respond with OK"],
+                 _warmup],
                 capture_output=True, text=True, encoding="utf-8",
                 errors="replace", timeout=60,
             )
@@ -288,9 +297,10 @@ class ACPClient:
     def _send_prompt(self, prompt: str) -> str:
         """Send a prompt via acpx and return the response text.
 
-        For large prompts that would exceed the OS argument-length limit
-        (``E2BIG``), the prompt is written to a temp file and the agent
-        is asked to read it.
+        On Windows, multi-line prompts passed as CLI arguments are mangled
+        by ``.cmd`` wrappers (newlines truncated by ``cmd.exe``), so we
+        always use file-based transport there.  On other platforms, inline
+        CLI arguments are used when the prompt is small enough.
 
         If the session has died (common after long-running stages), retries
         up to ``_MAX_RECONNECT_ATTEMPTS`` times with automatic reconnection.
@@ -304,14 +314,18 @@ class ACPClient:
         if not acpx:
             raise RuntimeError("acpx not found")
 
+        # On Windows, .cmd/.bat wrappers route through cmd.exe which
+        # silently truncates multi-line CLI arguments.  Always use file
+        # transport to avoid mangled prompts.
         prompt_bytes = len(prompt.encode("utf-8"))
         prompt_limit = self._cli_prompt_limit(acpx)
-        use_file = prompt_bytes > prompt_limit
+        use_file = prompt_bytes > prompt_limit or (
+            sys.platform == "win32" and "\n" in prompt
+        )
         if use_file:
             logger.info(
-                "Prompt too large for CLI arg (%d bytes > %d). Using temp file.",
+                "Using file-based prompt transport (%d bytes).",
                 prompt_bytes,
-                prompt_limit,
             )
 
         last_exc: RuntimeError | None = None
@@ -374,7 +388,8 @@ class ACPClient:
         """Send prompt as a CLI argument (original path)."""
         try:
             result = subprocess.run(
-                [acpx, "--approve-all", "--ttl", "0", "--cwd", self._abs_cwd(),
+                [acpx, "--approve-all", "--max-turns", "1",
+                 "--ttl", "0", "--cwd", self._abs_cwd(),
                  self.config.agent, "-s", self.config.session_name,
                  prompt],
                 capture_output=True, text=True, encoding="utf-8",
@@ -392,46 +407,29 @@ class ACPClient:
         return self._extract_response(result.stdout)
 
     def _send_prompt_via_file(self, acpx: str, prompt: str) -> str:
-        """Write prompt to a temp file, ask the agent to read and respond."""
-        fd, prompt_path = tempfile.mkstemp(
-            suffix=".md", prefix="rc_prompt_",
-        )
+        """Send prompt via stdin pipe (``-f -``) to avoid CLI arg limits."""
         try:
-            with os.fdopen(fd, "w", encoding="utf-8") as f:
-                f.write(prompt)
+            result = subprocess.run(
+                [acpx, "--approve-all", "--max-turns", "1",
+                 "--ttl", "0", "--cwd", self._abs_cwd(),
+                 self.config.agent, "-s", self.config.session_name,
+                 "-f", "-"],
+                input=prompt,
+                capture_output=True, text=True, encoding="utf-8",
+                errors="replace", timeout=self.config.timeout_sec,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise RuntimeError(
+                f"ACP prompt timed out after {self.config.timeout_sec}s"
+            ) from exc
 
-            short_prompt = (
-                f"Read the file at {prompt_path} in its entirety. "
-                f"Follow ALL instructions contained in that file and "
-                f"respond exactly as requested. Do NOT summarize, "
-                f"just produce the requested output."
+        if result.returncode != 0:
+            stderr = (result.stderr or "").strip()
+            raise RuntimeError(
+                f"ACP prompt failed (exit {result.returncode}): {stderr}"
             )
 
-            try:
-                result = subprocess.run(
-                    [acpx, "--approve-all", "--ttl", "0", "--cwd", self._abs_cwd(),
-                     self.config.agent, "-s", self.config.session_name,
-                     short_prompt],
-                    capture_output=True, text=True, encoding="utf-8",
-                    errors="replace", timeout=self.config.timeout_sec,
-                )
-            except subprocess.TimeoutExpired as exc:
-                raise RuntimeError(
-                    f"ACP prompt timed out after {self.config.timeout_sec}s"
-                ) from exc
-
-            if result.returncode != 0:
-                stderr = (result.stderr or "").strip()
-                raise RuntimeError(
-                    f"ACP prompt failed (exit {result.returncode}): {stderr}"
-                )
-
-            return self._extract_response(result.stdout)
-        finally:
-            try:
-                os.unlink(prompt_path)
-            except OSError:
-                pass
+        return self._extract_response(result.stdout)
 
     @staticmethod
     def _extract_response(raw_output: str | None) -> str:


### PR DESCRIPTION
## Summary

The ACP client has three issues that prevent it from working on Windows, causing all pipeline stages to produce garbage output:

1. **Cold-start greeting swallows first prompt** — When an acpx session is created or reconnected, Claude Code emits a greeting as the response to the first real prompt, so goal.md contains the greeting instead of research goals.

2. **Windows .cmd wrappers truncate multi-line CLI arguments** — cmd.exe silently drops everything after the first newline, so the research prompt arrives as just `[System]` and the agent responds with `OK`.

3. **Agent enters agentic mode** — With `--approve-all`, Claude Code uses tools (file reads, writes, sub-agents) instead of generating text, causing stages to hang for 20+ minutes.

**Reproduction:**
```
researchclaw run --topic "Human-AI Collaborative Systems" --mode co-pilot
```
Stage 1 goal.md contains greeting text; Stage 2 problem_tree.md is empty/fails.

## Changes

All in `researchclaw/llm/acp_client.py`:

- **Warm-up instructs text-only mode**: After session creation, sends an instruction telling the agent to respond as a text-generation backend with no tool use. Consumes the greeting and prevents agentic behavior.
- **Stdin pipe replaces temp-file transport**: Uses `acpx -f -` with `subprocess.run(input=...)` instead of writing to a temp file and asking the agent to "Read the file at X".
- **Windows always uses stdin pipe**: Detects multi-line prompts on Windows and routes through stdin pipe instead of CLI args to avoid .cmd truncation.
- Remove unused `tempfile` import.

## Verified locally

| Test | Before | After |
|------|--------|-------|
| Stage 1 (TOPIC_INIT) | goal.md = agent greeting (38 chars) | 7754 chars of SMART research goals |
| Stage 2 (PROBLEM_DECOMPOSE) | empty problem_tree.md, FAILED | 5622 chars of decomposition |
| Tool use | Agent reads/writes files, spawns sub-agents | Pure text generation, no tools |
| Session persistence | N/A | Context preserved across stages |

## Test plan

- [x] Fresh session: Stage 1 produces proper research goals (no greeting)
- [x] Stage 2 on same session produces problem decomposition (no empty output)
- [x] No tool use in responses (pure text)
- [x] strip_thinking=True removes thinking tags from output
- [x] Full 23-stage pipeline run
- [ ] Linux/macOS still works (inline CLI args used when no newlines)