### PR TITLE
fix(cli): disable OpenCode Beast Mode for ACP provider in init

### DIFF
--- a/researchclaw/cli.py
+++ b/researchclaw/cli.py
@@ -850,6 +850,11 @@ def cmd_init(args: argparse.Namespace) -> int:
             'base_url: "https://api.openai.com/v1"', 'base_url: ""'
         )
         content = content.replace('api_key_env: "OPENAI_API_KEY"', 'api_key_env: ""')
+        # Beast Mode is incompatible with ACP (opencode_bridge prepends "openai/")
+        content = content.replace(
+            '    enabled: true                # Master switch (default: true)',
+            '    enabled: false               # Master switch (disabled for ACP)',
+        )
     else:
         base_url = _PROVIDER_URLS.get(provider, "https://api.openai.com/v1")
         content = content.replace(

--- a/tests/test_rc_cli.py
+++ b/tests/test_rc_cli.py
@@ -320,6 +320,26 @@ def test_cmd_init_force_overwrites(
     assert (tmp_path / "config.arc.yaml").read_text(encoding="utf-8") != "old\n"
 
 
+def test_cmd_init_acp_disables_opencode(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """When provider=acp is selected, OpenCode Beast Mode is disabled in the generated config."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "sys.stdin", type("FakeStdin", (), {"isatty": lambda self: True})()
+    )
+    monkeypatch.setattr("builtins.input", lambda _prompt: "5")
+    monkeypatch.setattr(rc_cli, "_prompt_opencode_install", lambda: None)
+
+    args = argparse.Namespace(force=False)
+    code = rc_cli.cmd_init(args)
+    assert code == 0
+
+    config = (tmp_path / "config.arc.yaml").read_text(encoding="utf-8")
+    assert "enabled: false               # Master switch (disabled for ACP)" in config
+    assert "enabled: true                # Master switch (default: true)" not in config
+
+
 def test_cmd_run_missing_config_shows_init_hint(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:


### PR DESCRIPTION
## Summary

Fixes #272.

When `researchclaw init` is run with provider option `5) acp`, the generated `config.arc.yaml` now disables `opencode.enabled`. This prevents the `Model not found: openai/gpt-4o` retry loop that fires on every Stage 10 invocation under ACP. CodeAgent fallback already handles code generation in that mode, so Beast Mode adds no value.

## Changes

- `cmd_init()` (`researchclaw/cli.py`): generated config sets `opencode.enabled: false` when provider is `acp`.
- `tests/test_rc_cli.py`: new test `test_cmd_init_acp_disables_opencode`.

## Testing

- [x] `pytest tests/test_rc_cli.py -k init -v` passes (new test + existing `cmd_init` tests).
- [x] Manual: `researchclaw init` with provider `5) acp` → generated config has `opencode.enabled: false`.
- [x] Manual: `researchclaw init` with provider `1) openai` → generated config has `opencode.enabled: true` (unchanged).
