### PR TITLE
fix: prevent SOTA hallucination in Stage 01 goal.md

### DIFF
--- a/researchclaw/pipeline/stage_impls/_topic.py
+++ b/researchclaw/pipeline/stage_impls/_topic.py
@@ -54,6 +54,15 @@ def _execute_topic_init(
             system=sp.system,
         )
         goal_md = resp.content
+        # Prepend a disclaimer so downstream stages treat any benchmark/SOTA
+        # figures in this file as provisional estimates, not verified facts.
+        # Actual citation and SOTA verification happens in later stages.
+        disclaimer = (
+            "> **Note (Stage 01 — unverified draft):** Benchmark names and SOTA "
+            "claims in this file are LLM-generated estimates. "
+            "They will be verified during the literature search stage.\n\n"
+        )
+        goal_md = disclaimer + goal_md
     else:
         goal_md = f"""# Research Goal
 

--- a/researchclaw/prompts.py
+++ b/researchclaw/prompts.py
@@ -1514,9 +1514,11 @@ _DEFAULT_STAGES: dict[str, dict[str, Any]] = {
             "will be retrieved in the literature search stage.\n"
             "- Name the specific benchmark/dataset that will be used for evaluation.\n"
             "- If no standard benchmark exists, explain how results will be measured.\n"
-            "- State whether SOTA results exist on this benchmark and what they are.\n"
-            "- Add a 'Benchmark' subsection listing: name, source, metrics, "
-            "current SOTA (if known)."
+            "- Note whether SOTA results are commonly tracked on this benchmark "
+            "(do NOT state specific model names or performance numbers — these "
+            "will be verified in the literature search stage).\n"
+            "- Add a 'Benchmark' subsection listing: name, source, and typical "
+            "metrics — omit unverified performance numbers."
         ),
     },
     "problem_decompose": {

--- a/tests/test_rc_executor.py
+++ b/tests/test_rc_executor.py
@@ -320,11 +320,10 @@ def test_execute_stage_creates_stage_dir_writes_artifacts_and_meta(
     assert "goal.md" in result.artifacts
     assert "hardware_profile.json" in result.artifacts
     assert (run_dir / "stage-01").is_dir()
-    assert (
-        (run_dir / "stage-01" / "goal.md")
-        .read_text(encoding="utf-8")
-        .startswith("# Goal")
-    )
+    goal_text = (run_dir / "stage-01" / "goal.md").read_text(encoding="utf-8")
+    # goal.md now starts with a disclaimer blockquote; the original content follows
+    assert "# Goal" in goal_text
+    assert "unverified draft" in goal_text  # disclaimer is present
     assert (run_dir / "stage-01" / "hardware_profile.json").exists()
     assert len(fake_llm.calls) == 1
 

--- a/tests/test_rc_prompts.py
+++ b/tests/test_rc_prompts.py
@@ -112,6 +112,23 @@ class TestPromptManagerDefaults:
         assert "ml" in sp.user
         assert sp.system
 
+    def test_topic_init_no_sota_hallucination(self) -> None:
+        """topic_init prompt must not ask for specific SOTA numbers (issue #238)."""
+        pm = PromptManager()
+        sp = pm.for_stage(
+            "topic_init",
+            topic="graph neural networks",
+            domains="ml",
+            project_name="test",
+            quality_threshold="4.0",
+        )
+        user = sp.user
+        # Must explicitly block paper citations and SOTA figures
+        assert "Do NOT fabricate" in user or "do NOT state specific" in user
+        # Must not ask the model to produce exact SOTA performance numbers
+        assert "what they are" not in user
+        assert "current SOTA (if known)" not in user
+
     def test_json_mode_stages(self) -> None:
         pm = PromptManager()
         json_stages = [


### PR DESCRIPTION
Fixes #238

## Problem

The previous fix (#226 / 5dc7fcc) removed the prompt line that asked the model to cite specific papers in Stage 01, but the TREND VALIDATION section still explicitly asked:

> *State whether SOTA results exist on this benchmark and what they are.*
> *Add a 'Benchmark' subsection listing: name, source, metrics, current SOTA (if known).*

These lines continue to invite the model to hallucinate specific model names and performance numbers. Because `goal.md` is the first pipeline artifact and is loaded as context by all downstream stages, inaccurate SOTA claims can anchor reasoning throughout the entire run.

## Solution

1. **Prompt hardening** (`researchclaw/prompts.py`): Replace the two problematic lines with instructions that explicitly prohibit stating specific model names or performance numbers, directing the model to describe the benchmark type and typical metrics only. Actual SOTA verification is deferred to the literature search stage — consistent with the existing guardrail for paper citations.

2. **Disclaimer in `goal.md`** (`researchclaw/pipeline/stage_impls/_topic.py`): Prepend a visible blockquote disclaimer to every LLM-generated `goal.md` so that downstream stages (and human reviewers) treat any benchmark/SOTA figures as provisional LLM estimates, not verified facts.

3. **Regression test** (`tests/test_rc_prompts.py`): Assert that the rendered `topic_init` prompt contains at least one anti-hallucination guardrail phrase and that the previously problematic phrases (`"what they are"`, `"current SOTA (if known)"`) are absent.

## Testing

- `pytest tests/test_rc_prompts.py` — all 35 tests pass including the new regression test.
- Full test suite run clean.