### PR TITLE
fix(pipeline): fail closed on degraded refine loops and arxiv exhaustion

### DIFF
--- a/researchclaw/literature/arxiv_client.py
+++ b/researchclaw/literature/arxiv_client.py
@@ -38,6 +38,8 @@ logger = logging.getLogger(__name__)
 _CB_THRESHOLD = 3
 _CB_INITIAL_COOLDOWN = 180
 _CB_MAX_COOLDOWN = 600
+_RATE_LIMIT_WINDOW_SEC = 300
+_RATE_LIMIT_FAILURES_TO_BLOCK = 6
 
 _CB_CLOSED = "closed"
 _CB_OPEN = "open"
@@ -49,18 +51,51 @@ _cb_cooldown_sec: float = _CB_INITIAL_COOLDOWN
 _cb_open_since: float = 0.0
 _cb_trip_count: int = 0
 _cb_lock = threading.Lock()
+_rate_limit_failures: list[float] = []
+
+
+class ArxivRateLimitExhausted(RuntimeError):
+    """Raised when arXiv keeps returning 429/503 within the failure window."""
 
 
 def _reset_circuit_breaker() -> None:
     """Reset circuit breaker state (for tests)."""
     global _cb_state, _cb_consecutive_429s, _cb_cooldown_sec  # noqa: PLW0603
-    global _cb_open_since, _cb_trip_count  # noqa: PLW0603
+    global _cb_open_since, _cb_trip_count, _rate_limit_failures  # noqa: PLW0603
     with _cb_lock:
         _cb_state = _CB_CLOSED
         _cb_consecutive_429s = 0
         _cb_cooldown_sec = _CB_INITIAL_COOLDOWN
         _cb_open_since = 0.0
         _cb_trip_count = 0
+        _rate_limit_failures = []
+
+
+def _is_rate_limit_error(exc: Exception) -> bool:
+    message = str(exc).lower()
+    return (
+        "429" in message
+        or "503" in message
+        or "too many requests" in message
+        or "service unavailable" in message
+    )
+
+
+def _record_rate_limit_failure() -> int:
+    global _rate_limit_failures  # noqa: PLW0603
+    now = time.monotonic()
+    with _cb_lock:
+        _rate_limit_failures = [
+            ts for ts in _rate_limit_failures if now - ts <= _RATE_LIMIT_WINDOW_SEC
+        ]
+        _rate_limit_failures.append(now)
+        return len(_rate_limit_failures)
+
+
+def _clear_rate_limit_failures() -> None:
+    global _rate_limit_failures  # noqa: PLW0603
+    with _cb_lock:
+        _rate_limit_failures = []
 
 
 def _cb_should_allow() -> bool:
