### PR TITLE
domain detector: remove bare 'drug' keyword that misclassifies network-medicine topics

### DIFF
--- a/researchclaw/domains/detector.py
+++ b/researchclaw/domains/detector.py
@@ -309,8 +309,12 @@ _KEYWORD_RULES: list[tuple[list[str], str]] = [
     # Chemistry
     (["quantum chemistry", "dft", "hartree-fock", "pyscf", "ccsd",
       "molecular orbital", "basis set"], "chemistry_qm"),
-    (["molecular property", "smiles", "rdkit", "fingerprint", "drug",
-      "binding affinity", "admet"], "chemistry_molprop"),
+    # NOTE: bare "drug" removed — too broad, was mis-matching
+    # "drug repurposing" / "drug-target" network-medicine topics into
+    # chemistry_molprop and injecting RDKit/SMILES/QM9 guidance into
+    # network-medicine experiments. Use specific cheminformatics terms instead.
+    (["molecular property prediction", "smiles", "rdkit", "morgan fingerprint",
+      "ecfp", "binding affinity", "admet", "qsar"], "chemistry_molprop"),
     (["chemistry", "molecule", "reaction", "catalyst"], "chemistry_general"),
 
     # Biology

--- a/tests/test_domain_detector.py
+++ b/tests/test_domain_detector.py
@@ -337,3 +337,38 @@ class TestDetectionAccuracy:
             f"Full detection accuracy: {accuracy:.1%} ({correct}/{total}). "
             f"Expected > 90%."
         )
+
+
+# ---------------------------------------------------------------------------
+# Regression: drug repurposing must not bleed into chemistry_molprop
+# ---------------------------------------------------------------------------
+
+
+class TestDrugKeywordRegression:
+    """Regression tests for the bare 'drug' keyword removal from chemistry_molprop.
+
+    Previously the chemistry_molprop rule contained a bare 'drug' keyword that
+    caused network-medicine topics (drug repurposing, drug-target interaction)
+    to be routed into chemistry_molprop, injecting RDKit/SMILES/QM9 prompt
+    guidance that overrode the user's domain-specific overrides.
+    """
+
+    def setup_method(self):
+        _profile_cache.clear()
+
+    def test_drug_repurposing_falls_back_to_generic(self):
+        """Network-medicine drug-repurposing topics must NOT misclassify as chemistry."""
+        assert detect_domain_id("COVID-19 drug repurposing using gene-disease associations") == "generic"
+        assert detect_domain_id("Drug repurposing with network medicine") == "generic"
+        assert detect_domain_id("drug-target interaction network analysis") == "generic"
+        assert detect_domain_id("drug-disease association using network propagation") == "generic"
+
+    def test_cheminformatics_topics_still_detected(self):
+        """Real cheminformatics topics must still route to chemistry_molprop
+        via the more specific keywords that replaced the bare 'drug'."""
+        # New specific keywords added by this patch
+        assert _keyword_detect("QSAR model with Morgan fingerprints") == "chemistry_molprop"
+        assert _keyword_detect("ECFP fingerprint for binding affinity") == "chemistry_molprop"
+        # Pre-existing keywords (rdkit, binding affinity, admet) still trigger
+        assert _keyword_detect("Drug binding affinity with RDKit fingerprints") == "chemistry_molprop"
+        assert _keyword_detect("ADMET descriptor prediction") == "chemistry_molprop"


### PR DESCRIPTION
## Summary

Fix a domain-detection false positive where network-medicine topics such as drug repurposing were incorrectly routed to `chemistry_molprop`.

The fix removes the overly broad bare `"drug"` keyword and tightens related chemistry keywords so that ARC no longer injects RDKit / SMILES / QM9 guidance into non-cheminformatics topics.

## Motivation

When running ARC end-to-end on the topic `"COVID-19 drug repurposing using gene-disease associations"`, the pipeline classified the topic as `chemistry_molprop` and started emitting molecular-property prediction prompts (SMILES parsing, fingerprint computation, QM9 dataset references) into Stage 7-10. The chemistry profile overlay effectively took precedence over the intended network-medicine prompt customizations, because the `chemistry_molprop` profile path is applied *after* `PromptManager.for_stage(...)` returns.

Root cause: the keyword list `["molecular property", "smiles", "rdkit", "fingerprint", "drug", "binding affinity", "admet"]` contained the bare token `"drug"`, which matches any phrase containing the substring (with word-boundary regex). `"drug repurposing"`, `"drug-target interaction"`, `"drug-disease association"` all matched.

## Changes

- Remove the bare `"drug"` keyword from `chemistry_molprop`.
- Tighten three other keywords to be more specific:
  - `"molecular property"` → `"molecular property prediction"`
  - `"fingerprint"` → `"morgan fingerprint"`
  - Add `"ecfp"` and `"qsar"` as new specific tokens.
- Keep `"smiles"`, `"rdkit"`, `"binding affinity"`, `"admet"` — these are unambiguously cheminformatics and were unaffected by the bug.

## Verification

Two regression tests added in `tests/test_domain_detector.py::TestDrugKeywordRegression`:

- `test_drug_repurposing_falls_back_to_generic` — asserts that the following all return `"generic"`:
  - `"COVID-19 drug repurposing using gene-disease associations"`
  - `"Drug repurposing with network medicine"`
  - `"drug-target interaction network analysis"`
  - `"drug-disease association using network propagation"`
- `test_cheminformatics_topics_still_detected` — asserts that real cheminformatics topics (`"QSAR model with Morgan fingerprints"`, `"ECFP fingerprint for binding affinity"`, `"Drug binding affinity with RDKit fingerprints"`, `"ADMET descriptor prediction"`) all still route to `chemistry_molprop` via the more specific keyword set. The positive `"Drug binding affinity with RDKit fingerprints"` case is expected to match via `binding affinity` / `rdkit`, not via the removed bare `drug` keyword.

All 39 tests in `tests/test_domain_detector.py` pass:

```
============================== 39 passed in 0.53s ==============================
```

## Scope

This PR is intentionally limited to the `chemistry_molprop` domain-detection rule.

The bare `"drug"` keyword is the offending term. The related keyword tightenings are included because they touch the same rule and prevent the same class of broad keyword collision, such as `"fingerprint"` matching non-chemical uses like behavioural fingerprinting.

## Test plan

- [x] `pytest tests/test_domain_detector.py` — 39 passed
- [x] Regression: `detect_domain_id("COVID-19 drug repurposing ...")` returns `"generic"`
- [x] Regression: `detect_domain_id("drug-target interaction ...")` returns `"generic"`
- [x] Regression: existing chemistry_molprop topics still detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
