### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/config.researchclaw.example.yaml
+++ b/config.researchclaw.example.yaml
@@ -47,9 +47,10 @@ llm:
   # --- MiniMax provider example ---
   # provider: "minimax"
   # api_key_env: "MINIMAX_API_KEY"
-  # primary_model: "MiniMax-M2.5"
+  # primary_model: "MiniMax-M3"
   # fallback_models:
-  #   - "MiniMax-M2.5-highspeed"
+  #   - "MiniMax-M2.7"
+  #   - "MiniMax-M2.7-highspeed"
   # --- Ollama (local) example ---
   # provider: "ollama"
   # base_url: "http://localhost:11434/v1"

--- a/researchclaw/cli.py
+++ b/researchclaw/cli.py
@@ -793,7 +793,7 @@ _PROVIDER_MODELS = {
         ["google/gemini-pro-1.5", "meta-llama/llama-3.1-70b-instruct"],
     ),
     "deepseek": ("deepseek-chat", ["deepseek-reasoner"]),
-    "minimax": ("MiniMax-M2.5", ["MiniMax-M2.5-highspeed"]),
+    "minimax": ("MiniMax-M3", ["MiniMax-M2.7", "MiniMax-M2.7-highspeed"]),
     "ollama": ("llama3.2", ["mistral", "qwen2.5:7b"]),
 }
 

--- a/tests/test_minimax_provider.py
+++ b/tests/test_minimax_provider.py
@@ -41,14 +41,14 @@ class _DummyHTTPResponse:
 def _make_minimax_client(
     *,
     api_key: str = "test-minimax-key",
-    primary_model: str = "MiniMax-M2.5",
+    primary_model: str = "MiniMax-M3",
     fallback_models: list[str] | None = None,
 ) -> LLMClient:
     config = LLMConfig(
         base_url="https://api.minimaxi.com/v1",
         api_key=api_key,
         primary_model=primary_model,
-        fallback_models=fallback_models or ["MiniMax-M2.5-highspeed"],
+        fallback_models=fallback_models or ["MiniMax-M2.7", "MiniMax-M2.7-highspeed"],
     )
     return LLMClient(config)
 
@@ -83,15 +83,15 @@ class TestMiniMaxFromRCConfig:
                 base_url="",
                 api_key="mk-test",
                 api_key_env="",
-                primary_model="MiniMax-M2.5",
-                fallback_models=("MiniMax-M2.5-highspeed",),
+                primary_model="MiniMax-M3",
+                fallback_models=("MiniMax-M2.7", "MiniMax-M2.7-highspeed"),
             ),
         )
         client = LLMClient.from_rc_config(rc_config)
         assert client.config.base_url == "https://api.minimaxi.com/v1"
         assert client.config.api_key == "mk-test"
-        assert client.config.primary_model == "MiniMax-M2.5"
-        assert client.config.fallback_models == ["MiniMax-M2.5-highspeed"]
+        assert client.config.primary_model == "MiniMax-M3"
+        assert client.config.fallback_models == ["MiniMax-M2.7", "MiniMax-M2.7-highspeed"]
 
     def test_from_rc_config_reads_minimax_api_key_from_env(self, monkeypatch):
         monkeypatch.setenv("MINIMAX_API_KEY", "env-minimax-key")
@@ -101,7 +101,7 @@ class TestMiniMaxFromRCConfig:
                 base_url="",
                 api_key="",
                 api_key_env="MINIMAX_API_KEY",
-                primary_model="MiniMax-M2.5",
+                primary_model="MiniMax-M3",
                 fallback_models=(),
             ),
         )
@@ -115,7 +115,7 @@ class TestMiniMaxFromRCConfig:
                 base_url="https://custom-proxy.example/v1",
                 api_key="mk-test",
                 api_key_env="",
-                primary_model="MiniMax-M2.5",
+                primary_model="MiniMax-M3",
                 fallback_models=(),
             ),
         )