@@ -137,6 +172,7 @@ def search_arxiv(
     limit: int = 50,
     sort_by: str = "relevance",
     year_min: int = 0,
+    fail_fast: bool = False,
 ) -> list[Paper]:
     """Search arXiv for papers matching *query*.
 
@@ -162,6 +198,14 @@ def search_arxiv(
         return []
     if not _cb_should_allow():
         logger.info("[rate-limit] arXiv circuit breaker OPEN — skipping")
+        if fail_fast:
+            failures = _record_rate_limit_failure()
+            if failures >= _RATE_LIMIT_FAILURES_TO_BLOCK:
+                raise ArxivRateLimitExhausted(
+                    "arXiv rate-limit retries exhausted "
+                    f"({failures} HTTP 429/503 events or open-circuit skips "
+                    f"in {_RATE_LIMIT_WINDOW_SEC}s)"
+                )
         return []
 
     limit = min(limit, 300)
@@ -189,16 +233,31 @@ def search_arxiv(
                 continue
             papers.append(paper)
         _cb_on_success()
+        _clear_rate_limit_failures()
         logger.info("arXiv: found %d papers for %r", len(papers), query)
     except arxiv.HTTPError as exc:
         logger.warning("arXiv HTTP error: %s", exc)
         _cb_on_failure()
+        if fail_fast and _is_rate_limit_error(exc):
+            failures = _record_rate_limit_failure()
+            if failures >= _RATE_LIMIT_FAILURES_TO_BLOCK:
+                raise ArxivRateLimitExhausted(
+                    "arXiv rate-limit retries exhausted "
+                    f"({failures} HTTP 429/503 events in {_RATE_LIMIT_WINDOW_SEC}s)"
+                )
     except arxiv.UnexpectedEmptyPageError:
         logger.warning("arXiv returned unexpected empty page for %r", query)
         _cb_on_failure()
     except Exception as exc:  # noqa: BLE001
         logger.warning("arXiv search failed: %s", exc)
         _cb_on_failure()
+        if fail_fast and _is_rate_limit_error(exc):
+            failures = _record_rate_limit_failure()
+            if failures >= _RATE_LIMIT_FAILURES_TO_BLOCK:
+                raise ArxivRateLimitExhausted(
+                    "arXiv rate-limit retries exhausted "
+                    f"({failures} HTTP 429/503 events in {_RATE_LIMIT_WINDOW_SEC}s)"
+                )
 
     return papers
 

--- a/researchclaw/literature/search.py
+++ b/researchclaw/literature/search.py
@@ -24,7 +24,7 @@ import time
 import urllib.error
 from typing import cast
 
-from researchclaw.literature.arxiv_client import search_arxiv
+from researchclaw.literature.arxiv_client import ArxivRateLimitExhausted, search_arxiv
 from researchclaw.literature.models import Author, Paper
 from researchclaw.literature.openalex_client import search_openalex
 from researchclaw.literature.semantic_scholar import search_semantic_scholar
@@ -177,7 +177,12 @@ def search_papers(
                 time.sleep(1.0)
 
             elif src_lower == "arxiv":
-                papers = search_arxiv(query, limit=limit, year_min=year_min)
+                papers = search_arxiv(
+                    query,
+                    limit=limit,
+                    year_min=year_min,
+                    fail_fast=True,
+                )
                 all_papers.extend(papers)
                 cache_put(query, "arxiv", limit, _papers_to_dicts(papers))
                 source_stats["arxiv"] = len(papers)
@@ -185,6 +190,8 @@ def search_papers(
 
             else:
                 logger.warning("Unknown literature source: %s (skipped)", src)
+        except ArxivRateLimitExhausted:
+            raise
         except (
             OSError,
             RuntimeError,

--- a/researchclaw/pipeline/runner.py
+++ b/researchclaw/pipeline/runner.py
@@ -19,6 +19,7 @@ from researchclaw.pipeline.executor import StageResult, execute_stage
 from researchclaw.pipeline.stages import (
     DECISION_ROLLBACK,
     MAX_DECISION_PIVOTS,
+    MAX_DECISION_REFINES,
     NONCRITICAL_STAGES,
     STAGE_SEQUENCE,
     Stage,
@@ -45,6 +46,55 @@ def _build_pipeline_summary(
     from_stage: Stage,
     run_dir: Path | None = None,
 ) -> dict[str, object]:
+    final_result = results[-1] if results else None
+    degraded = any(r.decision == "degraded" for r in results)
+    final_status = final_result.status.value if final_result is not None else "no_stages"
+    content_metrics = _collect_content_metrics(run_dir)
+    final_decision = next(
+        (
+            item.decision
+            for item in reversed(results)
+            if item.stage == Stage.RESEARCH_DECISION
+        ),
+        "proceed",
+    )
+    stall_reason: str | None = None
+
+    # Fail-closed: degraded + REFINE/PIVOT is not a completed run.
+    if (
+        final_status == "done"
+        and degraded
+        and final_decision in {"refine", "pivot"}
+    ):
+        final_status = "failed"
+        stall_reason = (
+            "degraded pipeline ended with non-terminal research decision "
+            f"({final_decision})"
+        )
+
+    total_citations = content_metrics.get("total_citations")
+    verified_citations = content_metrics.get("verified_citations")
+    if (
+        final_status == "done"
+        and degraded
+        and (total_citations == 0 or verified_citations == 0)
+    ):
+        final_status = "failed"
+        stall_reason = (
+            "degraded pipeline ended with zero citation evidence "
+            f"(total={total_citations}, verified={verified_citations})"
+        )
+
+    # Explicit blocked terminal path (used by loop/rate-limit guards).
+    if (
+        final_result is not None
+        and final_result.status == StageStatus.FAILED
+        and final_result.decision == "blocked"
+    ):
+        final_status = "blocked"
+        if final_result.error:
+            stall_reason = final_result.error
+
     summary: dict[str, object] = {
         "run_id": run_id,
         "stages_executed": len(results),
@@ -58,13 +108,16 @@ def _build_pipeline_summary(
         "stages_failed": sum(
             1 for item in results if item.status == StageStatus.FAILED
         ),
-        "degraded": any(r.decision == "degraded" for r in results),
+        "degraded": degraded,
         "from_stage": int(from_stage),
         "final_stage": int(results[-1].stage) if results else int(from_stage),
-        "final_status": results[-1].status.value if results else "no_stages",
+        "final_status": final_status,
+        "final_decision": final_decision,
         "generated": _utcnow_iso(),
-        "content_metrics": _collect_content_metrics(run_dir),
+        "content_metrics": content_metrics,
     }
+    if stall_reason:
+        summary["stall_reason"] = stall_reason
     return summary
 
 
@@ -686,6 +739,47 @@ def execute_pipeline(
             and result.decision in DECISION_ROLLBACK
         ):
             pivot_count = _read_pivot_count(run_dir)
+            decision_count = _read_decision_count(run_dir, result.decision)
+
+            # Fail-closed cap for REFINE loops.
+            if (
+                result.decision == "refine"
+                and decision_count >= MAX_DECISION_REFINES
+            ):
+                stall_reason = (
+                    "stage-15 refine loop cap reached "
+                    f"({MAX_DECISION_REFINES})"
+                )
+                logger.warning("%s — blocking run", stall_reason)
+                print(f"[{run_id}] BLOCKED: {stall_reason}")
+                blocked_result = StageResult(
+                    stage=result.stage,
+                    status=StageStatus.FAILED,
+                    artifacts=result.artifacts,
+                    error=stall_reason,
+                    decision="blocked",
+                    evidence_refs=result.evidence_refs,
+                )
+                results[-1] = blocked_result
+
+                stage_dir = run_dir / f"stage-{int(stage):02d}"
+                stage_dir.mkdir(parents=True, exist_ok=True)
+                (stage_dir / "stall_reason.txt").write_text(
+                    stall_reason + "\n", encoding="utf-8"
+                )
+                break
+
+            rollback_limit = (
+                MAX_DECISION_REFINES
+                if result.decision == "refine"
+                else MAX_DECISION_PIVOTS
+            )
+            rollback_attempts = (
+                decision_count
+                if result.decision == "refine"
+                else pivot_count
+            )
+
             # R6-4: Skip REFINE if experiment metrics are empty for consecutive cycles
             if pivot_count > 0 and _consecutive_empty_metrics(run_dir, pivot_count):
                 logger.warning(
@@ -697,7 +791,7 @@ def execute_pipeline(
                 # BUG-211: Promote best stage-14 before proceeding with
                 # empty data — an earlier iteration may have real metrics.
                 _promote_best_stage14(run_dir, config)
-            elif pivot_count < MAX_DECISION_PIVOTS:
+            elif rollback_attempts < rollback_limit:
                 rollback_target = DECISION_ROLLBACK[result.decision]
                 _record_decision_history(
                     run_dir, result.decision, rollback_target, pivot_count + 1
@@ -706,13 +800,13 @@ def execute_pipeline(
                     "Decision %s: rolling back to %s (attempt %d/%d)",
                     result.decision.upper(),
                     rollback_target.name,
-                    pivot_count + 1,
-                    MAX_DECISION_PIVOTS,
+                    rollback_attempts + 1,
+                    rollback_limit,
                 )
                 print(
                     f"[{run_id}] Decision: {result.decision.upper()} → "
                     f"rollback to {rollback_target.name} "
-                    f"(attempt {pivot_count + 1}/{MAX_DECISION_PIVOTS})"
+                    f"(attempt {rollback_attempts + 1}/{rollback_limit})"
                 )
                 # Version existing stage directories before overwriting
                 _version_rollback_stages(
@@ -1439,6 +1533,26 @@ def _read_pivot_count(run_dir: Path) -> int:
     except (json.JSONDecodeError, OSError):
         pass
     return 0
+
+
+def _read_decision_count(run_dir: Path, decision: str) -> int:
+    """Read how many times a specific decision has been recorded."""
+    history_path = run_dir / "decision_history.json"
+    if not history_path.exists():
+        return 0
+    try:
+        data = json.loads(history_path.read_text(encoding="utf-8"))
+        if not isinstance(data, list):
+            return 0
+        decision_lower = decision.lower()
+        return sum(
+            1
+            for item in data
+            if isinstance(item, dict)
+            and str(item.get("decision", "")).lower() == decision_lower
+        )
+    except (json.JSONDecodeError, OSError):
+        return 0
 
 
 def _record_decision_history(

--- a/researchclaw/pipeline/stage_impls/_literature.py
+++ b/researchclaw/pipeline/stage_impls/_literature.py
@@ -368,6 +368,7 @@ def _execute_literature_collect(
     real_search_succeeded = False
 
     try:
+        from researchclaw.literature.arxiv_client import ArxivRateLimitExhausted
         from researchclaw.literature.search import (
             search_papers_multi_query,
             papers_to_bibtex,
@@ -401,6 +402,19 @@ def _execute_literature_collect(
             logger.info(
                 "[literature] Found %d papers (%s)", len(papers), src_str
             )
+    except ArxivRateLimitExhausted as exc:
+        stall_reason = (
+            "arXiv backoff exhausted: repeated HTTP 429/503 during literature "
+            f"collection ({exc})"
+        )
+        logger.error("[rate-limit] %s", stall_reason)
+        return StageResult(
+            stage=Stage.LITERATURE_COLLECT,
+            status=StageStatus.FAILED,
+            artifacts=(),
+            error=stall_reason,
+            decision="blocked",
+        )
     except Exception:  # noqa: BLE001
         logger.warning(
             "[rate-limit] Literature search failed — falling back to LLM",

--- a/researchclaw/pipeline/stages.py
+++ b/researchclaw/pipeline/stages.py
@@ -131,6 +131,7 @@ DECISION_ROLLBACK: dict[str, Stage] = {
 }
 
 MAX_DECISION_PIVOTS: int = 2  # Prevent infinite loops
+MAX_DECISION_REFINES: int = 3  # Hard cap for REFINE rollback loops
 
 # ---------------------------------------------------------------------------
 # Noncritical stages — can be skipped on failure without aborting pipeline

--- a/tests/test_rc_executor.py
+++ b/tests/test_rc_executor.py
@@ -590,6 +590,40 @@ def test_stage_executor_mapping_values_are_callable(stage: Stage) -> None:
     assert callable(rc_executor._STAGE_EXECUTORS[stage])
 
 
+def test_literature_collect_arxiv_backoff_exhaustion_blocks(
+    monkeypatch: pytest.MonkeyPatch,
+    run_dir: Path,
+    rc_config: RCConfig,
+    adapters: AdapterBundle,
+) -> None:
+    """arXiv 429/503 exhaustion must terminally block, not degrade to placeholders."""
+    from researchclaw.literature.arxiv_client import ArxivRateLimitExhausted
+
+    def exhausted(*args: object, **kwargs: object) -> list[object]:
+        _ = args, kwargs
+        raise ArxivRateLimitExhausted("six 429/503 responses")
+
+    monkeypatch.setattr(
+        "researchclaw.literature.search.search_papers_multi_query",
+        exhausted,
+    )
+
+    stage_dir = run_dir / "stage-04"
+    stage_dir.mkdir()
+    result = rc_executor._execute_literature_collect(
+        stage_dir,
+        run_dir,
+        rc_config,
+        adapters,
+    )
+
+    assert result.stage == Stage.LITERATURE_COLLECT
+    assert result.status == StageStatus.FAILED
+    assert result.decision == "blocked"
+    assert "arXiv backoff exhausted" in (result.error or "")
+    assert not (stage_dir / "candidates.jsonl").exists()
+
+
 class TestStageHealth:
     def test_stage_health_json_written(self, tmp_path: Path) -> None:
         from researchclaw.pipeline.executor import execute_stage

--- a/tests/test_rc_literature.py
+++ b/tests/test_rc_literature.py
@@ -649,6 +649,39 @@ class TestArxivCircuitBreaker:
         papers = search_arxiv("test", limit=5)
         assert papers == []
 
+    def test_fail_fast_raises_after_repeated_rate_limits(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Fail-fast mode should raise after repeated arXiv 429/503 pressure."""
+        import types
+
+        from researchclaw.literature import arxiv_client
+
+        _fake_arxiv = types.ModuleType("arxiv")
+
+        class _FakeHTTPError(Exception):
+            pass
+
+        class _FakeUnexpectedEmptyPageError(Exception):
+            pass
+
+        _fake_arxiv.HTTPError = _FakeHTTPError
+        _fake_arxiv.UnexpectedEmptyPageError = _FakeUnexpectedEmptyPageError
+        _fake_arxiv.SortCriterion = MagicMock()
+        _fake_arxiv.SortOrder = MagicMock()
+        _fake_arxiv.Search = MagicMock()
+        monkeypatch.setattr(arxiv_client, "arxiv", _fake_arxiv)
+
+        mock_client = MagicMock()
+        mock_client.results.side_effect = _FakeHTTPError("HTTP 429")
+        monkeypatch.setattr(arxiv_client, "_get_client", lambda: mock_client)
+        monkeypatch.setattr(arxiv_client, "_RATE_LIMIT_FAILURES_TO_BLOCK", 3)
+        arxiv_client._reset_circuit_breaker()
+
+        with pytest.raises(arxiv_client.ArxivRateLimitExhausted):
+            for _ in range(3):
+                search_arxiv("test", limit=5, fail_fast=True)
+
 
 # ──────────────────────────────────────────────────────────────────────
 # OpenAlex client tests

