### PR TITLE
feat: add SSE streaming support to LLMClient to prevent proxy 504 timeouts

### DIFF
--- a/researchclaw/llm/client.py
+++ b/researchclaw/llm/client.py
@@ -6,7 +6,7 @@ Features:
   - Cloudflare User-Agent bypass
   - Exponential backoff retry with jitter
   - JSON mode support
-  - Streaming disabled (sync only)
+  - SSE streaming support to avoid proxy timeouts
 """
 
 from __future__ import annotations
@@ -88,6 +88,7 @@ class LLMConfig:
     # MetaClaw bridge: fallback URL if primary (proxy) is unreachable
     fallback_url: str = ""
     fallback_api_key: str = ""
+    stream: bool = True  # Use SSE streaming to avoid proxy timeouts
 
 
 class LLMClient:
@@ -388,6 +389,59 @@ class LLMClient:
             f"LLM call failed after {self.config.max_retries} retries for model {model}"
         )
 
+    def _read_stream(
+        self,
+        resp: Any,
+        model: str,
+    ) -> LLMResponse:
+        """Read an SSE stream and assemble an LLMResponse."""
+        content_chunks: list[str] = []
+        finish_reason = ""
+        usage: dict[str, int] = {}
+        resp_model = model
+
+        for raw_line in resp:
+            # SSE lines are bytes
+            line = raw_line.decode("utf-8", errors="replace").rstrip("\n\r")
+            if not line.startswith("data: "):
+                continue
+            payload = line[6:]
+            if payload.strip() == "[DONE]":
+                break
+            try:
+                chunk = json.loads(payload)
+            except json.JSONDecodeError:
+                continue
+
+            # Extract model name from first chunk
+            if "model" in chunk:
+                resp_model = chunk["model"]
+
+            # Accumulate content deltas
+            choices = chunk.get("choices") or []
+            for choice in choices:
+                delta = choice.get("delta") or {}
+                if "content" in delta and delta["content"]:
+                    content_chunks.append(delta["content"])
+                if choice.get("finish_reason"):
+                    finish_reason = choice["finish_reason"]
+
+            # Some providers send usage in the final chunk
+            if "usage" in chunk and chunk["usage"]:
+                usage = chunk["usage"]
+
+        content = "".join(content_chunks)
+        return LLMResponse(
+            content=content,
+            model=resp_model,
+            prompt_tokens=usage.get("prompt_tokens", 0),
+            completion_tokens=usage.get("completion_tokens", 0),
+            total_tokens=usage.get("total_tokens", 0),
+            finish_reason=finish_reason,
+            truncated=(finish_reason == "length"),
+            raw={},
+        )
+
     def _raw_call(
         self,
         model: str,
@@ -472,6 +526,16 @@ class LLMClient:
                 else:
                     body["response_format"] = {"type": "json_object"}
 
+            # Enable streaming to avoid proxy timeouts on long generations
+            _use_stream = (
+                self.config.stream
+                and self._normalize_wire_api(self.config.wire_api) != "responses"
+            )
+            if _use_stream:
+                body["stream"] = True
+                # Request usage stats in the final streamed chunk
+                body["stream_options"] = {"include_usage": True}
+
             payload = json.dumps(body).encode("utf-8")
             url = self._endpoint_url(self.config.base_url)
 
@@ -489,7 +553,11 @@ class LLMClient:
                 with urllib.request.urlopen(
                     req, timeout=self.config.timeout_sec
                 ) as resp:
-                    data = json.loads(resp.read())
+                    if _use_stream:
+                        data = None
+                        stream_result = self._read_stream(resp, model)
+                    else:
+                        data = json.loads(resp.read())
             except (urllib.error.URLError, OSError) as exc:
                 # MetaClaw bridge: fallback to direct LLM if proxy unreachable
                 if self.config.fallback_url:
@@ -511,9 +579,17 @@ class LLMClient:
                     with urllib.request.urlopen(
                         fallback_req, timeout=self.config.timeout_sec
                     ) as resp:
-                        data = json.loads(resp.read())
+                        if _use_stream:
+                            data = None
+                            stream_result = self._read_stream(resp, model)
+                        else:
+                            data = json.loads(resp.read())
                 else:
                     raise
+
+            # If we used streaming, return the assembled result directly
+            if _use_stream:
+                return stream_result
 
         if not isinstance(data, dict):
             raise ValueError(


### PR DESCRIPTION
## Problem

When using `LLMClient` behind a reverse proxy (e.g., NVIDIA's `inference-api.nvidia.com`), large code generation requests reliably produce **504 Gateway Timeout** errors. The proxy has a hard timeout (~60-120s) on synchronous responses, and models generating 8-16K output tokens from large prompts frequently exceed this.

Since the client sends a synchronous request and waits for the full response, the proxy kills the connection before the model finishes generating — even though the model would eventually complete.

This affects all models equally — it's not a model issue but a transport issue.

## Solution

Add SSE (Server-Sent Events) streaming support. With `"stream": true`, the API returns tokens incrementally. Bytes flow continuously, keeping the proxy connection alive regardless of total generation time.

### Changes

- **`LLMConfig.stream`** — New boolean field (default: `True`)
- **`_read_stream()`** — New method that parses SSE chunks (`data: {...}` lines), accumulates content deltas, and assembles a final `LLMResponse`
- **`_raw_call()`** — When streaming is enabled and using the `chat_completions` wire API, injects `"stream": true` and `"stream_options": {"include_usage": true}` into the request body, then delegates response parsing to `_read_stream()`
- Fallback path (MetaClaw bridge) also supports streaming
- No changes to Anthropic/Gemini adapter paths (they have their own HTTP clients)

### What's not affected

- The `responses` wire API (doesn't use streaming)
- Anthropic and Gemini native adapters
- All existing call patterns — `_raw_call` still returns an `LLMResponse`
- Set `stream: false` in config to disable

## Testing

Tested end-to-end against `inference-api.nvidia.com`:
- ✅ Streaming with Claude Sonnet — correct content, token counts, finish_reason
- ✅ Non-streaming fallback — unchanged behavior
- ✅ JSON mode + streaming — works correctly
- ✅ Import/instantiation checks pass