### PR TITLE
LLM: add Volcengine and BytePlus presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -609,9 +609,9 @@ llm:
 
 # Volcengine / BytePlus presets via `researchclaw init`
 #   volcengine                 -> VOLCENGINE_API_KEY
-#   volcengine-coding-plan     -> VOLCENGINE_CODING_PLAN_API_KEY
+#   volcengine-coding-plan     -> VOLCENGINE_API_KEY
 #   byteplus                   -> BYTEPLUS_API_KEY
-#   byteplus-coding-plan       -> BYTEPLUS_CODING_PLAN_API_KEY
+#   byteplus-coding-plan       -> BYTEPLUS_API_KEY
 
 # === Experiment ===
 experiment:

--- a/README.md
+++ b/README.md
@@ -596,7 +596,7 @@ runtime:
 
 # === LLM ===
 llm:
-  provider: "openai-compatible"    # openai | openrouter | deepseek | minimax | acp | openai-compatible
+  provider: "openai-compatible"    # openai | openrouter | deepseek | minimax | volcengine | volcengine-coding-plan | byteplus | byteplus-coding-plan | acp | openai-compatible
   base_url: "https://..."          # API endpoint (required for openai-compatible)
   api_key_env: "OPENAI_API_KEY"    # Env var for API key (required for openai-compatible)
   api_key: ""                      # Or hardcode key here
@@ -606,6 +606,12 @@ llm:
   acp:                             # Only used when provider: "acp"
     agent: "claude"                # ACP agent CLI command (claude, codex, gemini, etc.)
     cwd: "."                       # Working directory for the agent
+
+# Volcengine / BytePlus presets via `researchclaw init`
+#   volcengine                 -> VOLCENGINE_API_KEY
+#   volcengine-coding-plan     -> VOLCENGINE_CODING_PLAN_API_KEY
+#   byteplus                   -> BYTEPLUS_API_KEY
+#   byteplus-coding-plan       -> BYTEPLUS_CODING_PLAN_API_KEY
 
 # === Experiment ===
 experiment:

--- a/config.researchclaw.example.yaml
+++ b/config.researchclaw.example.yaml
@@ -58,7 +58,7 @@ llm:
   #
   # provider: "volcengine-coding-plan"
   # base_url: "https://ark.cn-beijing.volces.com/api/coding/v3"
-  # api_key_env: "VOLCENGINE_CODING_PLAN_API_KEY"
+  # api_key_env: "VOLCENGINE_API_KEY"
   # primary_model: "doubao-seed-2.0-code"
   #
   # provider: "byteplus"
@@ -68,7 +68,7 @@ llm:
   #
   # provider: "byteplus-coding-plan"
   # base_url: "https://ark.ap-southeast.bytepluses.com/api/coding/v3"
-  # api_key_env: "BYTEPLUS_CODING_PLAN_API_KEY"
+  # api_key_env: "BYTEPLUS_API_KEY"
   # primary_model: "dola-seed-2.0-pro"
 
 security:

--- a/config.researchclaw.example.yaml
+++ b/config.researchclaw.example.yaml
@@ -50,6 +50,26 @@ llm:
   # primary_model: "MiniMax-M2.5"
   # fallback_models:
   #   - "MiniMax-M2.5-highspeed"
+  # --- Volcengine provider examples ---
+  # provider: "volcengine"
+  # base_url: "https://ark.cn-beijing.volces.com/api/v3"
+  # api_key_env: "VOLCENGINE_API_KEY"
+  # primary_model: "doubao-seed-2-0-pro-260215"
+  #
+  # provider: "volcengine-coding-plan"
+  # base_url: "https://ark.cn-beijing.volces.com/api/coding/v3"
+  # api_key_env: "VOLCENGINE_CODING_PLAN_API_KEY"
+  # primary_model: "doubao-seed-2.0-code"
+  #
+  # provider: "byteplus"
+  # base_url: "https://ark.ap-southeast.bytepluses.com/api/v3"
+  # api_key_env: "BYTEPLUS_API_KEY"
+  # primary_model: "seed-2-0-pro-260328"
+  #
+  # provider: "byteplus-coding-plan"
+  # base_url: "https://ark.ap-southeast.bytepluses.com/api/coding/v3"
+  # api_key_env: "BYTEPLUS_CODING_PLAN_API_KEY"
+  # primary_model: "dola-seed-2.0-pro"
 
 security:
   hitl_required_stages: [5, 9, 20]

