### PR TITLE
test: stage output->input contract continuity

### DIFF
--- a/tests/test_rc_contracts.py
+++ b/tests/test_rc_contracts.py
@@ -97,3 +97,32 @@ def test_contracts_follow_stage_sequence_order():
 @pytest.mark.parametrize("stage", STAGE_SEQUENCE)
 def test_contract_stage_int_matches_stage_enum_value(stage: Stage):
     assert int(CONTRACTS[stage].stage) == int(stage)
+
+
+def test_stage_output_satisfies_next_input():
+    # Valida la CONTINUIDAD declarativa output->input a lo largo de STAGE_SEQUENCE:
+    # recorriendo los stages en orden, cada archivo de input_files debe haber sido
+    # declarado como output_files por algun stage ANTERIOR.
+    #
+    # Notas de diseño:
+    # (a) El estado del pipeline fluye via un run_dir compartido (los stages leen/escriben
+    #     archivos en ese directorio), no por paso explicito de argumentos entre stages.
+    #     Por eso este test verifica la COHERENCIA DECLARATIVA de los contratos, no el
+    #     wiring runtime real.
+    # (b) Stages con input_files=() son casos aceptados: TOPIC_INIT (entrada del pipeline,
+    #     no consume nada previo) y KNOWLEDGE_ARCHIVE (opera sobre run_dir, no sobre
+    #     archivos declarados).
+    # (c) Si apareciera un input no cubierto por outputs previos, NO se debe parchear el
+    #     pipeline: documentarlo aqui en ALLOWED_UNSATISFIED con el motivo. Hoy esta VACIO
+    #     porque la cadena no tiene gaps.
+    ALLOWED_UNSATISFIED: set[tuple[Stage, str]] = set()
+
+    produced: set[str] = set()
+    for stage in STAGE_SEQUENCE:
+        for path in CONTRACTS[stage].input_files:
+            if (stage, path) in ALLOWED_UNSATISFIED:
+                continue
+            assert path in produced, (
+                f"{stage.name}: input file {path!r} no fue producido por ningun stage previo"
+            )
+        produced.update(CONTRACTS[stage].output_files)


### PR DESCRIPTION
## Qué
Agrega un único test `test_stage_output_satisfies_next_input` en `tests/test_rc_contracts.py` que valida la continuidad declarativa de la cadena output→input entre stages del pipeline. Recorre `STAGE_SEQUENCE` en orden acumulando los `output_files` de stages previos y verifica que cada `input_files` de un stage haya sido producido antes. Sin tocar código de producción ni agregar dependencias.

## Por qué
Los contratos (`CONTRACTS` en `researchclaw/pipeline/contracts.py`) describen qué consume y produce cada stage. Un gap en esa cadena (un input que ningún stage previo produce) sería un bug de wiring silencioso. Este test fija la coherencia declarativa de los contratos como invariante.

Notas de diseño documentadas en el test:
- El estado fluye vía `run_dir` compartido, no por paso explícito de archivos; el test valida coherencia declarativa, no wiring runtime.
- Stages con `input_files=()` aceptados: `TOPIC_INIT` (entrada del pipeline) y `KNOWLEDGE_ARCHIVE` (opera sobre `run_dir`).
- `ALLOWED_UNSATISFIED` queda VACÍO porque hoy no hay gaps; si apareciera uno se documenta ahí sin parchear el pipeline.

## Cómo verifiqué
```
cd /Users/ema/AutoResearchClaw && python3 -m pytest tests/test_rc_contracts.py -v
```
Resultado: **218 passed** — el nuevo test pasa junto a todos los existentes.