--- a/tests/test_rc_runner.py
+++ b/tests/test_rc_runner.py
@@ -404,6 +404,65 @@ def test_build_pipeline_summary_core_fields(
     assert summary["final_stage"] == expected_final_stage
 
 
+def test_pipeline_summary_degraded_refine_is_not_done() -> None:
+    """A degraded run that still wants REFINE must fail closed, not report done."""
+    summary = rc_runner._build_pipeline_summary(
+        run_id="run-degraded-refine",
+        results=[
+            StageResult(
+                stage=Stage.RESEARCH_DECISION,
+                status=StageStatus.DONE,
+                artifacts=("decision.md",),
+                decision="refine",
+            ),
+            StageResult(
+                stage=Stage.QUALITY_GATE,
+                status=StageStatus.DONE,
+                artifacts=("quality_report.json",),
+                decision="degraded",
+            ),
+            _done(Stage.CITATION_VERIFY),
+        ],
+        from_stage=Stage.TOPIC_INIT,
+    )
+    assert summary["degraded"] is True
+    assert summary["final_decision"] == "refine"
+    assert summary["final_status"] != "done"
+    assert "non-terminal research decision" in str(summary["stall_reason"])
+
+
+def test_pipeline_summary_degraded_zero_citations_is_not_done(
+    run_dir: Path,
+) -> None:
+    """A degraded run with zero citation evidence must fail closed."""
+    stage23 = run_dir / "stage-23"
+    stage23.mkdir(parents=True)
+    (stage23 / "verification_report.json").write_text(
+        json.dumps({"summary": {"total": 0, "verified": 0}}),
+        encoding="utf-8",
+    )
+
+    summary = rc_runner._build_pipeline_summary(
+        run_id="run-degraded-zero-citations",
+        results=[
+            StageResult(
+                stage=Stage.QUALITY_GATE,
+                status=StageStatus.DONE,
+                artifacts=("quality_report.json",),
+                decision="degraded",
+            ),
+            _done(Stage.CITATION_VERIFY),
+        ],
+        from_stage=Stage.TOPIC_INIT,
+        run_dir=run_dir,
+    )
+    assert summary["degraded"] is True
+    assert summary["content_metrics"]["total_citations"] == 0
+    assert summary["content_metrics"]["verified_citations"] == 0
+    assert summary["final_status"] != "done"
+    assert "zero citation evidence" in str(summary["stall_reason"])
+
+
 def test_pipeline_prints_stage_progress(
     monkeypatch: pytest.MonkeyPatch,
     run_dir: Path,
@@ -604,6 +663,42 @@ def test_max_pivot_count_prevents_infinite_loop(
     assert decision_count <= MAX_DECISION_PIVOTS + 1
 
 
+def test_max_refine_count_blocks_instead_of_forcing_success(
+    monkeypatch: pytest.MonkeyPatch,
+    run_dir: Path,
+    rc_config: RCConfig,
+    adapters: AdapterBundle,
+) -> None:
+    seen: list[Stage] = []
+
+    def mock_execute_stage(stage: Stage, **kwargs) -> StageResult:
+        _ = kwargs
+        seen.append(stage)
+        if stage == Stage.RESEARCH_DECISION:
+            return _refine_result(stage)
+        return _done(stage)
+
+    monkeypatch.setattr(rc_runner, "execute_stage", mock_execute_stage)
+    results = rc_runner.execute_pipeline(
+        run_dir=run_dir,
+        run_id="run-max-refine",
+        config=rc_config,
+        adapters=adapters,
+    )
+    from researchclaw.pipeline.stages import MAX_DECISION_REFINES
+
+    decision_count = sum(1 for s in seen if s == Stage.RESEARCH_DECISION)
+    assert decision_count == MAX_DECISION_REFINES + 1
+    assert results[-1].stage == Stage.RESEARCH_DECISION
+    assert results[-1].status == StageStatus.FAILED
+    assert results[-1].decision == "blocked"
+    assert "refine loop cap" in (results[-1].error or "")
+
+    summary = json.loads((run_dir / "pipeline_summary.json").read_text())
+    assert summary["final_status"] == "blocked"
+    assert "refine loop cap" in summary["stall_reason"]
+
+
 def test_proceed_decision_does_not_trigger_rollback(
     monkeypatch: pytest.MonkeyPatch,
     run_dir: Path,
@@ -783,11 +878,13 @@ def test_write_checkpoint_preserves_old_on_write_failure(
     original_open = builtins.open
 
     def _exploding_open(path, *args, **kwargs):
-        # After os.close(fd), _write_checkpoint opens via path string —
-        # intercept temp-file opens (checkpoint_*.tmp)
-        if isinstance(path, (str, Path)) and "checkpoint_" in str(path):
-            raise OSError("disk full")
-        if isinstance(path, int):
+        # Intercept the temporary checkpoint write, regardless of whether the
+        # implementation opens by fd or path.
+        if isinstance(path, int) or (
+            isinstance(path, (str, Path))
+            and "checkpoint_" in str(path)
+            and str(path).endswith(".tmp")
+        ):
             raise OSError("disk full")
         return original_open(path, *args, **kwargs)
 


### PR DESCRIPTION
## Summary
This patch closes the nightly false-green/stall cluster by making ARC fail closed in three places:

1. **Mode 3 (highest priority):** `pipeline_summary.final_status` can no longer be `done` when the run is degraded and the latest stage-15 decision is `REFINE/PIVOT`, or when degraded + zero citation evidence.
2. **Mode 1:** arXiv 429/503 storms now escalate to typed exhaustion and terminal blocked stage failure (instead of silent empty/fallback drift).
3. **Mode 2:** stage-15 REFINE loops now have a hard cap (`MAX_DECISION_REFINES=3`) and terminate blocked with explicit stall reason.

## RCA
- Local RCA artifact: `/Users/rose/.openclaw/workspace/memory/arc-rca-2026-04-24.md`

## Key changes
- `researchclaw/pipeline/runner.py`
  - summary normalization with `final_decision` + `stall_reason`
  - fail-closed status for degraded+REFINE/PIVOT and degraded+zero-citations
  - REFINE loop cap enforcement to terminal blocked
- `researchclaw/pipeline/stages.py`
  - add `MAX_DECISION_REFINES = 3`
- `researchclaw/literature/arxiv_client.py`
  - add `ArxivRateLimitExhausted`
  - add fail-fast 429/503/open-circuit exhaustion window logic
- `researchclaw/literature/search.py`
  - propagate arXiv exhaustion instead of swallowing
- `researchclaw/pipeline/executor.py`
  - stage-4 converts arXiv exhaustion to terminal blocked failure

## Tests
Added/updated:
- `tests/test_rc_runner.py`
  - degraded+REFINE cannot report done
  - degraded+zero-citations cannot report done
  - REFINE cap terminates blocked
- `tests/test_rc_executor.py`
  - arXiv backoff exhaustion blocks stage-4
- `tests/test_rc_literature.py`
  - fail-fast raises after repeated rate limits

Executed:
- `pytest -q tests/test_rc_runner.py::test_pipeline_summary_degraded_refine_is_not_done tests/test_rc_runner.py::test_pipeline_summary_degraded_zero_citations_is_not_done tests/test_rc_runner.py::test_max_refine_count_blocks_instead_of_forcing_success tests/test_rc_executor.py::test_literature_collect_arxiv_backoff_exhaustion_blocks tests/test_rc_literature.py::TestArxivCircuitBreaker::test_fail_fast_raises_after_repeated_rate_limits`
  - **5 passed, 1 warning**
- `pytest -q tests/test_rc_runner.py tests/test_rc_executor.py tests/test_rc_literature.py`
  - **263 passed, 1 warning**

## External gate check (defense in depth)
- `python3 /Users/rose/.openclaw/workspace/scripts/nightly_arc_research_gate.py --run research-20260424T070102Z-2-assess-uv-marimo-modal-a`
  - correctly returns `decision: block` on degraded/REFINE/0-citation run.
