### PR TITLE
feat: add support for Ollama as a local LLM provider

### DIFF
--- a/config.researchclaw.example.yaml
+++ b/config.researchclaw.example.yaml
@@ -50,6 +50,14 @@ llm:
   # primary_model: "MiniMax-M2.5"
   # fallback_models:
   #   - "MiniMax-M2.5-highspeed"
+  # --- Ollama (local) example ---
+  # provider: "ollama"
+  # base_url: "http://localhost:11434/v1"
+  # api_key_env: ""
+  # api_key: "ollama"
+  # primary_model: "llama3.2"
+  # fallback_models:
+  #   - "mistral"
 
 security:
   hitl_required_stages: [5, 9, 20]

--- a/researchclaw/cli.py
+++ b/researchclaw/cli.py
@@ -775,6 +775,7 @@ _PROVIDER_CHOICES = {
     "3": ("deepseek", "DEEPSEEK_API_KEY"),
     "4": ("minimax", "MINIMAX_API_KEY"),
     "5": ("acp", ""),
+    "6": ("ollama", ""),
 }
 
 _PROVIDER_URLS = {
@@ -782,6 +783,7 @@ _PROVIDER_URLS = {
     "openrouter": "https://openrouter.ai/api/v1",
     "deepseek": "https://api.deepseek.com/v1",
     "minimax": "https://api.minimaxi.com/v1",
+    "ollama": "http://localhost:11434/v1",
 }
 
 _PROVIDER_MODELS = {
@@ -792,6 +794,7 @@ _PROVIDER_MODELS = {
     ),
     "deepseek": ("deepseek-chat", ["deepseek-reasoner"]),
     "minimax": ("MiniMax-M2.5", ["MiniMax-M2.5-highspeed"]),
+    "ollama": ("llama3.2", ["mistral", "qwen2.5:7b"]),
 }
 
 
@@ -828,6 +831,7 @@ def cmd_init(args: argparse.Namespace) -> int:
         print("  3) deepseek     (requires DEEPSEEK_API_KEY)")
         print("  4) minimax      (requires MINIMAX_API_KEY)")
         print("  5) acp          (local AI agent — no API key needed)")
+        print("  6) ollama       (local Ollama server — no API key needed)")
         try:
             raw = input("Choice [1]: ").strip()
         except (EOFError, KeyboardInterrupt):
@@ -850,6 +854,14 @@ def cmd_init(args: argparse.Namespace) -> int:
             'base_url: "https://api.openai.com/v1"', 'base_url: ""'
         )
         content = content.replace('api_key_env: "OPENAI_API_KEY"', 'api_key_env: ""')
+    elif provider == "ollama":
+        # Ollama runs locally — set base_url, clear api_key_env, set dummy key
+        base_url = _PROVIDER_URLS["ollama"]
+        content = content.replace(
+            'base_url: "https://api.openai.com/v1"', f'base_url: "{base_url}"'
+        )
+        content = content.replace('api_key_env: "OPENAI_API_KEY"', 'api_key_env: ""')
+        content = content.replace('api_key: ""', 'api_key: "ollama"')
     else:
         base_url = _PROVIDER_URLS.get(provider, "https://api.openai.com/v1")
         content = content.replace(
@@ -878,6 +890,12 @@ def cmd_init(args: argparse.Namespace) -> int:
         print("  1. Ensure your ACP agent is installed and on PATH")
         print("  2. Edit config.arc.yaml to set llm.acp.agent if needed")
         print("  3. Run: researchclaw doctor")
+    elif provider == "ollama":
+        print("\nNext steps:")
+        print("  1. Ensure Ollama is running: ollama serve")
+        print("  2. Pull your model: ollama pull llama3.2")
+        print("  3. Edit config.arc.yaml to set llm.primary_model to your model name")
+        print("  4. Run: researchclaw doctor")
     else:
         env_var = api_key_env or "OPENAI_API_KEY"
         print(f"\nNext steps:")

--- a/researchclaw/config.py
+++ b/researchclaw/config.py
@@ -1068,8 +1068,10 @@ def validate_config(
 
     llm_provider = _get_by_path(data, "llm.provider")
     for key in REQUIRED_FIELDS:
-        # ACP provider doesn't need base_url or api_key_env
-        if llm_provider == "acp" and key in ("llm.base_url", "llm.api_key_env"):
+        # ACP and Ollama don't need api_key_env (local/keyless providers)
+        if llm_provider in ("acp", "ollama") and key == "llm.api_key_env":
+            continue
+        if llm_provider == "acp" and key == "llm.base_url":
             continue
         value = _get_by_path(data, key)
         if _is_blank(value):

--- a/researchclaw/llm/__init__.py
+++ b/researchclaw/llm/__init__.py
@@ -32,6 +32,9 @@ PROVIDER_PRESETS = {
     "minimax": {
         "base_url": "https://api.minimaxi.com/v1",
     },
+    "ollama": {
+        "base_url": "http://localhost:11434/v1",
+    },
     "openai-compatible": {
         "base_url": None,  # Use user-provided base_url
     },


### PR DESCRIPTION
# Why

Ollama serves an OpenAI-compatible API, so almost all the compatibility work was already there. Existing `LLMClient` just needed a preset pointing at `localhost:11434/v1`. The bulk of this PR is wiring up the `researchclaw init` wizard (choice 6) and fixing the validator to not demand an `api_key_env` for keyless local providers (same exemption `ACP` already had).

# Changes

- `llm/__init__.py`, add "ollama" preset
- `cli.py`, add Ollama to provider menu, URL table, and default model suggestions
- `config.py`, extend the `ACP` keyless exemption to Ollama
- `config.researchclaw.example.yaml`, add commented Ollama example block

<img width="686" height="206" alt="image" src="https://github.com/user-attachments/assets/e2ce328d-4402-47d1-9d15-54928c772c70" />

> Worth noting: yes, a default `llama3.2:8b` is weak. But the fallback chains for other providers already include things like `gpt-4o-mini` and `MiniMax-M2.5-highspeed`, so the bar isn't that high. Researchers running larger local models can get full pipeline access.