### PR TITLE
Add configurable literature search API keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -612,6 +612,17 @@ llm:
     agent: "claude"                # ACP agent CLI command (claude, codex, gemini, etc.)
     cwd: "."                       # Working directory for the agent
 
+# === Literature search ===
+literature_search:
+  sources: ["openalex", "semantic_scholar", "arxiv"]  # Stage 4 backend order
+  max_results_per_query: 40          # Results per query before deduplication
+  inter_query_delay_sec: 1.5         # Delay between expanded queries
+  openalex_email: "researchclaw@users.noreply.github.com"
+  openalex_api_key_env: "OPENALEX_API_KEY"
+  openalex_api_key: ""              # Optional; env var is preferred
+  s2_api_key_env: "S2_API_KEY"
+  s2_api_key: ""                    # Optional; falls back to llm.s2_api_key
+
 # === Experiment ===
 experiment:
   mode: "sandbox"                  # simulated | sandbox | docker | ssh_remote

--- a/config.researchclaw.example.yaml
+++ b/config.researchclaw.example.yaml
@@ -60,6 +60,21 @@ llm:
   # fallback_models:
   #   - "mistral"
 
+literature_search:
+  # Stage 4 academic search backends. Defaults preserve the current
+  # OpenAlex -> Semantic Scholar -> arXiv order.
+  sources:
+    - "openalex"
+    - "semantic_scholar"
+    - "arxiv"
+  max_results_per_query: 40
+  inter_query_delay_sec: 1.5
+  openalex_email: "researchclaw@users.noreply.github.com"
+  openalex_api_key_env: "OPENALEX_API_KEY"
+  openalex_api_key: ""
+  s2_api_key_env: "S2_API_KEY"
+  s2_api_key: ""
+
 security:
   hitl_required_stages: [5, 9, 20]
   allow_publish_without_approval: false

--- a/researchclaw/config.py
+++ b/researchclaw/config.py
@@ -206,6 +206,20 @@ class LlmConfig:
 
 
 @dataclass(frozen=True)
+class LiteratureSearchConfig:
+    """Configuration for Stage 4 academic literature search backends."""
+
+    sources: tuple[str, ...] = ("openalex", "semantic_scholar", "arxiv")
+    max_results_per_query: int = 40
+    inter_query_delay_sec: float = 1.5
+    openalex_email: str = "researchclaw@users.noreply.github.com"
+    openalex_api_key: str = ""
+    openalex_api_key_env: str = "OPENALEX_API_KEY"
+    s2_api_key: str = ""
+    s2_api_key_env: str = "S2_API_KEY"
+
+
+@dataclass(frozen=True)
 class SecurityConfig:
     hitl_required_stages: tuple[int, ...] = (5, 9, 20)
     allow_publish_without_approval: bool = False
@@ -835,6 +849,9 @@ class RCConfig:
     knowledge_base: KnowledgeBaseConfig
     openclaw_bridge: OpenClawBridgeConfig
     llm: LlmConfig
+    literature_search: LiteratureSearchConfig = field(
+        default_factory=LiteratureSearchConfig
+    )
     security: SecurityConfig = field(default_factory=SecurityConfig)
     experiment: ExperimentConfig = field(default_factory=ExperimentConfig)
     export: ExportConfig = field(default_factory=ExportConfig)
@@ -887,6 +904,7 @@ class RCConfig:
         knowledge_base = data["knowledge_base"]
         bridge = data.get("openclaw_bridge") or {}
         llm = data["llm"]
+        literature_search = data.get("literature_search") or {}
         security = data.get("security") or {}
         experiment = data.get("experiment") or {}
         export = data.get("export") or {}
@@ -948,6 +966,7 @@ class RCConfig:
                 use_browser=bool(bridge.get("use_browser", False)),
             ),
             llm=_parse_llm_config(llm),
