### PR TITLE
fix: track last error across retries in _call_with_retry

### DIFF
--- a/researchclaw/llm/client.py
+++ b/researchclaw/llm/client.py
@@ -298,6 +298,7 @@ class LLMClient:
         json_mode: bool,
     ) -> LLMResponse:
         """Call with exponential backoff retry."""
+        last_err = "unknown"
         for attempt in range(self.config.max_retries):
             try:
                 return self._raw_call(
@@ -354,12 +355,14 @@ class LLMClient:
                         status,
                         delay,
                     )
+                    last_err = f"HTTP {e.code}: {body[:200]}"
                     time.sleep(delay)
                     continue
 
                 raise  # Other HTTP errors
-            except urllib.error.URLError:
+            except urllib.error.URLError as e:
                 if attempt < self.config.max_retries - 1:
+                    last_err = f"URLError: {e}"
                     delay = min(
                         self.config.retry_base_delay * (2**attempt),
                         _MAX_BACKOFF_SEC,
@@ -370,6 +373,7 @@ class LLMClient:
             except (TimeoutError, OSError) as exc:
                 # Covers TimeoutError, ConnectionResetError, IncompleteRead, etc.
                 if attempt < self.config.max_retries - 1:
+                    last_err = f"Timeout/OSError: {exc}"
                     delay = self.config.retry_base_delay * (2**attempt)
                     logger.info(
                         "Retry %d/%d for %s (%s). Waiting %.1fs.",
@@ -385,7 +389,7 @@ class LLMClient:
 
         # All retries exhausted
         raise RuntimeError(
-            f"LLM call failed after {self.config.max_retries} retries for model {model}"
+            f"LLM call failed after {self.config.max_retries} retries for model {model}. Last error: {last_err}"
         )
 
     def _raw_call(


### PR DESCRIPTION
## Problem

When all retries are exhausted in `_call_with_retry()`, the final `RuntimeError` only says:
```
LLM call failed after N retries for model X
```
...with no indication of *what* went wrong (rate limit? timeout? connection refused?).

Additionally, `URLError` exceptions are caught but not captured as a variable, so their details are lost.

## Fix

- Add `last_err` tracking across all three exception handlers (`HTTPError`, `URLError`, `TimeoutError`/`OSError`)
- Capture `URLError` as `e` so the error details are available
- Include `last_err` in the final `RuntimeError` message
- Truncate HTTP body to 200 chars to keep error messages manageable

## After

```
LLM call failed after 8 retries for model gpt-4o. Last error: HTTP 429: {"error":{"message":"Rate limit exceeded"...}}
```

## Testing

Import-tested; no new dependencies. Change is limited to the retry loop in `researchclaw/llm/client.py`.