### PR TITLE
feat: add CLI chat API test command with JSON output

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,27 @@ researchclaw run --config config.arc.yaml --topic "Your research idea" --auto-ap
 
 Output → `artifacts/rc-YYYYMMDD-HHMMSS-<hash>/deliverables/` — compile-ready LaTeX, BibTeX, experiment code, charts.
 
+### Quick API Chat Check
+
+Use the built-in CLI chat utility to verify your LLM endpoint before running the full pipeline:
+
+```bash
+# Connectivity check (human-readable)
+researchclaw chat --config config.arc.yaml --check
+
+# Connectivity check (JSON for scripts/CI)
+researchclaw chat --config config.arc.yaml --check --json
+
+# One-shot chat test
+researchclaw chat --config config.arc.yaml -m "Hello, please reply with pong."
+
+# One-shot chat test (JSON output)
+researchclaw chat --config config.arc.yaml -m "Hello, please reply with pong." --json
+
+# Interactive chat mode (type /exit to quit)
+researchclaw chat --config config.arc.yaml
+```
+
 <details>
 <summary>📝 Minimum required config</summary>
 

--- a/docs/README_CN.md
+++ b/docs/README_CN.md
@@ -139,6 +139,27 @@ researchclaw run --config config.arc.yaml --topic "Your research idea" --auto-ap
 
 输出 → `artifacts/rc-YYYYMMDD-HHMMSS-<hash>/deliverables/` — 可编译的 LaTeX、BibTeX、实验代码、图表。
 
+### 快速 API 对话检测
+
+在跑完整流水线前，可先用内置 chat 命令验证 LLM 接口是否可用：
+
+```bash
+# 连通性检测（人类可读）
+researchclaw chat --config config.arc.yaml --check
+
+# 连通性检测（脚本/CI 友好的 JSON 输出）
+researchclaw chat --config config.arc.yaml --check --json
+
+# 单条消息测试
+researchclaw chat --config config.arc.yaml -m "你好，请回复 pong。"
+
+# 单条消息测试（JSON 输出）
+researchclaw chat --config config.arc.yaml -m "你好，请回复 pong。" --json
+
+# 交互对话模式（输入 /exit 退出）
+researchclaw chat --config config.arc.yaml
+```
+
 <details>
 <summary>📝 最小必要配置</summary>
 

--- a/researchclaw/cli.py
+++ b/researchclaw/cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import json
 import shutil
 import subprocess
 import sys