+            literature_search=_parse_literature_search_config(literature_search),
             security=SecurityConfig(
                 hitl_required_stages=tuple(
                     int(s) for s in security.get("hitl_required_stages", (5, 9, 20))
@@ -1153,6 +1172,55 @@ def _parse_llm_config(data: dict[str, Any]) -> LlmConfig:
             acpx_command=acp_data.get("acpx_command", ""),
             session_name=acp_data.get("session_name", "researchclaw"),
             timeout_sec=int(acp_data.get("timeout_sec", 1800)),
+        ),
+    )
+
+
+def _parse_literature_search_config(data: dict[str, Any]) -> LiteratureSearchConfig:
+    if not data:
+        return LiteratureSearchConfig()
+
+    sources_raw = data.get("sources", LiteratureSearchConfig.sources)
+    if isinstance(sources_raw, str):
+        sources = tuple(
+            source.strip()
+            for source in sources_raw.split(",")
+            if source.strip()
+        )
+    else:
+        sources = tuple(str(source) for source in (sources_raw or ()))
+    if not sources:
+        sources = LiteratureSearchConfig.sources
+
+    return LiteratureSearchConfig(
+        sources=sources,
+        max_results_per_query=max(
+            1,
+            _safe_int(
+                data.get("max_results_per_query"),
+                LiteratureSearchConfig.max_results_per_query,
+            ),
+        ),
+        inter_query_delay_sec=max(
+            0.0,
+            _safe_float(
+                data.get("inter_query_delay_sec"),
+                LiteratureSearchConfig.inter_query_delay_sec,
+            ),
+        ),
+        openalex_email=str(
+            data.get("openalex_email", LiteratureSearchConfig.openalex_email)
+        ),
+        openalex_api_key=str(data.get("openalex_api_key", "")),
+        openalex_api_key_env=str(
+            data.get(
+                "openalex_api_key_env",
+                LiteratureSearchConfig.openalex_api_key_env,
+            )
+        ),
+        s2_api_key=str(data.get("s2_api_key", "")),
+        s2_api_key_env=str(
+            data.get("s2_api_key_env", LiteratureSearchConfig.s2_api_key_env)
         ),
     )
 

--- a/researchclaw/literature/openalex_client.py
+++ b/researchclaw/literature/openalex_client.py
@@ -52,6 +52,7 @@ def search_openalex(
     limit: int = 20,
     year_min: int = 0,
     email: str = _POLITE_EMAIL,
+    api_key: str = "",
 ) -> list[Paper]:
     """Search OpenAlex for papers matching *query*.
 
@@ -65,6 +66,8 @@ def search_openalex(
         If >0, restrict to papers published in this year or later.
     email:
         Polite pool email for higher rate limits.
+    api_key:
+        Optional OpenAlex API key.
 
     Returns
     -------
@@ -97,6 +100,8 @@ def search_openalex(
             "cited_by_count,doi,ids,abstract_inverted_index,type"
         ),
     }
+    if api_key:
+        params["api_key"] = api_key
     if filters:
         params["filter"] = ",".join(filters)
 
@@ -184,7 +189,7 @@ def _request_with_retry(
                 time.sleep(wait + jitter)
                 continue
 
-            logger.warning("OpenAlex HTTP %d for %s", exc.code, url)
+            logger.warning("OpenAlex HTTP %d for %s", exc.code, _redact_url(url))
             return None
 
         except (urllib.error.URLError, OSError, json.JSONDecodeError) as exc:
@@ -199,8 +204,21 @@ def _request_with_retry(
             )
             time.sleep(wait + jitter)
 
-    logger.error("OpenAlex request exhausted retries for: %s", url)
+    logger.error("OpenAlex request exhausted retries for: %s", _redact_url(url))
     return None
+
+
+def _redact_url(url: str) -> str:
+    """Redact sensitive query parameters before logging URLs."""
+    parsed = urllib.parse.urlsplit(url)
+    query = urllib.parse.parse_qsl(parsed.query, keep_blank_values=True)
+    redacted = [
+        (key, "***" if key.lower() == "api_key" else value)
+        for key, value in query
+    ]
+    return urllib.parse.urlunsplit(
+        parsed._replace(query=urllib.parse.urlencode(redacted))
+    )
 
 
 def _reconstruct_abstract(inverted_index: dict[str, list[int]] | None) -> str:

--- a/researchclaw/literature/search.py
+++ b/researchclaw/literature/search.py
@@ -109,6 +109,8 @@ def search_papers(
     year_min: int = 0,
     deduplicate: bool = True,
     s2_api_key: str = "",
+    openalex_email: str = "",
+    openalex_api_key: str = "",
 ) -> list[Paper]:
     """Search multiple academic sources and return deduplicated results.
 