@@ -147,7 +147,7 @@ class TestMiniMaxTemperatureClamping:
 
         monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
         client._raw_call(
-            "MiniMax-M2.5",
+            "MiniMax-M3",
             [{"role": "user", "content": "hi"}],
             1024,
             temperature,
@@ -206,17 +206,20 @@ class TestMiniMaxModelChain:
 
     def test_model_chain_default(self):
         client = _make_minimax_client()
-        assert client._model_chain == ["MiniMax-M2.5", "MiniMax-M2.5-highspeed"]
+        assert client._model_chain == [
+            "MiniMax-M3",
+            "MiniMax-M2.7",
+            "MiniMax-M2.7-highspeed",
+        ]
 
     def test_model_chain_custom_fallbacks(self):
         client = _make_minimax_client(
             primary_model="MiniMax-M2.7",
-            fallback_models=["MiniMax-M2.5", "MiniMax-M2.5-highspeed"],
+            fallback_models=["MiniMax-M2.7-highspeed"],
         )
         assert client._model_chain == [
             "MiniMax-M2.7",
-            "MiniMax-M2.5",
-            "MiniMax-M2.5-highspeed",
+            "MiniMax-M2.7-highspeed",
         ]
 
 
@@ -238,7 +241,7 @@ class TestMiniMaxRawCall:
             captured["headers"] = {k.lower(): v for k, v in req.headers.items()}
             return _DummyHTTPResponse(
                 {
-                    "model": "MiniMax-M2.5",
+                    "model": "MiniMax-M3",
                     "choices": [{"message": {"content": "pong"}, "finish_reason": "stop"}],
                     "usage": {"prompt_tokens": 5, "completion_tokens": 1, "total_tokens": 6},
                 }
@@ -246,18 +249,18 @@ class TestMiniMaxRawCall:
 
         monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
         resp = client._raw_call(
-            "MiniMax-M2.5",
+            "MiniMax-M3",
             [{"role": "user", "content": "ping"}],
             1024,
             0.5,
             False,
         )
         assert captured["url"] == "https://api.minimaxi.com/v1/chat/completions"
-        assert captured["body"]["model"] == "MiniMax-M2.5"
+        assert captured["body"]["model"] == "MiniMax-M3"
         assert captured["body"]["temperature"] == 0.5
         assert captured["headers"]["authorization"] == "Bearer test-minimax-key"
         assert resp.content == "pong"
-        assert resp.model == "MiniMax-M2.5"
+        assert resp.model == "MiniMax-M3"
 
     def test_json_mode_uses_system_prompt_fallback(self, monkeypatch):
         """MiniMax models don't support response_format — json_mode should
@@ -273,7 +276,7 @@ class TestMiniMaxRawCall:
 
         monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
         client._raw_call(
-            "MiniMax-M2.5",
+            "MiniMax-M3",
             [{"role": "user", "content": "json"}],
             1024,
             0.5,
@@ -309,8 +312,9 @@ class TestMiniMaxCLI:
         from researchclaw.cli import _PROVIDER_MODELS
 
         primary, fallbacks = _PROVIDER_MODELS["minimax"]
-        assert primary == "MiniMax-M2.5"
-        assert "MiniMax-M2.5-highspeed" in fallbacks
+        assert primary == "MiniMax-M3"
+        assert "MiniMax-M2.7" in fallbacks
+        assert "MiniMax-M2.7-highspeed" in fallbacks
 
 
 # ---------------------------------------------------------------------------
@@ -330,7 +334,7 @@ class TestMiniMaxFactory:
                 base_url="",
                 api_key="mk-factory-test",
                 api_key_env="",
-                primary_model="MiniMax-M2.5",
+                primary_model="MiniMax-M3",
                 fallback_models=(),
             ),
         )
@@ -361,14 +365,14 @@ class TestMiniMaxChatFallback:
             json_mode: bool,
         ) -> LLMResponse:
             calls.append(model)
-            if model == "MiniMax-M2.5":
+            if model == "MiniMax-M3":
                 raise RuntimeError("rate limited")
             return LLMResponse(content="ok", model=model)
 
         monkeypatch.setattr(LLMClient, "_call_with_retry", fake_call_with_retry)
         resp = client.chat([{"role": "user", "content": "test"}])
-        assert calls == ["MiniMax-M2.5", "MiniMax-M2.5-highspeed"]
-        assert resp.model == "MiniMax-M2.5-highspeed"
+        assert calls == ["MiniMax-M3", "MiniMax-M2.7"]
+        assert resp.model == "MiniMax-M2.7"
 
 
 # ---------------------------------------------------------------------------
@@ -388,8 +392,8 @@ class TestMiniMaxLiveAPI:
             LLMConfig(
                 base_url="https://api.minimaxi.com/v1",
                 api_key=os.environ["MINIMAX_API_KEY"],
-                primary_model="MiniMax-M2.5",
-                fallback_models=["MiniMax-M2.5-highspeed"],
+                primary_model="MiniMax-M3",
+                fallback_models=["MiniMax-M2.7", "MiniMax-M2.7-highspeed"],
                 max_tokens=64,
                 timeout_sec=60,
             )
@@ -417,7 +421,7 @@ class TestMiniMaxLiveAPI:
             json_mode=True,
             strip_thinking=True,
         )
-        # MiniMax M2.5 may wrap JSON in markdown code fences
+        # MiniMax models may wrap JSON in markdown code fences
         import re
         text = resp.content.strip()
         fence_match = re.search(r"```(?:json)?\s*\n(.*?)```", text, re.DOTALL)


### PR DESCRIPTION
## Summary
Upgrade MiniMax model configuration to use M3 as the default model.

## Changes
- Add `MiniMax-M3` to the model selection list and set as default
- Keep `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` as fallback alternatives
- Remove older models (`MiniMax-M2.5`/`MiniMax-M2.5-highspeed`)
- Update related unit tests (`tests/test_minimax_provider.py`)
- Update example config (`config.researchclaw.example.yaml`)

## Why
`MiniMax-M3` is the latest MiniMax model, offering:
- 512K context window
- Up to 128K maximum output
- Image input support (OpenAI- and Anthropic-compatible)

## Testing
- 19 unit tests in `tests/test_minimax_provider.py` updated and passing
- Live integration tests (gated on `MINIMAX_API_KEY`) remain skipped by default