### PR TITLE
fix(search_strategy): accept search_phases / phases / dict-wrapped queries

### DIFF
--- a/researchclaw/pipeline/stage_impls/_literature.py
+++ b/researchclaw/pipeline/stage_impls/_literature.py
@@ -197,13 +197,33 @@ def _execute_search_strategy(
     queries_list: list[str] = []
     year_min = 2020
     if isinstance(plan, dict):
-        strategies = plan.get("search_strategies", [])
+        strategies = (
+            plan.get("search_strategies")
+            or plan.get("search_phases")
+            or plan.get("phases")
+            or []
+        )
         if isinstance(strategies, list):
             for strat in strategies:
                 if isinstance(strat, dict):
                     qs = strat.get("queries", [])
                     if isinstance(qs, list):
-                        queries_list.extend(str(q) for q in qs if q)
+                        for q in qs:
+                            if isinstance(q, str) and q.strip():
+                                queries_list.append(q.strip())
+                            elif isinstance(q, dict):
+                                for v in q.values():
+                                    if isinstance(v, str) and v.strip():
+                                        queries_list.append(v.strip())
+        top_level_queries = plan.get("queries")
+        if isinstance(top_level_queries, list) and not queries_list:
+            for q in top_level_queries:
+                if isinstance(q, str) and q.strip():
+                    queries_list.append(q.strip())
+                elif isinstance(q, dict):
+                    for v in q.values():
+                        if isinstance(v, str) and v.strip():
+                            queries_list.append(v.strip())
         filters = plan.get("filters", {})
         if isinstance(filters, dict) and filters.get("min_year"):
             try:


### PR DESCRIPTION
## Summary

`_execute_search_strategy` only recognizes `search_strategies` as the top-level key of LLM-generated plans, and only accepts queries as a list of strings. When the LLM produces a semantically equivalent but syntactically different schema (e.g. `search_phases:` with queries like `{q1: "..."}`), the parser silently returns an empty `queries_list` and the stage falls back to `_build_default_search_queries()`, which slices the topic sentence into stopword-filtered n-grams.

Those n-grams then drive Stage 4's real API search, which returns whichever high-citation papers happen to match those generic tokens, and Stage 5's shortlist is populated with off-topic papers.

## Repro

Any run where the LLM produces a plan with a top-level key other than `search_strategies`, or with queries wrapped as dicts. After Stage 3 completes:

- `stage-03/search_plan.yaml` — a well-formed plan
- `stage-03/queries.json` — only topic n-grams: `<first N words of topic>` plus literal `" benchmark"` / `" survey"` / `" recent advances"`
- `stage-04/candidates.jsonl` — top hits match generic tokens rather than the intended domain
- `stage-05/shortlist.jsonl` — off-topic papers

## Fix

- Accept `search_strategies`, `search_phases`, or `phases` at the top level.
- In each strategy's `queries` list, handle items that are either strings or single-key dicts like `{"q1": "query text"}`.
- Also treat a top-level `queries:` list as a last-resort fallback (same shape handling).

Plans that already use the original schema are unaffected.

## Test plan

- [ ] Existing test suite passes unchanged
- [ ] `queries.json` reflects the LLM's plan rather than topic n-grams

## Notes for reviewers

Separately, `_build_default_search_queries()` is a weak fallback that produces low-quality queries regardless of domain. That is out of scope here — this patch only addresses why the fallback is being hit when the LLM did produce a good plan. Happy to follow up.