@@ -777,6 +778,119 @@ def cmd_report(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_chat(args: argparse.Namespace) -> int:
+    """LLM/API chat utility for connectivity checks and quick dialogues."""
+    resolved = _resolve_config_or_exit(args)
+    if resolved is None:
+        return 1
+
+    config = RCConfig.load(resolved, check_paths=False)
+    check_only = cast(bool, args.check)
+    one_shot_message = cast(str | None, args.message)
+    system_prompt = cast(str | None, args.system)
+    max_turns = int(cast(int, args.max_turns))
+    json_output = cast(bool, getattr(args, "json", False))
+
+    from researchclaw.llm import create_llm_client
+
+    client = create_llm_client(config)
+
+    if check_only:
+        ok, msg = client.preflight()
+        payload = {
+            "ok": ok,
+            "mode": "check",
+            "message": msg,
+            "provider": config.llm.provider,
+            "model": config.llm.primary_model,
+        }
+        if json_output:
+            print(json.dumps(payload, ensure_ascii=False))
+            return 0 if ok else 1
+        if ok:
+            print(f"API check passed: {msg}")
+            return 0
+        print(f"API check failed: {msg}", file=sys.stderr)
+        return 1
+
+    if one_shot_message:
+        try:
+            resp = client.chat(
+                [{"role": "user", "content": one_shot_message}],
+                system=system_prompt,
+            )
+        except Exception as exc:  # noqa: BLE001
+            if json_output:
+                print(
+                    json.dumps(
+                        {
+                            "ok": False,
+                            "mode": "oneshot",
+                            "error": str(exc),
+                        },
+                        ensure_ascii=False,
+                    )
+                )
+                return 1
+            print(f"Chat request failed: {exc}", file=sys.stderr)
+            return 1
+        if json_output:
+            print(
+                json.dumps(
+                    {
+                        "ok": True,
+                        "mode": "oneshot",
+                        "response": resp.content,
+                        "model": resp.model,
+                        "prompt_tokens": resp.prompt_tokens,
+                        "completion_tokens": resp.completion_tokens,
+                        "total_tokens": resp.total_tokens,
+                    },
+                    ensure_ascii=False,
+                )
+            )
+            return 0
+        print(resp.content)
+        return 0
+
+    if json_output:
+        print(
+            "Error: --json is supported with --check or --message only.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("ResearchClaw chat mode (type /exit to quit)")
+    print("Tip: use --check for API connectivity only.\n")
+
+    history: list[dict[str, str]] = []
+    turns = 0
+    while True:
+        if max_turns > 0 and turns >= max_turns:
+            print("\nReached max turns, exiting.")
+            return 0
+        try:
+            user_input = input("you> ").strip()
+        except (EOFError, KeyboardInterrupt):
+            print()
+            return 0
+
+        if not user_input:
+            continue
+        if user_input.lower() in ("/exit", "/quit", "/q"):
+            return 0
+
+        history.append({"role": "user", "content": user_input})
+        try:
+            resp = client.chat(history, system=system_prompt)
+        except Exception as exc:  # noqa: BLE001
+            print(f"assistant> [error] {exc}", file=sys.stderr)
+            continue
+        history.append({"role": "assistant", "content": resp.content})
+        print(f"assistant> {resp.content}\n")
+        turns += 1
+
+
 # ── Research Enhancement commands (Agent D) ───────────────────────
 
 
@@ -1031,6 +1145,32 @@ def main(argv: list[str] | None = None) -> int:
     )
     _ = rpt_p.add_argument("--output", "-o", help="Write report to file")
 
+    chat_p = sub.add_parser("chat", help="Test LLM API connectivity and chat")
+    _ = chat_p.add_argument(
+        "--config", "-c", default=None,
+        help="Config file (default: auto-detect config.arc.yaml or config.yaml)",
+    )
+    _ = chat_p.add_argument(
+        "--check", action="store_true",
+        help="Run API preflight connectivity check only",
+    )
+    _ = chat_p.add_argument(
+        "--message", "-m", default=None,
+        help="Send one message and print the response",
+    )
+    _ = chat_p.add_argument(
+        "--system", default=None,
+        help="Optional system prompt for one-shot/interactive chat",
+    )
+    _ = chat_p.add_argument(
+        "--max-turns", type=int, default=0,
+        help="Interactive mode: stop after N turns (0 = unlimited)",
+    )
+    _ = chat_p.add_argument(
+        "--json", action="store_true",
+        help="Output structured JSON (supported with --check or --message)",
+    )
+
     # A: Web platform
     srv_p = sub.add_parser("serve", help="Start the web server")
     _ = srv_p.add_argument("--config", "-c", default="config.yaml", help="Config file path")
@@ -1140,6 +1280,8 @@ def main(argv: list[str] | None = None) -> int:
         return cmd_setup(args)
     elif command == "report":
         return cmd_report(args)
+    elif command == "chat":
+        return cmd_chat(args)
     elif command == "serve":
         return cmd_serve(args)
     elif command == "dashboard":

--- a/tests/test_rc_cli.py
+++ b/tests/test_rc_cli.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import re
 from pathlib import Path
 
@@ -195,6 +196,129 @@ def test_main_dispatches_validate_command(monkeypatch: pytest.MonkeyPatch) -> No
     parsed = captured["args"]
     assert parsed.config == "cfg.yaml"
     assert parsed.no_check_paths is True
+
+
+def test_main_dispatches_chat_command(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured = {}
+
+    def fake_cmd_chat(args):
+        captured["args"] = args
+        return 0
+
+    monkeypatch.setattr(rc_cli, "cmd_chat", fake_cmd_chat)
+    code = rc_cli.main(
+        [
+            "chat",
+            "--config",
+            "cfg.yaml",
+            "--check",
+            "--message",
+            "hello",
+            "--system",
+            "you are concise",
+            "--max-turns",
+            "3",
+            "--json",
+        ]
+    )
+    assert code == 0
+    parsed = captured["args"]
+    assert parsed.config == "cfg.yaml"
+    assert parsed.check is True
+    assert parsed.message == "hello"
+    assert parsed.system == "you are concise"
+    assert parsed.max_turns == 3
+    assert parsed.json is True
+
+
+def test_cmd_chat_check_success(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    config_path = tmp_path / "config.yaml"
+    _write_valid_config(config_path)
+
+    class _FakeClient:
+        def preflight(self) -> tuple[bool, str]:
+            return True, "OK - test"
+
+    import researchclaw.llm as llm_mod
+
+    monkeypatch.setattr(llm_mod, "create_llm_client", lambda cfg: _FakeClient())
+
+    args = argparse.Namespace(
+        config=str(config_path),
+        check=True,
+        message=None,
+        system=None,
+        max_turns=0,
+    )
+    code = rc_cli.cmd_chat(args)
+    assert code == 0
+    assert "API check passed" in capsys.readouterr().out
+
+
+def test_cmd_chat_check_json_output(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    config_path = tmp_path / "config.yaml"
+    _write_valid_config(config_path)
+
+    class _FakeClient:
+        def preflight(self) -> tuple[bool, str]:
+            return True, "OK - test"
+
+    import researchclaw.llm as llm_mod
+
+    monkeypatch.setattr(llm_mod, "create_llm_client", lambda cfg: _FakeClient())
+
+    args = argparse.Namespace(
+        config=str(config_path),
+        check=True,
+        message=None,
+        system=None,
+        max_turns=0,
+        json=True,
+    )
+    code = rc_cli.cmd_chat(args)
+    assert code == 0
+    out = capsys.readouterr().out.strip()
+    payload = json.loads(out)
+    assert payload["ok"] is True
+    assert payload["mode"] == "check"
+    assert "message" in payload
+
+
+def test_cmd_chat_one_shot_prints_response(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    config_path = tmp_path / "config.yaml"
+    _write_valid_config(config_path)
+
+    class _FakeResp:
+        content = "pong"
+
+    class _FakeClient:
+        def preflight(self) -> tuple[bool, str]:
+            return True, "OK"
+
+        def chat(self, messages, **kwargs):  # noqa: ANN001
+            return _FakeResp()
+
+    import researchclaw.llm as llm_mod
+
+    monkeypatch.setattr(llm_mod, "create_llm_client", lambda cfg: _FakeClient())
+
+    args = argparse.Namespace(
+        config=str(config_path),
+        check=False,
+        message="ping",
+        system=None,
+        max_turns=0,
+        json=False,
+    )
+    code = rc_cli.cmd_chat(args)
+    assert code == 0
+    assert "pong" in capsys.readouterr().out
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- add `researchclaw chat` command for API preflight checks, one-shot prompts, and interactive CLI chat
- add `--json` output for `--check` and `--message` modes so API checks can be scripted in CI/tooling
- document command usage and examples in `README.md` and `docs/README_CN.md`

## Test plan
- [x] install pytest in project virtualenv
- [x] run `python -m pytest tests/test_rc_cli.py -q`
- [x] verify all chat-related tests pass

## Issue
Closes #219