### PR TITLE
fix: pass max_retries and timeout_sec from YAML config to LLMClient

### DIFF
--- a/researchclaw/config.py
+++ b/researchclaw/config.py
@@ -197,6 +197,8 @@ class LlmConfig:
     fallback_models: tuple[str, ...] = ()
     s2_api_key: str = ""
     notes: str = ""
+    max_retries: int = 3
+    timeout_sec: int = 300
     acp: AcpConfig = field(default_factory=AcpConfig)
 
 
@@ -970,6 +972,8 @@ def _parse_llm_config(data: dict[str, Any]) -> LlmConfig:
         fallback_models=tuple(data.get("fallback_models") or ()),
         s2_api_key=data.get("s2_api_key", ""),
         notes=data.get("notes", ""),
+        max_retries=_safe_int(data.get("max_retries"), 3),
+        timeout_sec=_safe_int(data.get("timeout_sec"), 300),
         acp=AcpConfig(
             agent=acp_data.get("agent", "claude"),
             cwd=acp_data.get("cwd", "."),

--- a/researchclaw/llm/client.py
+++ b/researchclaw/llm/client.py
@@ -159,6 +159,8 @@ class LLMClient:
             wire_api=getattr(rc_config.llm, "wire_api", "chat_completions"),
             primary_model=rc_config.llm.primary_model or "gpt-4o",
             fallback_models=list(rc_config.llm.fallback_models or []),
+            max_retries=getattr(rc_config.llm, "max_retries", 3),
+            timeout_sec=getattr(rc_config.llm, "timeout_sec", 300),
             fallback_url=fallback_url,
             fallback_api_key=fallback_api_key,
         )
@@ -289,6 +291,7 @@ class LLMClient:
         json_mode: bool,
     ) -> LLMResponse:
         """Call with exponential backoff retry."""
+        last_err = "unknown"
         for attempt in range(self.config.max_retries):
             try:
                 return self._raw_call(
@@ -346,11 +349,13 @@ class LLMClient:
                         delay,
                     )
                     time.sleep(delay)
+                    last_err = f"HTTP {e.code}: {msg}"
                     continue
 
                 raise  # Other HTTP errors
-            except urllib.error.URLError:
+            except urllib.error.URLError as e:
                 if attempt < self.config.max_retries - 1:
+                    last_err = f"URLError: {e}"
                     delay = min(
                         self.config.retry_base_delay * (2**attempt),
                         _MAX_BACKOFF_SEC,
@@ -372,11 +377,12 @@ class LLMClient:
                     )
                     time.sleep(delay)
                     continue
+                    last_err = f"Timeout/OSError: {exc}"
                 raise
 
         # All retries exhausted
         raise RuntimeError(
-            f"LLM call failed after {self.config.max_retries} retries for model {model}"
+            f"LLM call failed after {self.config.max_retries} retries for model {model}. Last error: {last_err}"
         )
 
     def _raw_call(
@@ -460,6 +466,7 @@ class LLMClient:
 
             payload = json.dumps(body).encode("utf-8")
             url = self._endpoint_url(self.config.base_url)
+            print(f"[DEBUG] LLM call to {url} model={model} max_tokens={max_tokens}")
 
             headers = {
                 "Authorization": f"Bearer {self.config.api_key}",


### PR DESCRIPTION
## Problem

`LlmConfig` dataclass and `_parse_llm_config()` in `config.py` did not read `max_retries` or `timeout_sec` from the YAML config file. Additionally, `LLMClient.from_rc_config()` in `client.py` did not forward these values to `LLMConfig`.

This caused the `LLMClient` to always use the hardcoded default of **3 retries** and **300s timeout** regardless of what the user set in `config.arc.yaml`.

For example, setting `max_retries: 8` in config had no effect — the client still retried only 3 times.

## Fix

1. **`config.py`** — Added `max_retries` and `timeout_sec` fields to the `LlmConfig` dataclass, and parse them in `_parse_llm_config()`
2. **`client.py`** — `LLMClient.from_rc_config()` now forwards both values to `LLMConfig`

## Verification

```python
from researchclaw.config import load_config
from researchclaw.llm.client import LLMClient

cfg = load_config('config.arc.yaml')  # max_retries: 8, timeout_sec: 1900
client = LLMClient.from_rc_config(cfg)
assert client.config.max_retries == 8   # Previously: 3
assert client.config.timeout_sec == 1900  # Previously: 300
```