### PR TITLE
IMP-21: gate Stage 6 (knowledge_extract) on non-empty shortlist

### DIFF
--- a/researchclaw/pipeline/stage_impls/_literature.py
+++ b/researchclaw/pipeline/stage_impls/_literature.py
@@ -822,6 +822,53 @@ def _execute_knowledge_extract(
 ) -> StageResult:
     shortlist = _read_prior_artifact(run_dir, "shortlist.jsonl") or ""
 
+    # IMP-21: Defensive gate — refuse to run on an empty/missing shortlist.
+    # Stage 5 (LITERATURE_SCREEN) returns PAUSED with decision="rejected_all"
+    # when its strict screen rejects all candidates, in which case no
+    # shortlist.jsonl is written. Without this gate, Stage 6 spends an LLM
+    # turn extracting knowledge cards from empty input, produces low-quality
+    # fallback cards, and lets downstream stages cascade on garbage.
+    #
+    # We return PAUSED (mirroring Stage 5's pattern) rather than
+    # BLOCKED_APPROVAL because the runner halts on PAUSED unconditionally
+    # (runner.py: ``if result.status == StageStatus.PAUSED: break``), whereas
+    # BLOCKED_APPROVAL only halts when ``stop_on_gate=True`` — and
+    # ``--auto-approve`` explicitly sets ``stop_on_gate=False``, which is
+    # the exact scenario this gate must prevent the cascade for.
+    if not _parse_jsonl_rows(shortlist):
+        logger.warning(
+            "Stage 6: shortlist.jsonl is empty or missing — Stage 5 likely "
+            "rejected all candidates. Refusing to extract from empty input."
+        )
+        (stage_dir / "knowledge_meta.json").write_text(
+            json.dumps(
+                {
+                    "outcome": "upstream_empty_shortlist",
+                    "shortlist_rows": 0,
+                    "note": (
+                        "Stage 6 (knowledge_extract) requires a non-empty "
+                        "shortlist.jsonl from Stage 5 (literature_screen). "
+                        "Resolve Stage 5 (refine search queries, manually "
+                        "approve a shortlist, or restart from "
+                        "search_strategy) before resuming."
+                    ),
+                },
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+        return StageResult(
+            stage=Stage.KNOWLEDGE_EXTRACT,
+            status=StageStatus.PAUSED,
+            artifacts=("knowledge_meta.json",),
+            error=(
+                "Cannot extract knowledge cards: shortlist.jsonl is empty "
+                "or missing. Resolve Stage 5 (literature_screen) first."
+            ),
+            evidence_refs=("stage-06/knowledge_meta.json",),
+            decision="upstream_blocked",
+        )
+
     # Inject web context from Stage 4 if available
     web_context = _read_prior_artifact(run_dir, "web_context.md") or ""
     if web_context:

--- a/tests/test_rc_executor.py
+++ b/tests/test_rc_executor.py
@@ -3599,3 +3599,148 @@ class TestExperimentValidatorPrecision:
             in issue
             for issue in issues
         )
+
+
+# ============================================================
+# IMP-21: Stage 6 (knowledge_extract) refuses to run on empty shortlist
+# ============================================================
+
+
+class TestIMP21_KnowledgeExtractEmptyShortlistGate:
+    """IMP-21: Stage 6 must short-circuit when Stage 5
+    (literature_screen) has produced no shortlist (PAUSED state with
+    ``decision="rejected_all"``). Without this gate, Stage 6 spends an
+    LLM turn extracting cards from empty input, produces low-quality
+    fallback content, and lets downstream stages cascade on garbage.
+
+    We use ``StageStatus.PAUSED`` (not ``BLOCKED_APPROVAL``) because the
+    runner halts on PAUSED unconditionally, whereas BLOCKED_APPROVAL only
+    halts when ``stop_on_gate=True`` — and ``--auto-approve`` explicitly
+    sets ``stop_on_gate=False``, which is the exact scenario this gate
+    must prevent the cascade for. Mirrors the existing Stage 5 pattern
+    (literature_screen returns PAUSED with ``decision="rejected_all"``).
+    """
+
+    def test_returns_paused_when_shortlist_missing(
+        self, rc_config: RCConfig, adapters: AdapterBundle, run_dir: Path
+    ) -> None:
+        """No stage-05*/shortlist.jsonl exists → PAUSED (halts pipeline)."""
+        from researchclaw.pipeline.stage_impls._literature import (
+            _execute_knowledge_extract,
+        )
+
+        stage_dir = run_dir / "stage-06"
+        stage_dir.mkdir()
+
+        result = _execute_knowledge_extract(
+            stage_dir=stage_dir,
+            run_dir=run_dir,
+            config=rc_config,
+            adapters=adapters,
+            llm=None,  # gate must trigger before any LLM call
+        )
+
+        assert result.status == StageStatus.PAUSED
+        assert result.stage == Stage.KNOWLEDGE_EXTRACT
+        assert result.error is not None
+        assert "shortlist" in result.error.lower()
+        assert result.decision == "upstream_blocked"
+        meta_path = stage_dir / "knowledge_meta.json"
+        assert meta_path.is_file(), "Gate must write knowledge_meta.json"
+        meta = json.loads(meta_path.read_text())
+        assert meta["outcome"] == "upstream_empty_shortlist"
+        assert meta["shortlist_rows"] == 0
+
+    def test_returns_paused_when_shortlist_empty_string(
+        self, rc_config: RCConfig, adapters: AdapterBundle, run_dir: Path
+    ) -> None:
+        """stage-05/shortlist.jsonl exists but is 0-byte → PAUSED."""
+        from researchclaw.pipeline.stage_impls._literature import (
+            _execute_knowledge_extract,
+        )
+
+        s5_dir = run_dir / "stage-05"
+        s5_dir.mkdir()
+        (s5_dir / "shortlist.jsonl").write_text("", encoding="utf-8")
+
+        stage_dir = run_dir / "stage-06"
+        stage_dir.mkdir()
+
+        result = _execute_knowledge_extract(
+            stage_dir=stage_dir,
+            run_dir=run_dir,
+            config=rc_config,
+            adapters=adapters,
+            llm=None,
+        )
+
+        assert result.status == StageStatus.PAUSED
+        assert "stage-06/knowledge_meta.json" in result.evidence_refs
+
+    def test_returns_paused_when_shortlist_only_whitespace(
+        self, rc_config: RCConfig, adapters: AdapterBundle, run_dir: Path
+    ) -> None:
+        """stage-05/shortlist.jsonl is just whitespace → PAUSED."""
+        from researchclaw.pipeline.stage_impls._literature import (
+            _execute_knowledge_extract,
+        )
+
+        s5_dir = run_dir / "stage-05"
+        s5_dir.mkdir()
+        (s5_dir / "shortlist.jsonl").write_text("\n\n  \n", encoding="utf-8")
+
+        stage_dir = run_dir / "stage-06"
+        stage_dir.mkdir()
+
+        result = _execute_knowledge_extract(
+            stage_dir=stage_dir,
+            run_dir=run_dir,
+            config=rc_config,
+            adapters=adapters,
+            llm=None,
+        )
+
+        assert result.status == StageStatus.PAUSED
+
+    def test_proceeds_when_shortlist_has_at_least_one_row(
+        self, rc_config: RCConfig, adapters: AdapterBundle, run_dir: Path
+    ) -> None:
+        """stage-05/shortlist.jsonl has >=1 valid row → gate passes,
+        stage proceeds (but exits early since llm=None and no real
+        cards can be generated, so we just assert it didn't BLOCK)."""
+        from researchclaw.pipeline.stage_impls._literature import (
+            _execute_knowledge_extract,
+        )
+
+        s5_dir = run_dir / "stage-05"
+        s5_dir.mkdir()
+        (s5_dir / "shortlist.jsonl").write_text(
+            json.dumps(
+                {
+                    "paper_id": "oalex-W123",
+                    "title": "A Real Paper About Label Noise",
+                    "abstract": "We study symmetric noise on MNIST.",
+                    "year": 2024,
+                    "cite_key": "doe2024noise",
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        stage_dir = run_dir / "stage-06"
+        stage_dir.mkdir()
+
+        result = _execute_knowledge_extract(
+            stage_dir=stage_dir,
+            run_dir=run_dir,
+            config=rc_config,
+            adapters=adapters,
+            llm=None,  # no LLM, but gate must not trigger
+        )
+
+        # Gate did NOT trigger — stage proceeded past the check.
+        # Without an LLM, the stage falls back to a template-card path,
+        # which is its existing behaviour (not gated by IMP-21).
+        assert result.status != StageStatus.PAUSED
+        assert result.stage == Stage.KNOWLEDGE_EXTRACT

--- a/tests/test_rc_runner.py
+++ b/tests/test_rc_runner.py
@@ -1049,3 +1049,80 @@ class TestPromoteBestStage14DegenerateDetection:
         data = json.loads(best_path.read_text(encoding="utf-8"))
         pm = data["metrics_summary"]["primary_metric"]
         assert pm["mean"] == 1e-10
+
+
+# ============================================================
+# IMP-21: Runner-level integration test — Stage 6 gate must halt
+# the pipeline under --auto-approve (stop_on_gate=False)
+# ============================================================
+
+
+def test_imp21_stage6_empty_shortlist_gate_halts_pipeline_under_auto_approve(
+    monkeypatch: pytest.MonkeyPatch,
+    run_dir: Path,
+    rc_config: RCConfig,
+    adapters: AdapterBundle,
+) -> None:
+    """IMP-21 regression: when Stage 6 returns PAUSED via the empty-shortlist
+    gate, the runner MUST halt the pipeline even with stop_on_gate=False
+    (the --auto-approve scenario). Stage 7 (KNOWLEDGE_GRAPH) and beyond
+    must NOT execute, otherwise the cascade-on-garbage problem returns.
+
+    This test would fail if the gate returned BLOCKED_APPROVAL instead of
+    PAUSED — BLOCKED_APPROVAL only halts when stop_on_gate=True, and
+    --auto-approve sets stop_on_gate=False.
+    """
+
+    def mock_execute_stage(stage: Stage, **kwargs: Any) -> StageResult:
+        _ = kwargs
+        if stage == Stage.KNOWLEDGE_EXTRACT:
+            # Simulate the IMP-21 gate firing on empty shortlist
+            return StageResult(
+                stage=Stage.KNOWLEDGE_EXTRACT,
+                status=StageStatus.PAUSED,
+                artifacts=("knowledge_meta.json",),
+                error=(
+                    "Cannot extract knowledge cards: shortlist.jsonl is "
+                    "empty or missing. Resolve Stage 5 first."
+                ),
+                evidence_refs=("stage-06/knowledge_meta.json",),
+                decision="upstream_blocked",
+            )
+        return _done(stage)
+
+    monkeypatch.setattr(rc_runner, "execute_stage", mock_execute_stage)
+    results = rc_runner.execute_pipeline(
+        run_dir=run_dir,
+        run_id="run-imp21-gate",
+        config=rc_config,
+        adapters=adapters,
+        stop_on_gate=False,  # the --auto-approve scenario
+        auto_approve_gates=True,
+    )
+
+    # Pipeline halts at Stage 6
+    assert results[-1].stage == Stage.KNOWLEDGE_EXTRACT
+    assert results[-1].status == StageStatus.PAUSED
+    assert results[-1].decision == "upstream_blocked"
+    assert len(results) == int(Stage.KNOWLEDGE_EXTRACT)
+
+    # Stage 7 (SYNTHESIS) and downstream stages MUST NOT have run
+    executed_stages = {r.stage for r in results}
+    for downstream in (
+        Stage.SYNTHESIS,
+        Stage.HYPOTHESIS_GEN,
+        Stage.EXPERIMENT_DESIGN,
+        Stage.PAPER_OUTLINE,
+        Stage.EXPORT_PUBLISH,
+    ):
+        assert downstream not in executed_stages, (
+            f"IMP-21 regression: {downstream.name} should not have run after "
+            f"Stage 6 PAUSED (cascade-on-garbage prevention failed)"
+        )
+
+    # Pipeline summary reports paused outcome
+    summary = json.loads(
+        (run_dir / "pipeline_summary.json").read_text(encoding="utf-8")
+    )
+    assert summary["final_status"] == "paused"
+    assert summary["stages_paused"] == 1


### PR DESCRIPTION
When Stage 5 (LITERATURE_SCREEN) returns PAUSED with decision="rejected_all" because its strict screen rejects all candidates, no shortlist.jsonl is written. Stage 6 then runs on empty input, spends an LLM turn extracting cards from nothing, produces low-quality fallback content, and lets downstream stages cascade on garbage.

Add a defensive entry-point gate in _execute_knowledge_extract: if shortlist.jsonl is missing, empty, or whitespace-only, return PAUSED with a knowledge_meta.json explaining the upstream issue. The gate fires before any LLM call, so a misconfigured run does not waste budget.

Why PAUSED, not BLOCKED_APPROVAL
--------------------------------
The runner halts on PAUSED unconditionally
(runner.py: 'if result.status == StageStatus.PAUSED: break'), whereas BLOCKED_APPROVAL only halts when stop_on_gate=True — and --auto-approve explicitly sets stop_on_gate=False, which is the exact scenario this gate must prevent the cascade for. Returning BLOCKED_APPROVAL would write the meta file but still allow Stages 7-23 to run on missing input, defeating the gate's purpose.

This mirrors the existing Stage 5 pattern, which also returns PAUSED with decision="rejected_all" when its strict screen rejects all candidates (literature.py:762-769). Stage 5 only becomes BLOCKED_APPROVAL because it is in GATE_STAGES and the executor wraps gate-stage results; KNOWLEDGE_EXTRACT is not a gate stage, so its PAUSED status is preserved end-to-end and halts the pipeline regardless of stop_on_gate.

Tests
-----
Adds 4 unit tests in TestIMP21_KnowledgeExtractEmptyShortlistGate (tests/test_rc_executor.py) covering: missing file, empty file, whitespace-only file, and the positive case where a single valid row passes the gate.

Adds 1 runner-level integration test in tests/test_rc_runner.py that drives execute_pipeline with stop_on_gate=False (the --auto-approve scenario) and asserts:
  (a) pipeline halts at Stage 6 with status=PAUSED
  (b) Stage 7 (SYNTHESIS) and downstream stages 8-23 never execute
  (c) pipeline_summary.json reports final_status="paused"
This regression test would fail if the gate returned BLOCKED_APPROVAL — verified by temporarily flipping the mock and seeing all 23 stages execute.

Reproduction
------------
rc-20260530-075008-438447 in our smoke-test run hit this exact path (Stage 5 rejected all candidates → Stage 6 ran on empty shortlist → cascade failure into Stage 9 plan-budget overflow).