### PR TITLE
feat: add clinical sleep domain profile

### DIFF
--- a/researchclaw/data/docker_profiles.yaml
+++ b/researchclaw/data/docker_profiles.yaml
@@ -142,5 +142,6 @@ domain_map:
   mathematics_optimization: math
   mathematics_general: math
   security_detection: security
+  clinical_sleep: generic
   robotics_control: robotics
   generic: generic

--- a/researchclaw/domains/detector.py
+++ b/researchclaw/domains/detector.py
@@ -269,6 +269,14 @@ _KEYWORD_RULES: list[tuple[list[str], str]] = [
       "neural dynamics", "population coding", "neural decoding",
       "raster plot", "firing rate", "synaptic", "connectome"],
      "neuroscience_computational"),
+    # Clinical sleep / perioperative monitoring. Keep these terms specific so
+    # general EEG/fMRI neuroscience topics still route to neuroscience_imaging.
+    (["polysomnography", "sleep apnea", "sleep staging", "sleep stage",
+      "apnea-hypopnea", "apnea hypopnea", "ahi score", "hsat",
+      "obstructive sleep apnea", "respiratory depression",
+      "sedation monitoring", "perioperative respiratory",
+      "airway management", "anesthesia monitoring"],
+     "clinical_sleep"),
     (["fmri", "eeg", "meg", "neuroimaging", "brain imaging",
       "nilearn", "mne-python", "bold signal", "brain network",
       "functional connectivity"], "neuroscience_imaging"),
@@ -413,6 +421,7 @@ Available domains:
 - security_detection: Security/intrusion detection
 - neuroscience_computational: Computational neuroscience (spiking networks, neural dynamics, population coding)
 - neuroscience_imaging: Brain imaging analysis (fMRI, EEG, MEG, functional connectivity)
+- clinical_sleep: Clinical sleep / perioperative monitoring (PSG, HSAT, sleep apnea, respiratory depression)
 - robotics_control: Robotics and control
 - generic: Cannot classify / cross-domain
 

--- a/researchclaw/domains/profiles/clinical_sleep.yaml
+++ b/researchclaw/domains/profiles/clinical_sleep.yaml
@@ -1,0 +1,123 @@
+domain_id: clinical_sleep
+display_name: Clinical Sleep and Perioperative Monitoring
+parent_domain: clinical
+
+experiment_paradigm: comparison
+condition_terminology:
+  baseline: reference clinical workflow
+  proposed: proposed monitoring or analysis method
+  variant: ablation / threshold variant
+  input: de-identified physiologic signal or synthetic clinical cohort
+  metric: sensitivity / specificity / AUROC / calibration error
+
+typical_file_structure:
+  config.py: "Study parameters, cohort simulation settings, and safety thresholds"
+  data.py: "Synthetic or de-identified signal loading with schema validation"
+  preprocessing.py: "Signal cleaning, artifact handling, and epoch alignment"
+  evaluate.py: "Clinical metrics, calibration, and false-alarm analysis"
+  main.py: "Entry point: load data -> preprocess -> run method -> evaluate"
+
+entry_point: main.py
+
+core_libraries:
+  - numpy
+  - scipy
+  - pandas
+  - scikit-learn
+  - matplotlib
+
+docker_image: researchclaw/sandbox-generic:latest
+gpu_required: false
+
+pip_packages:
+  - numpy
+  - scipy
+  - pandas
+  - scikit-learn
+  - matplotlib
+
+metric_types:
+  - scalar
+  - structured
+  - confusion
+
+standard_baselines:
+  - clinician-scored PSG or HSAT respiratory-event labels
+  - rule-based apnea-hypopnea event detector
+  - standard signal-quality and motion-artifact rejection baseline
+  - logistic-regression or threshold-based risk classifier
+
+evaluation_protocol: >
+  Use synthetic data or explicitly de-identified physiologic signal exports.
+  Compare predictions against a stated reference standard such as clinician-scored
+  PSG/HSAT epochs, validated respiratory-event labels, or documented simulation
+  ground truth. Report sensitivity, specificity, AUROC, calibration, confidence
+  intervals, and false-alarm burden. Separate research findings from clinical
+  recommendations and do not present generated outputs as patient-specific advice.
+
+statistical_tests:
+  - bootstrap_confidence_interval
+  - mcnemar_test
+  - calibration_curve
+  - bland_altman_analysis
+
+output_formats:
+  - latex_table
+  - confusion_matrix
+  - calibration_plot
+  - time_series_epoch_plot
+
+figure_types:
+  - confusion_matrix
+  - roc_curve
+  - calibration_curve
+  - epoch_timeline
+  - bland_altman_plot
+
+github_search_terms:
+  - sleep apnea detection python
+  - polysomnography signal processing
+  - physiological signal monitoring python
+  - perioperative respiratory monitoring
+  - anesthesia airway monitoring
+
+paper_keywords:
+  - sleep apnea
+  - polysomnography
+  - PSG
+  - HSAT
+  - perioperative monitoring
+  - anesthesia
+  - airway management
+  - respiratory depression
+  - physiological signal processing
+
+compute_budget_guidance: |
+  Clinical signal experiments should be lightweight and reproducible:
+  - Prefer synthetic cohorts or small de-identified excerpts for tests
+  - Keep epoch-level analyses bounded (for example, one overnight simulation)
+  - Use bootstrapping with a capped number of resamples when time-limited
+
+dataset_guidance: |
+  Clinical safety and privacy rules:
+  - Do NOT generate, request, or expose identifiable patient information
+  - Use synthetic data by default unless a de-identified public dataset is explicitly provided
+  - State the reference standard: PSG, HSAT, clinician-scored event labels, or simulation ground truth
+  - Keep research outputs separate from diagnosis, treatment, or monitoring recommendations
+
+code_generation_hints: |
+  Clinical sleep / anesthesia monitoring code requirements:
+  1. Use explicit units for every physiologic signal (seconds, BPM, SpO2 %, event count/hour).
+  2. Validate input schema before analysis; reject missing timestamps or unlabeled units.
+  3. Align predictions and reference labels by fixed epochs before scoring.
+  4. Report sensitivity, specificity, AUROC, positive predictive value, negative predictive value, and false alarms per hour where applicable.
+  5. Include uncertainty: bootstrap confidence intervals or clearly marked simulation variability.
+  6. Add a safety note in generated reports: this is research/engineering output, not patient-specific medical advice.
+  7. Output results.json with keys for metrics, reference_standard, cohort_size, signal_units, and safety_limitations.
+
+result_analysis_hints: |
+  Clinical result analysis:
+  - Prioritize false negatives and false alarms, not only average accuracy
+  - Stratify errors by sleep stage, body position, motion artifact, or signal quality when available
+  - Discuss calibration and threshold sensitivity before proposing deployment
+  - State whether the result is validated against PSG/HSAT, clinician labels, or synthetic ground truth

