### PR TITLE
fix: replace deprecated download_pdf() with pdf_url for arxiv 4.0 compatibility

### DIFF
--- a/researchclaw/literature/arxiv_client.py
+++ b/researchclaw/literature/arxiv_client.py
@@ -19,6 +19,7 @@ import logging
 import re
 import threading
 import time
+import urllib.request
 from pathlib import Path
 from typing import Any
 
@@ -249,8 +250,11 @@ def download_pdf(
             dirpath = Path(dirpath)
             dirpath.mkdir(parents=True, exist_ok=True)
             fname = filename or f"{arxiv_id.replace('/', '_')}.pdf"
-            result.download_pdf(dirpath=str(dirpath), filename=fname)
             pdf_path = dirpath / fname
+            if not result.pdf_url:
+                logger.warning("No PDF URL for %s", arxiv_id)
+                return None
+            urllib.request.urlretrieve(result.pdf_url, str(pdf_path))
             logger.info("Downloaded arXiv PDF: %s → %s", arxiv_id, pdf_path)
             return pdf_path
     except Exception as exc:  # noqa: BLE001


### PR DESCRIPTION
## Summary
- arxiv 4.0 removed the `Result.download_pdf()` method
- `_convert_result()` already worked with 4.0 (authors, primary_category unchanged)
- Replaced with `urllib.request.urlretrieve(result.pdf_url, ...)` which is the new API

## Test plan
- [x] Tested `search_arxiv()` against arxiv 4.0 — works
- [x] Tested `download_pdf()` for 3 papers — all downloaded correctly
- [x] Added `pdf_url` null check for robustness

🤖 Generated with [Claude Code](https://claude.com/claude-code)