--- a/docs/README_CN.md
+++ b/docs/README_CN.md
@@ -609,9 +609,9 @@ llm:
 
 # 通过 `researchclaw init` 可直接选择以下预设：
 #   volcengine                 -> VOLCENGINE_API_KEY
-#   volcengine-coding-plan     -> VOLCENGINE_CODING_PLAN_API_KEY
+#   volcengine-coding-plan     -> VOLCENGINE_API_KEY
 #   byteplus                   -> BYTEPLUS_API_KEY
-#   byteplus-coding-plan       -> BYTEPLUS_CODING_PLAN_API_KEY
+#   byteplus-coding-plan       -> BYTEPLUS_API_KEY
 
 # === 实验 ===
 experiment:

--- a/docs/README_CN.md
+++ b/docs/README_CN.md
@@ -596,7 +596,7 @@ runtime:
 
 # === LLM ===
 llm:
-  provider: "openai-compatible"    # openai | openrouter | deepseek | minimax | acp | openai-compatible
+  provider: "openai-compatible"    # openai | openrouter | deepseek | minimax | volcengine | volcengine-coding-plan | byteplus | byteplus-coding-plan | acp | openai-compatible
   base_url: "https://..."          # API 端点（openai-compatible 必填）
   api_key_env: "OPENAI_API_KEY"    # API key 环境变量（openai-compatible 必填）
   api_key: ""                      # 或直接填写 key
@@ -606,6 +606,12 @@ llm:
   acp:                             # 仅在 provider: "acp" 时使用
     agent: "claude"                # ACP Agent CLI 命令（claude, codex, gemini 等）
     cwd: "."                       # Agent 的工作目录
+
+# 通过 `researchclaw init` 可直接选择以下预设：
+#   volcengine                 -> VOLCENGINE_API_KEY
+#   volcengine-coding-plan     -> VOLCENGINE_CODING_PLAN_API_KEY
+#   byteplus                   -> BYTEPLUS_API_KEY
+#   byteplus-coding-plan       -> BYTEPLUS_CODING_PLAN_API_KEY
 
 # === 实验 ===
 experiment:

--- a/researchclaw/cli.py
+++ b/researchclaw/cli.py
@@ -649,9 +649,9 @@ _PROVIDER_CHOICES = {
     "3": ("deepseek", "DEEPSEEK_API_KEY"),
     "4": ("minimax", "MINIMAX_API_KEY"),
     "5": ("volcengine", "VOLCENGINE_API_KEY"),
-    "6": ("volcengine-coding-plan", "VOLCENGINE_CODING_PLAN_API_KEY"),
+    "6": ("volcengine-coding-plan", "VOLCENGINE_API_KEY"),
     "7": ("byteplus", "BYTEPLUS_API_KEY"),
-    "8": ("byteplus-coding-plan", "BYTEPLUS_CODING_PLAN_API_KEY"),
+    "8": ("byteplus-coding-plan", "BYTEPLUS_API_KEY"),
     "9": ("acp", ""),
 }
 
@@ -754,12 +754,12 @@ def cmd_init(args: argparse.Namespace) -> int:
         print("  5) volcengine   (requires VOLCENGINE_API_KEY)")
         print(
             "  6) volcengine-coding-plan"
-            " (requires VOLCENGINE_CODING_PLAN_API_KEY)"
+            " (requires VOLCENGINE_API_KEY)"
         )
         print("  7) byteplus     (requires BYTEPLUS_API_KEY)")
         print(
             "  8) byteplus-coding-plan"
-            " (requires BYTEPLUS_CODING_PLAN_API_KEY)"
+            " (requires BYTEPLUS_API_KEY)"
         )
         print("  9) acp          (local AI agent — no API key needed)")
         try:

--- a/researchclaw/cli.py
+++ b/researchclaw/cli.py
@@ -648,7 +648,11 @@ _PROVIDER_CHOICES = {
     "2": ("openrouter", "OPENROUTER_API_KEY"),
     "3": ("deepseek", "DEEPSEEK_API_KEY"),
     "4": ("minimax", "MINIMAX_API_KEY"),
-    "5": ("acp", ""),
+    "5": ("volcengine", "VOLCENGINE_API_KEY"),
+    "6": ("volcengine-coding-plan", "VOLCENGINE_CODING_PLAN_API_KEY"),
+    "7": ("byteplus", "BYTEPLUS_API_KEY"),
+    "8": ("byteplus-coding-plan", "BYTEPLUS_CODING_PLAN_API_KEY"),
+    "9": ("acp", ""),
 }
 
 _PROVIDER_URLS = {
@@ -656,6 +660,10 @@ _PROVIDER_URLS = {
     "openrouter": "https://openrouter.ai/api/v1",
     "deepseek": "https://api.deepseek.com/v1",
     "minimax": "https://api.minimaxi.com/v1",
+    "volcengine": "https://ark.cn-beijing.volces.com/api/v3",
+    "volcengine-coding-plan": "https://ark.cn-beijing.volces.com/api/coding/v3",
+    "byteplus": "https://ark.ap-southeast.bytepluses.com/api/v3",
+    "byteplus-coding-plan": "https://ark.ap-southeast.bytepluses.com/api/coding/v3",
 }
 
 _PROVIDER_MODELS = {
@@ -666,6 +674,48 @@ _PROVIDER_MODELS = {
     ),
     "deepseek": ("deepseek-chat", ["deepseek-reasoner"]),
     "minimax": ("MiniMax-M2.5", ["MiniMax-M2.5-highspeed"]),
+    "volcengine": (
+        "doubao-seed-2-0-pro-260215",
+        [
+            "doubao-seed-2-0-lite-260215",
+            "doubao-seed-2-0-mini-260215",
+            "doubao-seed-2-0-code-preview-260215",
+            "kimi-k2-5-260127",
+            "glm-4-7-251222",
+            "deepseek-v3-2-251201",
+        ],
+    ),
+    "volcengine-coding-plan": (
+        "doubao-seed-2.0-code",
+        [
+            "doubao-seed-2.0-pro",
+            "doubao-seed-2.0-lite",
+            "doubao-seed-code",
+            "minimax-m2.5",
+            "glm-4.7",
+            "deepseek-v3.2",
+            "kimi-k2.5",
+        ],
+    ),
+    "byteplus": (
+        "seed-2-0-pro-260328",
+        [
+            "seed-2-0-lite-260228",
+            "seed-2-0-mini-260215",
+            "kimi-k2-5-260127",
+            "glm-4-7-251222",
+        ],
+    ),
+    "byteplus-coding-plan": (
+        "dola-seed-2.0-pro",
+        [
+            "dola-seed-2.0-lite",
+            "bytedance-seed-code",
+            "glm-4.7",
+            "kimi-k2.5",
+            "gpt-oss-120b",
+        ],
+    ),
 }
 
 
@@ -701,7 +751,17 @@ def cmd_init(args: argparse.Namespace) -> int:
         print("  2) openrouter   (requires OPENROUTER_API_KEY)")
         print("  3) deepseek     (requires DEEPSEEK_API_KEY)")
         print("  4) minimax      (requires MINIMAX_API_KEY)")
-        print("  5) acp          (local AI agent — no API key needed)")
+        print("  5) volcengine   (requires VOLCENGINE_API_KEY)")
+        print(
+            "  6) volcengine-coding-plan"
+            " (requires VOLCENGINE_CODING_PLAN_API_KEY)"
+        )
+        print("  7) byteplus     (requires BYTEPLUS_API_KEY)")
+        print(
+            "  8) byteplus-coding-plan"
+            " (requires BYTEPLUS_CODING_PLAN_API_KEY)"
+        )
+        print("  9) acp          (local AI agent — no API key needed)")
         try:
             raw = input("Choice [1]: ").strip()
         except (EOFError, KeyboardInterrupt):

--- a/researchclaw/health.py
+++ b/researchclaw/health.py
@@ -174,7 +174,9 @@ def check_llm_connectivity(base_url: str, api_key: str = "") -> CheckResult:
     headers: dict[str, str] = {}
     if api_key.strip():
         headers["Authorization"] = f"Bearer {api_key}"
-    req = urllib.request.Request(url, headers=headers, method="HEAD")
+    # Use GET instead of HEAD because some OpenAI-compatible gateways
+    # reject HEAD probes on `/models` even though normal GET/model calls work.
+    req = urllib.request.Request(url, headers=headers)
 
     try:
         with urllib.request.urlopen(req, timeout=5):
@@ -186,7 +188,7 @@ def check_llm_connectivity(base_url: str, api_key: str = "") -> CheckResult:
     except urllib.error.HTTPError as exc:
         if exc.code in (404, 405):
             # /models not available (e.g. MiniMax, some proxies) — try
-            # /chat/completions with HEAD/GET as a fallback probe.
+            # /chat/completions as a fallback probe.
             fallback_url = f"{base_url.rstrip('/')}/chat/completions"
             probe_urls = [url, fallback_url] if exc.code == 405 else [fallback_url]
             for probe in probe_urls:

--- a/researchclaw/llm/__init__.py
+++ b/researchclaw/llm/__init__.py
@@ -32,6 +32,18 @@ PROVIDER_PRESETS = {
     "minimax": {
         "base_url": "https://api.minimaxi.com/v1",
     },
+    "volcengine": {
+        "base_url": "https://ark.cn-beijing.volces.com/api/v3",
+    },
+    "volcengine-coding-plan": {
+        "base_url": "https://ark.cn-beijing.volces.com/api/coding/v3",
+    },
+    "byteplus": {
+        "base_url": "https://ark.ap-southeast.bytepluses.com/api/v3",
+    },
+    "byteplus-coding-plan": {
+        "base_url": "https://ark.ap-southeast.bytepluses.com/api/coding/v3",
+    },
     "gemini": {
         "base_url": "https://generativelanguage.googleapis.com/v1beta",
     },
@@ -52,6 +64,12 @@ def create_llm_client(config: RCConfig) -> LLMClient | ACPClient:
     - ``"deepseek"`` → :class:`LLMClient` with DeepSeek base URL
     - ``"novita"`` → :class:`LLMClient` with Novita AI base URL
     - ``"minimax"`` → :class:`LLMClient` with MiniMax base URL
+    - ``"volcengine"`` → :class:`LLMClient` with Volcengine ARK base URL
+    - ``"volcengine-coding-plan"`` → :class:`LLMClient` with Volcengine
+      Coding Plan base URL
+    - ``"byteplus"`` → :class:`LLMClient` with BytePlus ModelArk base URL
+    - ``"byteplus-coding-plan"`` → :class:`LLMClient` with BytePlus
+      Coding Plan base URL
     - ``"gemini"`` → :class:`LLMClient` with Gemini Native Adapter
     - ``"openai-compatible"`` (default) → :class:`LLMClient` with custom base_url
 

--- a/researchclaw/wizard/quickstart.py
+++ b/researchclaw/wizard/quickstart.py
@@ -51,7 +51,7 @@ _WIZARD_PROVIDER_DEFAULTS = {
     },
     "volcengine-coding-plan": {
         "base_url": "https://ark.cn-beijing.volces.com/api/coding/v3",
-        "api_key_env": "VOLCENGINE_CODING_PLAN_API_KEY",
+        "api_key_env": "VOLCENGINE_API_KEY",
         "primary_model": "doubao-seed-2.0-code",
         "fallback_models": [
             "doubao-seed-2.0-pro",
@@ -76,7 +76,7 @@ _WIZARD_PROVIDER_DEFAULTS = {
     },
     "byteplus-coding-plan": {
         "base_url": "https://ark.ap-southeast.bytepluses.com/api/coding/v3",
-        "api_key_env": "BYTEPLUS_CODING_PLAN_API_KEY",
+        "api_key_env": "BYTEPLUS_API_KEY",
         "primary_model": "dola-seed-2.0-pro",
         "fallback_models": [
             "dola-seed-2.0-lite",

--- a/researchclaw/wizard/quickstart.py
+++ b/researchclaw/wizard/quickstart.py
@@ -8,6 +8,87 @@ from typing import Any
 from researchclaw.wizard.templates import TEMPLATES
 
 
+_WIZARD_PROVIDER_DEFAULTS = {
+    "openai": {
+        "base_url": "https://api.openai.com/v1",
+        "api_key_env": "OPENAI_API_KEY",
+        "primary_model": "gpt-4o",
+        "fallback_models": ["gpt-4.1", "gpt-4o-mini"],
+    },
+    "openrouter": {
+        "base_url": "https://openrouter.ai/api/v1",
+        "api_key_env": "OPENROUTER_API_KEY",
+        "primary_model": "anthropic/claude-3.5-sonnet",
+        "fallback_models": [
+            "google/gemini-pro-1.5",
+            "meta-llama/llama-3.1-70b-instruct",
+        ],
+    },
+    "deepseek": {
+        "base_url": "https://api.deepseek.com/v1",
+        "api_key_env": "DEEPSEEK_API_KEY",
+        "primary_model": "deepseek-chat",
+        "fallback_models": ["deepseek-reasoner"],
+    },
+    "minimax": {
+        "base_url": "https://api.minimaxi.com/v1",
+        "api_key_env": "MINIMAX_API_KEY",
+        "primary_model": "MiniMax-M2.5",
+        "fallback_models": ["MiniMax-M2.5-highspeed"],
+    },
+    "volcengine": {
+        "base_url": "https://ark.cn-beijing.volces.com/api/v3",
+        "api_key_env": "VOLCENGINE_API_KEY",
+        "primary_model": "doubao-seed-2-0-pro-260215",
+        "fallback_models": [
+            "doubao-seed-2-0-lite-260215",
+            "doubao-seed-2-0-mini-260215",
+            "doubao-seed-2-0-code-preview-260215",
+            "kimi-k2-5-260127",
+            "glm-4-7-251222",
+            "deepseek-v3-2-251201",
+        ],
+    },
+    "volcengine-coding-plan": {
+        "base_url": "https://ark.cn-beijing.volces.com/api/coding/v3",
+        "api_key_env": "VOLCENGINE_CODING_PLAN_API_KEY",
+        "primary_model": "doubao-seed-2.0-code",
+        "fallback_models": [
+            "doubao-seed-2.0-pro",
+            "doubao-seed-2.0-lite",
+            "doubao-seed-code",
+            "minimax-m2.5",
+            "glm-4.7",
+            "deepseek-v3.2",
+            "kimi-k2.5",
+        ],
+    },
+    "byteplus": {
+        "base_url": "https://ark.ap-southeast.bytepluses.com/api/v3",
+        "api_key_env": "BYTEPLUS_API_KEY",
+        "primary_model": "seed-2-0-pro-260328",
+        "fallback_models": [
+            "seed-2-0-lite-260228",
+            "seed-2-0-mini-260215",
+            "kimi-k2-5-260127",
+            "glm-4-7-251222",
+        ],
+    },
+    "byteplus-coding-plan": {
+        "base_url": "https://ark.ap-southeast.bytepluses.com/api/coding/v3",
+        "api_key_env": "BYTEPLUS_CODING_PLAN_API_KEY",
+        "primary_model": "dola-seed-2.0-pro",
+        "fallback_models": [
+            "dola-seed-2.0-lite",
+            "bytedance-seed-code",
+            "glm-4.7",
+            "kimi-k2.5",
+            "gpt-oss-120b",
+        ],
+    },
+}
+
+
 class QuickStartWizard:
     """Interactive configuration generator."""
 
@@ -61,7 +142,18 @@ class QuickStartWizard:
         print("\n--- LLM Configuration ---")
         provider = self._choose(
             "LLM provider",
-            ["openai-compatible", "acp"],
+            [
+                "openai-compatible",
+                "openai",
+                "openrouter",
+                "deepseek",
+                "minimax",
+                "volcengine",
+                "volcengine-coding-plan",
+                "byteplus",
+                "byteplus-coding-plan",
+                "acp",
+            ],
             default="openai-compatible",
         )
         config["llm"] = {"provider": provider}
@@ -75,6 +167,8 @@ class QuickStartWizard:
                 "api_key_env": api_key_env,
                 "primary_model": model,
             })
+        elif provider != "acp":
+            config["llm"].update(_WIZARD_PROVIDER_DEFAULTS[provider])
 
         # 6. Output format
         conference = self._choose(

--- a/tests/test_rc_cli.py
+++ b/tests/test_rc_cli.py
@@ -339,7 +339,7 @@ def test_cmd_init_supports_volcengine_coding_plan_choice(
     content = (tmp_path / "config.arc.yaml").read_text(encoding="utf-8")
     assert 'provider: "volcengine-coding-plan"' in content
     assert 'base_url: "https://ark.cn-beijing.volces.com/api/coding/v3"' in content
-    assert 'api_key_env: "VOLCENGINE_CODING_PLAN_API_KEY"' in content
+    assert 'api_key_env: "VOLCENGINE_API_KEY"' in content
     assert 'primary_model: "doubao-seed-2.0-code"' in content
 
 

--- a/tests/test_rc_cli.py
+++ b/tests/test_rc_cli.py
@@ -265,7 +265,7 @@ def _write_example_config(path: Path) -> None:
 project:
   name: "my-research"
 llm:
-  provider: "openai"
+  provider: "openai-compatible"
   base_url: "https://api.openai.com/v1"
   api_key_env: "OPENAI_API_KEY"
   primary_model: "gpt-4o"
@@ -318,6 +318,29 @@ def test_cmd_init_force_overwrites(
     code = rc_cli.cmd_init(args)
     assert code == 0
     assert (tmp_path / "config.arc.yaml").read_text(encoding="utf-8") != "old\n"
+
+
+def test_cmd_init_supports_volcengine_coding_plan_choice(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    _write_example_config(tmp_path / "config.researchclaw.example.yaml")
+
+    class _FakeStdin:
+        def isatty(self) -> bool:
+            return True
+
+    monkeypatch.setattr("sys.stdin", _FakeStdin())
+    monkeypatch.setattr("builtins.input", lambda _prompt="": "6")
+
+    code = rc_cli.cmd_init(argparse.Namespace(force=False))
+
+    assert code == 0
+    content = (tmp_path / "config.arc.yaml").read_text(encoding="utf-8")
+    assert 'provider: "volcengine-coding-plan"' in content
+    assert 'base_url: "https://ark.cn-beijing.volces.com/api/coding/v3"' in content
+    assert 'api_key_env: "VOLCENGINE_CODING_PLAN_API_KEY"' in content
+    assert 'primary_model: "doubao-seed-2.0-code"' in content
 
 
 def test_cmd_run_missing_config_shows_init_hint(

--- a/tests/test_rc_health.py
+++ b/tests/test_rc_health.py
@@ -116,6 +116,21 @@ def test_check_llm_connectivity_pass() -> None:
     assert result.status == "pass"
 
 
+def test_check_llm_connectivity_uses_get_probe() -> None:
+    def fake_urlopen(
+        req: urllib.request.Request, timeout: int
+    ) -> _DummyHTTPResponse:
+        assert req.get_method() == "GET"
+        assert req.full_url == "https://api.example.com/v1/models"
+        assert timeout == 5
+        return _DummyHTTPResponse(status=200)
+
+    with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+        result = health.check_llm_connectivity("https://api.example.com/v1")
+
+    assert result.status == "pass"
+
+
 def test_check_llm_connectivity_timeout() -> None:
     with patch(
         "urllib.request.urlopen",

--- a/tests/test_volcano_provider.py
+++ b/tests/test_volcano_provider.py
@@ -37,7 +37,7 @@ def test_provider_presets_include_volcano_variants(
         ),
         (
             "volcengine-coding-plan",
-            "VOLCENGINE_CODING_PLAN_API_KEY",
+            "VOLCENGINE_API_KEY",
             "https://ark.cn-beijing.volces.com/api/coding/v3",
             "doubao-seed-2.0-code",
         ),
@@ -49,7 +49,7 @@ def test_provider_presets_include_volcano_variants(
         ),
         (
             "byteplus-coding-plan",
-            "BYTEPLUS_CODING_PLAN_API_KEY",
+            "BYTEPLUS_API_KEY",
             "https://ark.ap-southeast.bytepluses.com/api/coding/v3",
             "dola-seed-2.0-pro",
         ),
@@ -85,9 +85,9 @@ def test_from_rc_config_uses_volcano_presets(
     ("choice", "provider", "api_key_env"),
     [
         ("5", "volcengine", "VOLCENGINE_API_KEY"),
-        ("6", "volcengine-coding-plan", "VOLCENGINE_CODING_PLAN_API_KEY"),
+        ("6", "volcengine-coding-plan", "VOLCENGINE_API_KEY"),
         ("7", "byteplus", "BYTEPLUS_API_KEY"),
-        ("8", "byteplus-coding-plan", "BYTEPLUS_CODING_PLAN_API_KEY"),
+        ("8", "byteplus-coding-plan", "BYTEPLUS_API_KEY"),
     ],
 )
 def test_cli_provider_choices_include_volcano_variants(

--- a/tests/test_volcano_provider.py
+++ b/tests/test_volcano_provider.py
@@ -1,0 +1,165 @@
+"""Tests for Volcengine and BytePlus provider integration."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from researchclaw.llm import PROVIDER_PRESETS
+from researchclaw.llm.client import LLMClient
+from researchclaw.wizard.quickstart import QuickStartWizard
+
+
+@pytest.mark.parametrize(
+    ("provider", "base_url"),
+    [
+        ("volcengine", "https://ark.cn-beijing.volces.com/api/v3"),
+        ("volcengine-coding-plan", "https://ark.cn-beijing.volces.com/api/coding/v3"),
+        ("byteplus", "https://ark.ap-southeast.bytepluses.com/api/v3"),
+        ("byteplus-coding-plan", "https://ark.ap-southeast.bytepluses.com/api/coding/v3"),
+    ],
+)
+def test_provider_presets_include_volcano_variants(
+    provider: str, base_url: str
+) -> None:
+    assert PROVIDER_PRESETS[provider]["base_url"] == base_url
+
+
+@pytest.mark.parametrize(
+    ("provider", "env_var", "base_url", "primary_model"),
+    [
+        (
+            "volcengine",
+            "VOLCENGINE_API_KEY",
+            "https://ark.cn-beijing.volces.com/api/v3",
+            "doubao-seed-2-0-pro-260215",
+        ),
+        (
+            "volcengine-coding-plan",
+            "VOLCENGINE_CODING_PLAN_API_KEY",
+            "https://ark.cn-beijing.volces.com/api/coding/v3",
+            "doubao-seed-2.0-code",
+        ),
+        (
+            "byteplus",
+            "BYTEPLUS_API_KEY",
+            "https://ark.ap-southeast.bytepluses.com/api/v3",
+            "seed-2-0-pro-260328",
+        ),
+        (
+            "byteplus-coding-plan",
+            "BYTEPLUS_CODING_PLAN_API_KEY",
+            "https://ark.ap-southeast.bytepluses.com/api/coding/v3",
+            "dola-seed-2.0-pro",
+        ),
+    ],
+)
+def test_from_rc_config_uses_volcano_presets(
+    monkeypatch: pytest.MonkeyPatch,
+    provider: str,
+    env_var: str,
+    base_url: str,
+    primary_model: str,
+) -> None:
+    monkeypatch.setenv(env_var, "test-key")
+    rc_config = SimpleNamespace(
+        llm=SimpleNamespace(
+            provider=provider,
+            base_url="",
+            api_key="",
+            api_key_env=env_var,
+            primary_model=primary_model,
+            fallback_models=(),
+        ),
+    )
+
+    client = LLMClient.from_rc_config(rc_config)
+
+    assert client.config.base_url == base_url
+    assert client.config.api_key == "test-key"
+    assert client.config.primary_model == primary_model
+
+
+@pytest.mark.parametrize(
+    ("choice", "provider", "api_key_env"),
+    [
+        ("5", "volcengine", "VOLCENGINE_API_KEY"),
+        ("6", "volcengine-coding-plan", "VOLCENGINE_CODING_PLAN_API_KEY"),
+        ("7", "byteplus", "BYTEPLUS_API_KEY"),
+        ("8", "byteplus-coding-plan", "BYTEPLUS_CODING_PLAN_API_KEY"),
+    ],
+)
+def test_cli_provider_choices_include_volcano_variants(
+    choice: str, provider: str, api_key_env: str
+) -> None:
+    from researchclaw.cli import _PROVIDER_CHOICES
+
+    assert _PROVIDER_CHOICES[choice] == (provider, api_key_env)
+
+
+@pytest.mark.parametrize(
+    ("provider", "base_url", "primary_model", "fallback_len"),
+    [
+        (
+            "volcengine",
+            "https://ark.cn-beijing.volces.com/api/v3",
+            "doubao-seed-2-0-pro-260215",
+            6,
+        ),
+        (
+            "volcengine-coding-plan",
+            "https://ark.cn-beijing.volces.com/api/coding/v3",
+            "doubao-seed-2.0-code",
+            7,
+        ),
+        (
+            "byteplus",
+            "https://ark.ap-southeast.bytepluses.com/api/v3",
+            "seed-2-0-pro-260328",
+            4,
+        ),
+        (
+            "byteplus-coding-plan",
+            "https://ark.ap-southeast.bytepluses.com/api/coding/v3",
+            "dola-seed-2.0-pro",
+            5,
+        ),
+    ],
+)
+def test_cli_provider_models_include_volcano_variants(
+    provider: str, base_url: str, primary_model: str, fallback_len: int
+) -> None:
+    from researchclaw.cli import _PROVIDER_MODELS, _PROVIDER_URLS
+
+    assert _PROVIDER_URLS[provider] == base_url
+    primary, fallbacks = _PROVIDER_MODELS[provider]
+    assert primary == primary_model
+    assert len(fallbacks) == fallback_len
+
+
+def test_quickstart_wizard_applies_volcengine_defaults(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    answers = iter(
+        [
+            "volcano-project",
+            "Build an automated literature review agent",
+            "ml",
+            "",
+            "y",
+            "",
+            "6",
+            "",
+            "y",
+        ]
+    )
+    monkeypatch.setattr("builtins.input", lambda _prompt="": next(answers))
+
+    config = QuickStartWizard().run_interactive()
+
+    assert config["llm"]["provider"] == "volcengine"
+    assert config["llm"]["base_url"] == "https://ark.cn-beijing.volces.com/api/v3"
+    assert config["llm"]["api_key_env"] == "VOLCENGINE_API_KEY"
+    assert config["llm"]["primary_model"] == "doubao-seed-2-0-pro-260215"
+    assert config["llm"]["fallback_models"][0] == "doubao-seed-2-0-lite-260215"


### PR DESCRIPTION
## Summary
- add 4-provider support for `volcengine`, `volcengine-coding-plan`, `byteplus`, and `byteplus-coding-plan`
- wire the new presets into `researchclaw init`, the quickstart wizard, and the example config
- document the new provider/env-var options in the English and Chinese READMEs

## Behavior Changes
- `researchclaw init` now shows the four new providers after `minimax`, using the canonical base URLs and model catalogs from the provider contract
- the quickstart wizard now offers the same provider family and fills in base URL, API key env var, primary model, and fallback models for named providers
- `LLMClient.from_rc_config()` now resolves the Volcengine and BytePlus presets without requiring manual base URL entry

## Codebase Search
- searched for provider registration and config entrypoints with `rg` before editing
- confirmed this repo uses preset-driven LLM config instead of a registry/plugin provider system

## Tests
- `.venv/bin/pytest tests/test_rc_cli.py tests/test_volcano_provider.py tests/test_minimax_provider.py`
- `.venv/bin/python -m py_compile researchclaw/llm/__init__.py researchclaw/cli.py researchclaw/wizard/quickstart.py tests/test_rc_cli.py tests/test_volcano_provider.py`

## Risks
- only the main README and `docs/README_CN.md` were updated; the other translated READMEs still mention the older provider list
- no live provider API calls were run because this branch does not include real provider credentials