@@ -126,6 +128,10 @@ def search_papers(
         Whether to remove duplicates across sources.
     s2_api_key:
         Optional Semantic Scholar API key.
+    openalex_email:
+        Optional OpenAlex mailto value.
+    openalex_api_key:
+        Optional OpenAlex API key.
 
     Returns
     -------
@@ -147,10 +153,17 @@ def search_papers(
         )
         try:
             if src_lower == "openalex":
+                openalex_kwargs: dict[str, object] = {
+                    "limit": limit,
+                    "year_min": year_min,
+                }
+                if openalex_email:
+                    openalex_kwargs["email"] = openalex_email
+                if openalex_api_key:
+                    openalex_kwargs["api_key"] = openalex_api_key
                 papers = search_openalex(
                     query,
-                    limit=limit,
-                    year_min=year_min,
+                    **openalex_kwargs,
                 )
                 all_papers.extend(papers)
                 cache_put(query, "openalex", limit, _papers_to_dicts(papers))
@@ -237,6 +250,8 @@ def search_papers_multi_query(
     sources: Sequence[str] = _DEFAULT_SOURCES,
     year_min: int = 0,
     s2_api_key: str = "",
+    openalex_email: str = "",
+    openalex_api_key: str = "",
     inter_query_delay: float = 1.5,
 ) -> list[Paper]:
     """Run multiple queries and return deduplicated union.
@@ -254,6 +269,8 @@ def search_papers_multi_query(
             sources=sources,
             year_min=year_min,
             s2_api_key=s2_api_key,
+            openalex_email=openalex_email,
+            openalex_api_key=openalex_api_key,
             deduplicate=False,  # we dedup globally below
         )
         all_papers.extend(results)

--- a/researchclaw/pipeline/stage_impls/_literature.py
+++ b/researchclaw/pipeline/stage_impls/_literature.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import re
 from pathlib import Path
 from typing import Any
@@ -384,17 +385,32 @@ def _execute_literature_collect(
 
         # Expand queries for broader coverage
         expanded_queries = _expand_search_queries(queries, config.research.topic)
+        literature_config = config.literature_search
+        s2_api_key = (
+            literature_config.s2_api_key
+            or config.llm.s2_api_key
+            or os.environ.get(literature_config.s2_api_key_env, "")
+        )
+        openalex_api_key = (
+            literature_config.openalex_api_key
+            or os.environ.get(literature_config.openalex_api_key_env, "")
+        )
         logger.info(
             "[literature] Searching %d queries (expanded from %d) "
-            "across OpenAlex → S2 → arXiv…",
+            "across %s",
             len(expanded_queries),
             len(queries),
+            " -> ".join(literature_config.sources),
         )
         papers = search_papers_multi_query(
             expanded_queries,
-            limit_per_query=40,
+            limit_per_query=literature_config.max_results_per_query,
+            sources=literature_config.sources,
             year_min=year_min,
-            s2_api_key=config.llm.s2_api_key,
+            s2_api_key=s2_api_key,
+            openalex_email=literature_config.openalex_email,
+            openalex_api_key=openalex_api_key,
+            inter_query_delay=literature_config.inter_query_delay_sec,
         )
         if papers:
             real_search_succeeded = True

--- a/tests/test_rc_config.py
+++ b/tests/test_rc_config.py
@@ -6,6 +6,7 @@ import pytest
 
 from researchclaw.config import (
     ExperimentConfig,
+    LiteratureSearchConfig,
     RCConfig,
     SandboxConfig,
     SecurityConfig,
@@ -233,6 +234,49 @@ def test_rcconfig_from_dict_parses_llm_wire_api(tmp_path: Path):
     config = RCConfig.from_dict(data, project_root=tmp_path, check_paths=False)
 
     assert config.llm.wire_api == "responses"
+
+
+def test_rcconfig_from_dict_uses_default_literature_search(tmp_path: Path):
+    config = RCConfig.from_dict(
+        _valid_config_data(),
+        project_root=tmp_path,
+        check_paths=False,
+    )
+
+    assert isinstance(config.literature_search, LiteratureSearchConfig)
+    assert config.literature_search.sources == (
+        "openalex",
+        "semantic_scholar",
+        "arxiv",
+    )
+    assert config.literature_search.max_results_per_query == 40
+    assert config.literature_search.openalex_api_key_env == "OPENALEX_API_KEY"
+    assert config.literature_search.s2_api_key_env == "S2_API_KEY"
+
+
+def test_rcconfig_from_dict_parses_literature_search(tmp_path: Path):
+    data = _valid_config_data()
+    data["literature_search"] = {
+        "sources": ["openalex", "arxiv"],
+        "max_results_per_query": 12,
+        "inter_query_delay_sec": 0.25,
+        "openalex_email": "bot@example.com",
+        "openalex_api_key_env": "CUSTOM_OPENALEX_KEY",
+        "openalex_api_key": "openalex-test-key",
+        "s2_api_key_env": "CUSTOM_S2_KEY",
+        "s2_api_key": "s2-test-key",
+    }
+
+    config = RCConfig.from_dict(data, project_root=tmp_path, check_paths=False)
+
+    assert config.literature_search.sources == ("openalex", "arxiv")
+    assert config.literature_search.max_results_per_query == 12
+    assert config.literature_search.inter_query_delay_sec == 0.25
+    assert config.literature_search.openalex_email == "bot@example.com"
+    assert config.literature_search.openalex_api_key_env == "CUSTOM_OPENALEX_KEY"
+    assert config.literature_search.openalex_api_key == "openalex-test-key"
+    assert config.literature_search.s2_api_key_env == "CUSTOM_S2_KEY"
+    assert config.literature_search.s2_api_key == "s2-test-key"
 
 
 def test_rcconfig_from_dict_missing_fields_raises_value_error(tmp_path: Path):

--- a/tests/test_rc_literature.py
+++ b/tests/test_rc_literature.py
@@ -716,6 +716,45 @@ class TestOpenAlex:
         assert p.source == "openalex"
         assert p.authors[0].name == "Ashish Vaswani"
 
+    def test_openalex_api_key_and_email_are_sent(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """OpenAlex API key and mailto should be encoded in request params."""
+        import urllib.parse
+
+        from researchclaw.literature.openalex_client import search_openalex
+
+        response_bytes = json.dumps(SAMPLE_OPENALEX_RESPONSE).encode("utf-8")
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = response_bytes
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        captured: dict[str, str] = {}
+
+        def fake_urlopen(req: Any, *args: Any, **kwargs: Any) -> MagicMock:
+            captured["url"] = req.full_url
+            return mock_resp
+
+        monkeypatch.setattr(
+            "researchclaw.literature.openalex_client.urllib.request.urlopen",
+            fake_urlopen,
+        )
+
+        papers = search_openalex(
+            "attention",
+            limit=5,
+            email="bot@example.com",
+            api_key="oa-test-key",
+        )
+
+        params = urllib.parse.parse_qs(
+            urllib.parse.urlsplit(captured["url"]).query
+        )
+        assert len(papers) == 1
+        assert params["mailto"] == ["bot@example.com"]
+        assert params["api_key"] == ["oa-test-key"]
+
     def test_abstract_reconstruction(self) -> None:
         from researchclaw.literature.openalex_client import _reconstruct_abstract
 
@@ -781,6 +820,41 @@ class TestMultiSourceFallback:
         assert len(papers) >= 1
         sources = {p.source for p in papers}
         assert "semantic_scholar" in sources or "arxiv" in sources
+
+    def test_search_papers_passes_openalex_options(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        captured: dict[str, object] = {}
+        openalex_paper = _make_paper(
+            paper_id="oalex-ok",
+            title="OpenAlex Paper",
+            source="openalex",
+            doi="10.1/oa",
+            arxiv_id="2401.12345",
+        )
+
+        def fake_openalex(query: str, **kwargs: object) -> list[Paper]:
+            captured["query"] = query
+            captured.update(kwargs)
+            return [openalex_paper]
+
+        monkeypatch.setattr(
+            "researchclaw.literature.search.search_openalex",
+            fake_openalex,
+        )
+        monkeypatch.setattr("researchclaw.literature.search.time.sleep", lambda _: None)
+
+        papers = search_papers(
+            "test",
+            sources=["openalex"],
+            openalex_email="bot@example.com",
+            openalex_api_key="oa-test-key",
+        )
+
+        assert len(papers) == 1
+        assert captured["query"] == "test"
+        assert captured["email"] == "bot@example.com"
+        assert captured["api_key"] == "oa-test-key"
 
 
 # ──────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- add a `literature_search` config section for Stage 4 backend order, per-query result limit, inter-query delay, OpenAlex mailto/API key, and Semantic Scholar API key/env settings
- thread literature search config into Stage 4 while preserving the current default order: OpenAlex -> Semantic Scholar -> arXiv
- add optional OpenAlex `api_key` support in the OpenAlex client and redact API keys from logged URLs
- document the new config in `README.md` and `config.researchclaw.example.yaml`

Refs #298.

## Why

OpenAlex is already the primary literature backend, but users cannot currently configure the OpenAlex API key or the Stage 4 backend/order/limit knobs from config. This keeps defaults unchanged while making the OpenAlex-first path more robust for users with API keys and clearer rate-limit requirements.

## Validation

- `python -m pytest tests/test_rc_config.py tests/test_rc_literature.py` (Python 3.14.6; 78 passed)
- `python -m py_compile researchclaw/config.py researchclaw/literature/openalex_client.py researchclaw/literature/search.py researchclaw/pipeline/stage_impls/_literature.py tests/test_rc_config.py tests/test_rc_literature.py`
- `git diff --check origin/main...HEAD`