--- a/tests/test_domain_detector.py
+++ b/tests/test_domain_detector.py
@@ -76,6 +76,7 @@ class TestProfileLoading:
             "biology_singlecell",
             "economics_empirical",
             "security_detection",
+            "clinical_sleep",
             "robotics_control",
         ]:
             profile = get_profile(domain_id)
@@ -133,6 +134,15 @@ class TestKeywordDetection:
 
     def test_security_keywords(self):
         assert _keyword_detect("intrusion detection system for network traffic") == "security_detection"
+
+    def test_clinical_sleep_keywords(self):
+        assert _keyword_detect("sleep apnea detection from polysomnography") == "clinical_sleep"
+        assert _keyword_detect("EEG sleep staging for apnea screening") == "clinical_sleep"
+        assert _keyword_detect("perioperative respiratory depression during sedation monitoring") == "clinical_sleep"
+        assert _keyword_detect("airway management risk prediction after anesthesia") == "clinical_sleep"
+
+    def test_general_eeg_still_routes_to_neuroscience(self):
+        assert _keyword_detect("EEG functional connectivity analysis with MNE") == "neuroscience_imaging"
 
     def test_robotics_keywords(self):
         assert _keyword_detect("robot manipulation with MuJoCo") == "robotics_control"
@@ -301,6 +311,11 @@ class TestDetectionAccuracy:
         # Security topics
         ("Network intrusion detection system", "security_detection"),
         ("Malware classification using random forest", "security_detection"),
+        # Clinical sleep / perioperative monitoring topics
+        ("Sleep apnea detection from polysomnography", "clinical_sleep"),
+        ("EEG sleep staging for apnea screening", "clinical_sleep"),
+        ("Perioperative respiratory depression during sedation monitoring", "clinical_sleep"),
+        ("Airway management risk prediction after anesthesia", "clinical_sleep"),
         # Robotics topics
         ("Robot manipulation policy learning", "robotics_control"),
         ("Locomotion control with MuJoCo", "robotics_control"),


### PR DESCRIPTION
## Summary

- Add a `clinical_sleep` domain profile for clinical sleep and perioperative monitoring research
- Route specific topics such as sleep apnea, PSG/HSAT, respiratory depression, sedation monitoring, airway management, and anesthesia monitoring to the new profile
- Add regression coverage so general EEG/fMRI neuroscience topics still route to `neuroscience_imaging`

## Motivation

AutoResearchClaw already has domain profiles for ML, HEP, biology, neuroscience, robotics, and security. Clinical sleep / perioperative monitoring is a distinct research setting: it often compares models or rules against clinician-scored PSG/HSAT epochs, de-identified physiologic signals, synthetic cohorts, and safety-focused metrics.

From a clinical/anesthesia perspective, topics around sleep apnea, sedation-related respiratory depression, and airway monitoring need different guidance from generic neuroscience or generic computational research. This profile adds that guidance without introducing a new runtime dependency or execution backend.

## Verification

- `git diff --check`
- `/tmp/arc-pr-venv/bin/python -m pytest tests/test_domain_detector.py -q`

Result: `41 passed`

## Risk / Compatibility

Low. The new keyword rules are intentionally specific, and the PR includes a regression test that keeps general EEG functional-connectivity topics on `neuroscience_imaging`. The new profile maps to the existing generic sandbox.
