### PR TITLE
ExperimentSpec v1: versioned schema, round-trip serialization, and real spec-violation gating

### DIFF
--- a/researchclaw/domains/experiment_schema.py
+++ b/researchclaw/domains/experiment_schema.py
@@ -13,6 +13,8 @@ from typing import Any
 
 import yaml
 
+SCHEMA_VERSION = "1.0"
+
 
 class ConditionRole(str, Enum):
     """Role of an experimental condition."""
@@ -60,6 +62,32 @@ class EvaluationSpec:
 
 
 @dataclass
+class ExperimentBudget:
+    """Execution budget for an experiment."""
+    wall_clock_seconds: int = 3600
+    max_cost_usd: float | None = None
+
+
+@dataclass
+class PreregisteredPrediction:
+    """Machine-checkable preregistered prediction."""
+    statement: str
+    metric: str
+    condition: str
+    baseline: str
+    comparison: str
+    min_effect_size: float = 0.0
+
+
+class SpecValidationError(ValueError):
+    """Raised when an experiment spec cannot be parsed as v1."""
+
+    def __init__(self, violations: list[str]) -> None:
+        self.violations = violations
+        super().__init__("; ".join(violations))
+
+
+@dataclass
 class UniversalExperimentPlan:
     """Domain-agnostic experiment plan.
 
@@ -87,6 +115,13 @@ class UniversalExperimentPlan:
 
     # Raw YAML (for backward compatibility with existing pipeline)
     raw_yaml: str = ""
+
+    # ExperimentSpec v1 contract fields
+    schema_version: str = SCHEMA_VERSION
+    mode: str = "falsify"
+    budget: ExperimentBudget = field(default_factory=ExperimentBudget)
+    seeds: list[int] = field(default_factory=list)
+    prediction: PreregisteredPrediction | None = None
 
     @property
     def references(self) -> list[Condition]:
@@ -138,6 +173,221 @@ class UniversalExperimentPlan:
             },
         }
 
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to the canonical ExperimentSpec v1 dict shape."""
+        return {
+            "schema_version": self.schema_version,
+            "experiment_type": self.experiment_type,
+            "domain_id": self.domain_id,
+            "problem_description": self.problem_description,
+            "conditions": [
+                {
+                    "name": c.name,
+                    "role": c.role,
+                    "description": c.description,
+                    "varies_from": c.varies_from,
+                    "variation": c.variation,
+                    "parameters": dict(c.parameters),
+                }
+                for c in self.conditions
+            ],
+            "input_type": self.input_type,
+            "input_description": self.input_description,
+            "evaluation": {
+                "primary_metric": {
+                    "name": self.evaluation.primary_metric.name,
+                    "direction": self.evaluation.primary_metric.direction,
+                    "unit": self.evaluation.primary_metric.unit,
+                    "description": self.evaluation.primary_metric.description,
+                },
+                "secondary_metrics": [
+                    {
+                        "name": m.name,
+                        "direction": m.direction,
+                        "unit": m.unit,
+                        "description": m.description,
+                    }
+                    for m in self.evaluation.secondary_metrics
+                ],
+                "protocol": self.evaluation.protocol,
+                "statistical_test": self.evaluation.statistical_test,
+                "num_seeds": self.evaluation.num_seeds,
+            },
+            "main_figure_type": self.main_figure_type,
+            "main_table_type": self.main_table_type,
+            "raw_yaml": self.raw_yaml,
+            "mode": self.mode,
+            "budget": {
+                "wall_clock_seconds": self.budget.wall_clock_seconds,
+                "max_cost_usd": self.budget.max_cost_usd,
+            },
+            "seeds": list(self.seeds),
+            "prediction": (
+                {
+                    "statement": self.prediction.statement,
+                    "metric": self.prediction.metric,
+                    "condition": self.prediction.condition,
+                    "baseline": self.prediction.baseline,
+                    "comparison": self.prediction.comparison,
+                    "min_effect_size": self.prediction.min_effect_size,
+                }
+                if self.prediction is not None
+                else None
+            ),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "UniversalExperimentPlan":
+        """Load a canonical ExperimentSpec v1 dict."""
+        if not isinstance(data, dict):
+            raise SpecValidationError(["spec must be a mapping"])
+
+        allowed_keys = {
+            "schema_version",
+            "experiment_type",
+            "domain_id",
+            "problem_description",
+            "conditions",
+            "input_type",
+            "input_description",
+            "evaluation",
+            "main_figure_type",
+            "main_table_type",
+            "raw_yaml",
+            "mode",
+            "budget",
+            "seeds",
+            "prediction",
+        }
+        unknown_keys = sorted(set(data) - allowed_keys)
+        if unknown_keys:
+            raise SpecValidationError(
+                [f"Unknown top-level key: {key}" for key in unknown_keys]
+            )
+
+        violations: list[str] = []
+
+        conditions = _conditions_from_dict(data.get("conditions", []), violations)
+        evaluation = _evaluation_from_dict(data.get("evaluation", {}), violations)
+        budget = _budget_from_dict(data.get("budget", {}), violations)
+        prediction = _prediction_from_dict(data.get("prediction"), violations)
+        seeds = data.get("seeds", [])
+        if not isinstance(seeds, list):
+            violations.append("seeds must be a list")
+            seeds = []
+        converted_seeds: list[int] = []
+        for idx, seed in enumerate(seeds):
+            try:
+                converted_seeds.append(int(seed))
+            except (TypeError, ValueError):
+                violations.append(f"seeds[{idx}] must be an integer")
+
+        if violations:
+            raise SpecValidationError(violations)
+
+        return cls(
+            schema_version=str(data.get("schema_version", SCHEMA_VERSION)),
+            experiment_type=str(
+                data.get("experiment_type", ExperimentType.COMPARISON.value)
+            ),
+            domain_id=str(data.get("domain_id", "")),
+            problem_description=str(data.get("problem_description", "")),
+            conditions=conditions,
+            input_type=str(data.get("input_type", "generated")),
+            input_description=str(data.get("input_description", "")),
+            evaluation=evaluation,
+            main_figure_type=str(data.get("main_figure_type", "bar_chart")),
+            main_table_type=str(data.get("main_table_type", "comparison_table")),
+            raw_yaml=str(data.get("raw_yaml", "")),
+            mode=str(data.get("mode", "falsify")),
+            budget=budget,
+            seeds=converted_seeds,
+            prediction=prediction,
+        )
+
+    def to_yaml_v1(self) -> str:
+        """Serialize to canonical ExperimentSpec v1 YAML."""
+        return yaml.dump(self.to_dict(), default_flow_style=False, sort_keys=False)
+
+    @classmethod
+    def from_yaml_v1(cls, text: str) -> "UniversalExperimentPlan":
+        """Load canonical ExperimentSpec v1 YAML."""
+        try:
+            data = yaml.safe_load(text) or {}
+        except yaml.YAMLError as exc:
+            raise SpecValidationError([f"invalid YAML: {exc}"]) from exc
+        return cls.from_dict(data)
+
+    def validate(self, strict: bool = True) -> list[str]:
+        """Return validation violations for this ExperimentSpec."""
+        violations: list[str] = []
+
+        if not self.conditions:
+            violations.append("at least one condition is required")
+
+        valid_roles = {role.value for role in ConditionRole}
+        for condition in self.conditions:
+            role = (
+                condition.role.value
+                if isinstance(condition.role, ConditionRole)
+                else condition.role
+            )
+            if role not in valid_roles:
+                violations.append(
+                    f"condition role for {condition.name} is invalid: {role}"
+                )
+
+        valid_experiment_types = {item.value for item in ExperimentType}
+        experiment_type = (
+            self.experiment_type.value
+            if isinstance(self.experiment_type, ExperimentType)
+            else self.experiment_type
+        )
+        if experiment_type not in valid_experiment_types:
+            violations.append(f"experiment_type is invalid: {self.experiment_type}")
+
+        if self.mode not in {"falsify", "optimize"}:
+            violations.append("mode must be 'falsify' or 'optimize'")
+
+        if self.budget.wall_clock_seconds <= 0:
+            violations.append("budget.wall_clock_seconds must be > 0")
+
+        if self.prediction is not None:
+            metric_names = {
+                self.evaluation.primary_metric.name,
+                *(metric.name for metric in self.evaluation.secondary_metrics),
+            }
+            condition_names = {condition.name for condition in self.conditions}
+            if self.prediction.metric not in metric_names:
+                violations.append(
+                    "prediction.metric is not defined in evaluation metrics: "
+                    f"{self.prediction.metric}"
+                )
+            if self.prediction.condition not in condition_names:
+                violations.append(
+                    "prediction.condition is not defined in conditions: "
+                    f"{self.prediction.condition}"
+                )
+            if self.prediction.baseline not in condition_names:
+                violations.append(
+                    "prediction.baseline is not defined in conditions: "
+                    f"{self.prediction.baseline}"
+                )
+            if self.prediction.comparison not in {"greater_than", "less_than"}:
+                violations.append(
+                    "prediction.comparison must be 'greater_than' or 'less_than'"
+                )
+
+        if strict:
+            if self.prediction is None:
+                violations.append("prediction is required for strict v1 validation")
+            if not self.seeds:
+                violations.append("seeds must be non-empty for strict v1 validation")
+            if self.schema_version != SCHEMA_VERSION:
+                violations.append(f"schema_version must be {SCHEMA_VERSION}")
+
+        return violations
+
     def to_yaml(self) -> str:
         """Serialize to YAML string."""
         data: dict[str, Any] = {
@@ -176,6 +426,182 @@ class UniversalExperimentPlan:
         return yaml.dump(data, default_flow_style=False, sort_keys=False)
 
 
+def _reject_unknown_keys(
+    name: str,
+    data: dict[str, Any],
+    allowed_keys: set[str],
+    violations: list[str],
+) -> None:
+    for key in sorted(set(data) - allowed_keys):
+        violations.append(f"Unknown {name} key: {key}")
+
+
+def _metric_from_dict(data: Any, name: str, violations: list[str]) -> MetricSpec:
+    if not isinstance(data, dict):
+        violations.append(f"{name} must be a mapping")
+        return MetricSpec(name="")
+
+    _reject_unknown_keys(
+        name,
+        data,
+        {"name", "direction", "unit", "description"},
+        violations,
+    )
+    return MetricSpec(
+        name=str(data.get("name", "")),
+        direction=str(data.get("direction", "minimize")),
+        unit=str(data.get("unit", "")),
+        description=str(data.get("description", "")),
+    )
+
+
+def _conditions_from_dict(data: Any, violations: list[str]) -> list[Condition]:
+    if not isinstance(data, list):
+        violations.append("conditions must be a list")
+        return []
+
+    conditions: list[Condition] = []
+    for idx, item in enumerate(data):
+        if not isinstance(item, dict):
+            violations.append(f"conditions[{idx}] must be a mapping")
+            continue
+        _reject_unknown_keys(
+            f"conditions[{idx}]",
+            item,
+            {"name", "role", "description", "varies_from", "variation", "parameters"},
+            violations,
+        )
+        parameters = item.get("parameters", {})
+        if not isinstance(parameters, dict):
+            violations.append(f"conditions[{idx}].parameters must be a mapping")
+            parameters = {}
+        conditions.append(
+            Condition(
+                name=str(item.get("name", "")),
+                role=str(item.get("role", ConditionRole.PROPOSED.value)),
+                description=str(item.get("description", "")),
+                varies_from=str(item.get("varies_from", "")),
+                variation=str(item.get("variation", "")),
+                parameters=dict(parameters),
+            )
+        )
+    return conditions
+
+
+def _evaluation_from_dict(data: Any, violations: list[str]) -> EvaluationSpec:
+    if not isinstance(data, dict):
+        violations.append("evaluation must be a mapping")
+        return EvaluationSpec()
+
+    _reject_unknown_keys(
+        "evaluation",
+        data,
+        {
+            "primary_metric",
+            "secondary_metrics",
+            "protocol",
+            "statistical_test",
+            "num_seeds",
+        },
+        violations,
+    )
+    primary_metric = _metric_from_dict(
+        data.get("primary_metric", {"name": "primary_metric"}),
+        "evaluation.primary_metric",
+        violations,
+    )
+    secondary_data = data.get("secondary_metrics", [])
+    if not isinstance(secondary_data, list):
+        violations.append("evaluation.secondary_metrics must be a list")
+        secondary_data = []
+    secondary_metrics = [
+        _metric_from_dict(metric, f"evaluation.secondary_metrics[{idx}]", violations)
+        for idx, metric in enumerate(secondary_data)
+    ]
+
+    try:
+        num_seeds = int(data.get("num_seeds", 3))
+    except (TypeError, ValueError):
+        violations.append("evaluation.num_seeds must be an integer")
+        num_seeds = 3
+
+    return EvaluationSpec(
+        primary_metric=primary_metric,
+        secondary_metrics=secondary_metrics,
+        protocol=str(data.get("protocol", "")),
+        statistical_test=str(data.get("statistical_test", "paired_t_test")),
+        num_seeds=num_seeds,
+    )
+
+
+def _budget_from_dict(data: Any, violations: list[str]) -> ExperimentBudget:
+    if not isinstance(data, dict):
+        violations.append("budget must be a mapping")
+        return ExperimentBudget()
+
+    _reject_unknown_keys(
+        "budget",
+        data,
+        {"wall_clock_seconds", "max_cost_usd"},
+        violations,
+    )
+    max_cost_usd = data.get("max_cost_usd")
+    try:
+        wall_clock_seconds = int(data.get("wall_clock_seconds", 3600))
+    except (TypeError, ValueError):
+        violations.append("budget.wall_clock_seconds must be an integer")
+        wall_clock_seconds = 3600
+    try:
+        converted_max_cost = (
+            float(max_cost_usd) if max_cost_usd is not None else None
+        )
+    except (TypeError, ValueError):
+        violations.append("budget.max_cost_usd must be numeric or null")
+        converted_max_cost = None
+    return ExperimentBudget(
+        wall_clock_seconds=wall_clock_seconds,
+        max_cost_usd=converted_max_cost,
+    )
+
+
+def _prediction_from_dict(
+    data: Any,
+    violations: list[str],
+) -> PreregisteredPrediction | None:
+    if data is None:
+        return None
+    if not isinstance(data, dict):
+        violations.append("prediction must be a mapping or null")
+        return None
+
+    _reject_unknown_keys(
+        "prediction",
+        data,
+        {
+            "statement",
+            "metric",
+            "condition",
+            "baseline",
+            "comparison",
+            "min_effect_size",
+        },
+        violations,
+    )
+    try:
+        min_effect_size = float(data.get("min_effect_size", 0.0))
+    except (TypeError, ValueError):
+        violations.append("prediction.min_effect_size must be numeric")
+        min_effect_size = 0.0
+    return PreregisteredPrediction(
+        statement=str(data.get("statement", "")),
+        metric=str(data.get("metric", "")),
+        condition=str(data.get("condition", "")),
+        baseline=str(data.get("baseline", "")),
+        comparison=str(data.get("comparison", "")),
+        min_effect_size=min_effect_size,
+    )
+
+
 def from_legacy_exp_plan(
     plan_yaml: str | dict[str, Any],
     domain_id: str = "",
@@ -186,9 +612,14 @@ def from_legacy_exp_plan(
     This allows existing ML experiment plans to work with the new system.
     """
     if isinstance(plan_yaml, str):
-        data = yaml.safe_load(plan_yaml) or {}
+        try:
+            data = yaml.safe_load(plan_yaml) or {}
+        except yaml.YAMLError as exc:
+            raise SpecValidationError([f"invalid legacy YAML: {exc}"]) from exc
     else:
         data = plan_yaml
+    if not isinstance(data, dict):
+        raise SpecValidationError(["legacy exp_plan must be a mapping"])
 
     conditions: list[Condition] = []
 

--- a/researchclaw/pipeline/runner.py
+++ b/researchclaw/pipeline/runner.py
@@ -10,6 +10,7 @@ import tempfile
 import threading
 import time as _time
 from pathlib import Path
+from typing import Any
 
 from researchclaw.adapters import AdapterBundle
 from researchclaw.config import RCConfig
@@ -149,6 +150,212 @@ def resume_from_checkpoint(
     """Resolve the stage to resume from using checkpoint metadata."""
     next_stage = read_checkpoint(run_dir)
     return next_stage if next_stage is not None else default_stage
+
+
+def _with_artifact_once(artifacts: tuple[str, ...], artifact: str) -> tuple[str, ...]:
+    if artifact in artifacts:
+        return artifacts
+    return (*artifacts, artifact)
+
+
+def _with_evidence_once(
+    evidence_refs: tuple[str, ...],
+    evidence_ref: str,
+) -> tuple[str, ...]:
+    if evidence_ref in evidence_refs:
+        return evidence_refs
+    return (*evidence_refs, evidence_ref)
+
+
+def _write_spec_violations(stage_dir: Path, violations: list[str]) -> Path:
+    path = stage_dir / "spec_violations.json"
+    stage_dir.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(violations, indent=2), encoding="utf-8")
+    return path
+
+
+def _fail_with_spec_violations(
+    result: StageResult,
+    stage_dir: Path,
+    violations: list[str],
+) -> StageResult:
+    violations_path = _write_spec_violations(stage_dir, violations)
+    logger.warning(
+        "Experiment spec validation failed for %s: %s",
+        result.stage.name,
+        violations,
+    )
+    return StageResult(
+        stage=result.stage,
+        status=StageStatus.FAILED,
+        artifacts=_with_artifact_once(result.artifacts, violations_path.name),
+        error="Experiment spec validation failed: " + "; ".join(violations),
+        decision="retry",
+        evidence_refs=_with_evidence_once(
+            result.evidence_refs,
+            f"{stage_dir.name}/{violations_path.name}",
+        ),
+    )
+
+
+def _post_experiment_design_spec_gate(
+    result: StageResult,
+    run_dir: Path,
+    config: RCConfig,
+) -> StageResult:
+    from researchclaw.domains.experiment_schema import (
+        SpecValidationError,
+        from_legacy_exp_plan,
+    )
+
+    stage_dir = run_dir / f"stage-{int(Stage.EXPERIMENT_DESIGN):02d}"
+    plan_path = stage_dir / "exp_plan.yaml"
+    if not plan_path.exists():
+        if "exp_plan.yaml" in result.artifacts:
+            return _fail_with_spec_violations(
+                result,
+                stage_dir,
+                ["missing exp_plan.yaml"],
+            )
+        return result
+
+    domain_id = str(getattr(getattr(config, "project", None), "profile", "") or "")
+    try:
+        plan_text = plan_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return _fail_with_spec_violations(
+            result,
+            stage_dir,
+            [f"could not read exp_plan.yaml: {exc}"],
+        )
+    try:
+        spec = from_legacy_exp_plan(
+            plan_text,
+            domain_id=domain_id,
+        )
+    except SpecValidationError as exc:
+        return _fail_with_spec_violations(result, stage_dir, exc.violations)
+    violations = spec.validate(strict=False)
+    if violations:
+        return _fail_with_spec_violations(result, stage_dir, violations)
+
+    spec_path = stage_dir / "experiment_spec.yaml"
+    spec_path.write_text(spec.to_yaml_v1(), encoding="utf-8")
+    logger.info("Experiment spec generated: %s", spec_path)
+    return StageResult(
+        stage=result.stage,
+        status=result.status,
+        artifacts=_with_artifact_once(result.artifacts, spec_path.name),
+        error=result.error,
+        decision=result.decision,
+        evidence_refs=_with_evidence_once(
+            result.evidence_refs,
+            f"{stage_dir.name}/{spec_path.name}",
+        ),
+    )
+
+
+def _metric_contract_names(spec: object) -> list[str]:
+    evaluation = getattr(spec, "evaluation")
+    names = [evaluation.primary_metric.name]
+    names.extend(metric.name for metric in evaluation.secondary_metrics)
+    return [name for name in names if name]
+
+
+def _result_metric_mapping(results: dict[str, Any]) -> dict[str, Any]:
+    metrics = results.get("metrics")
+    if isinstance(metrics, dict):
+        return metrics
+    return results
+
+
+def _validate_results_against_metric_contract(
+    spec: object,
+    results: dict[str, Any],
+) -> list[str]:
+    result_metrics = _result_metric_mapping(results)
+    violations: list[str] = []
+    for metric_name in _metric_contract_names(spec):
+        if metric_name not in result_metrics:
+            violations.append(f"missing result metric: {metric_name}")
+            continue
+        value = result_metrics[metric_name]
+        if (
+            isinstance(value, bool)
+            or not isinstance(value, (int, float))
+            or not math.isfinite(float(value))
+        ):
+            violations.append(f"non-numeric result metric: {metric_name}")
+    return violations
+
+
+def _post_result_analysis_spec_gate(
+    result: StageResult,
+    run_dir: Path,
+) -> StageResult:
+    from researchclaw.domains.experiment_schema import (
+        SpecValidationError,
+        UniversalExperimentPlan,
+    )
+
+    stage_dir = run_dir / f"stage-{int(Stage.RESULT_ANALYSIS):02d}"
+    spec_path = run_dir / "stage-09" / "experiment_spec.yaml"
+    if not spec_path.exists():
+        logger.warning(
+            "Experiment spec validation skipped: %s is missing, likely from a pre-v1 stage 9 run",
+            spec_path,
+        )
+        return result
+
+    try:
+        spec_text = spec_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return _fail_with_spec_violations(
+            result,
+            stage_dir,
+            [f"could not read experiment_spec.yaml: {exc}"],
+        )
+    try:
+        spec = UniversalExperimentPlan.from_yaml_v1(spec_text)
+    except SpecValidationError as exc:
+        return _fail_with_spec_violations(result, stage_dir, exc.violations)
+
+    spec_violations = spec.validate(strict=False)
+    if spec_violations:
+        return _fail_with_spec_violations(result, stage_dir, spec_violations)
+
+    results_path = run_dir / "results.json"
+    exp_results: dict[str, Any] = {}
+    if results_path.exists():
+        try:
+            results_text = results_path.read_text(encoding="utf-8")
+        except OSError as exc:
+            return _fail_with_spec_violations(
+                result,
+                stage_dir,
+                [f"could not read results.json: {exc}"],
+            )
+        try:
+            loaded = json.loads(results_text)
+        except json.JSONDecodeError as exc:
+            return _fail_with_spec_violations(
+                result,
+                stage_dir,
+                [f"results.json is invalid JSON: {exc}"],
+            )
+        if isinstance(loaded, dict):
+            exp_results = loaded
+        else:
+            return _fail_with_spec_violations(
+                result,
+                stage_dir,
+                ["results.json must contain a JSON object"],
+            )
+
+    violations = _validate_results_against_metric_contract(spec, exp_results)
+    if violations:
+        return _fail_with_spec_violations(result, stage_dir, violations)
+    return result
 
 
 def _collect_content_metrics(run_dir: Path | None) -> dict[str, object]:
@@ -550,33 +757,10 @@ def execute_pipeline(
 
         # ── ExperimentSpec: generate after design, validate after analysis ──
         if stage == Stage.EXPERIMENT_DESIGN and result.status == StageStatus.DONE:
-            try:
-                from researchclaw.pipeline.experiment_spec import ExperimentSpec, MetricDef, generate_spec
-                spec_text = generate_spec(config.research.topic, "")
-                spec_path = run_dir / f"stage-{int(stage):02d}" / "experiment_spec.md"
-                spec_path.write_text(spec_text, encoding="utf-8")
-                logger.info("Experiment spec generated: %s", spec_path)
-            except Exception:
-                logger.debug("Experiment spec generation skipped")
+            result = _post_experiment_design_spec_gate(result, run_dir, config)
 
         if stage == Stage.RESULT_ANALYSIS and result.status == StageStatus.DONE:
-            try:
-                from researchclaw.pipeline.experiment_spec import parse_spec, validate_results_against_spec
-                spec_path = run_dir / "stage-09" / "experiment_spec.md"
-                if spec_path.exists():
-                    spec = parse_spec(spec_path.read_text(encoding="utf-8"))
-                    results_path = run_dir / "results.json"
-                    exp_results = {}
-                    if results_path.exists():
-                        exp_results = json.loads(results_path.read_text(encoding="utf-8"))
-                    violations = validate_results_against_spec(spec, exp_results)
-                    if violations:
-                        logger.warning("Spec violations: %s", violations)
-                        (run_dir / f"stage-{int(stage):02d}" / "spec_violations.json").write_text(
-                            json.dumps(violations, indent=2), encoding="utf-8"
-                        )
-            except Exception:
-                logger.debug("Experiment spec validation skipped")
+            result = _post_result_analysis_spec_gate(result, run_dir)
 
         # ── Pitfall detection after code generation / experiment run ──
         if stage in (Stage.CODE_GENERATION, Stage.EXPERIMENT_RUN) and result.status == StageStatus.DONE:

--- a/tests/test_experiment_schema.py
+++ b/tests/test_experiment_schema.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 import yaml
 
+import researchclaw.domains.experiment_schema as experiment_schema
 from researchclaw.domains.experiment_schema import (
     Condition,
     ConditionRole,
@@ -14,6 +15,69 @@ from researchclaw.domains.experiment_schema import (
     UniversalExperimentPlan,
     from_legacy_exp_plan,
 )
+
+
+def _full_v1_plan() -> UniversalExperimentPlan:
+    return UniversalExperimentPlan(
+        experiment_type=ExperimentType.COMPARISON.value,
+        domain_id="ml_vision",
+        problem_description="Compare classifier variants",
+        conditions=[
+            Condition(
+                name="baseline",
+                role=ConditionRole.REFERENCE.value,
+                description="Reference classifier",
+                parameters={"depth": 18},
+            ),
+            Condition(
+                name="proposed",
+                role=ConditionRole.PROPOSED.value,
+                description="New classifier",
+                parameters={"depth": 34},
+            ),
+            Condition(
+                name="proposed_no_aug",
+                role=ConditionRole.VARIANT.value,
+                description="No augmentation variant",
+                varies_from="proposed",
+                variation="disable augmentation",
+                parameters={"augmentation": False},
+            ),
+        ],
+        input_type="benchmark_dataset",
+        input_description="CIFAR-like benchmark",
+        evaluation=EvaluationSpec(
+            primary_metric=MetricSpec(
+                name="accuracy",
+                direction="maximize",
+                unit="fraction",
+                description="Held-out accuracy",
+            ),
+            secondary_metrics=[
+                MetricSpec(name="latency", direction="minimize", unit="ms"),
+            ],
+            protocol="train on train split, evaluate on holdout",
+            statistical_test="bootstrap_ci",
+            num_seeds=5,
+        ),
+        main_figure_type="line_chart",
+        main_table_type="metric_table",
+        raw_yaml="raw: yaml\n",
+        mode="falsify",
+        budget=experiment_schema.ExperimentBudget(
+            wall_clock_seconds=7200,
+            max_cost_usd=12.5,
+        ),
+        seeds=[1, 2, 3],
+        prediction=experiment_schema.PreregisteredPrediction(
+            statement="The proposed method improves accuracy",
+            metric="accuracy",
+            condition="proposed",
+            baseline="baseline",
+            comparison="greater_than",
+            min_effect_size=0.02,
+        ),
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -50,6 +114,14 @@ class TestUniversalExperimentPlan:
         plan = UniversalExperimentPlan()
         assert plan.conditions == []
         assert plan.experiment_type == "comparison"
+
+    def test_legacy_positional_constructor_order_is_preserved(self):
+        plan = UniversalExperimentPlan("convergence", "physics_pde", "Track error")
+
+        assert plan.experiment_type == "convergence"
+        assert plan.domain_id == "physics_pde"
+        assert plan.problem_description == "Track error"
+        assert plan.schema_version == experiment_schema.SCHEMA_VERSION
 
     def test_plan_with_conditions(self):
         plan = UniversalExperimentPlan(
@@ -96,6 +168,63 @@ class TestUniversalExperimentPlan:
         assert data["experiment"]["type"] == "convergence"
         assert data["experiment"]["domain"] == "physics_pde"
         assert len(data["experiment"]["conditions"]) == 2
+
+    def test_v1_yaml_file_roundtrip_preserves_every_field(self, tmp_path):
+        plan = _full_v1_plan()
+        path = tmp_path / "experiment_spec.yaml"
+
+        path.write_text(plan.to_yaml_v1(), encoding="utf-8")
+        plan2 = UniversalExperimentPlan.from_yaml_v1(
+            path.read_text(encoding="utf-8")
+        )
+
+        assert plan2 == plan
+        assert plan2.to_dict() == plan.to_dict()
+
+    def test_from_dict_rejects_unknown_top_level_keys(self):
+        data = _full_v1_plan().to_dict()
+        data["silently_lost"] = True
+        error_type = experiment_schema.SpecValidationError
+
+        with pytest.raises(error_type) as excinfo:
+            UniversalExperimentPlan.from_dict(data)
+
+        assert "Unknown top-level key: silently_lost" in excinfo.value.violations
+
+    def test_validate_strict_requires_prediction_seeds_and_schema_version(self):
+        plan = _full_v1_plan()
+        plan.prediction = None
+        plan.seeds = []
+        plan.schema_version = "0.9"
+
+        violations = plan.validate(strict=True)
+
+        assert "prediction is required for strict v1 validation" in violations
+        assert "seeds must be non-empty for strict v1 validation" in violations
+        assert "schema_version must be 1.0" in violations
+
+    def test_validate_structural_checks(self):
+        plan = _full_v1_plan()
+        plan.experiment_type = "unsupported"
+        plan.mode = "explore"
+        plan.budget.wall_clock_seconds = 0
+        plan.conditions[0].role = "control"
+        assert plan.prediction is not None
+        plan.prediction.metric = "missing_metric"
+        plan.prediction.condition = "missing_condition"
+        plan.prediction.baseline = "missing_baseline"
+        plan.prediction.comparison = "equal_to"
+
+        violations = plan.validate(strict=False)
+
+        assert "experiment_type is invalid: unsupported" in violations
+        assert "mode must be 'falsify' or 'optimize'" in violations
+        assert "budget.wall_clock_seconds must be > 0" in violations
+        assert "condition role for baseline is invalid: control" in violations
+        assert "prediction.metric is not defined in evaluation metrics: missing_metric" in violations
+        assert "prediction.condition is not defined in conditions: missing_condition" in violations
+        assert "prediction.baseline is not defined in conditions: missing_baseline" in violations
+        assert "prediction.comparison must be 'greater_than' or 'less_than'" in violations
 
 
 # ---------------------------------------------------------------------------
@@ -180,6 +309,19 @@ metrics:
         legacy = {"metrics": ["accuracy", "f1"]}
         plan = from_legacy_exp_plan(legacy)
         assert plan.evaluation.primary_metric.name == "accuracy"
+
+    def test_legacy_converted_plan_passes_structural_not_strict_validation(self):
+        legacy = {
+            "baselines": [{"name": "baseline"}],
+            "proposed_methods": [{"name": "proposed"}],
+            "metrics": {"accuracy": {"direction": "maximize"}},
+        }
+        plan = from_legacy_exp_plan(legacy)
+
+        assert plan.validate(strict=False) == []
+        assert "prediction is required for strict v1 validation" in plan.validate(
+            strict=True
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_rc_runner.py
+++ b/tests/test_rc_runner.py
@@ -362,6 +362,208 @@ def test_execute_pipeline_passes_auto_approve_flag_to_execute_stage(
     assert all(received)
 
 
+def test_experiment_design_spec_violations_fail_stage(
+    monkeypatch: pytest.MonkeyPatch,
+    run_dir: Path,
+    rc_config: RCConfig,
+    adapters: AdapterBundle,
+) -> None:
+    def mock_execute_stage(stage: Stage, **kwargs) -> StageResult:
+        _ = kwargs
+        stage_dir = run_dir / f"stage-{int(stage):02d}"
+        stage_dir.mkdir(parents=True, exist_ok=True)
+        (stage_dir / "exp_plan.yaml").write_text(
+            "metrics:\n  accuracy:\n    direction: maximize\n",
+            encoding="utf-8",
+        )
+        return _done(stage, artifacts=("exp_plan.yaml",))
+
+    monkeypatch.setattr(rc_runner, "execute_stage", mock_execute_stage)
+
+    results = rc_runner.execute_pipeline(
+        run_dir=run_dir,
+        run_id="run-exp-spec-gate",
+        config=rc_config,
+        adapters=adapters,
+        from_stage=Stage.EXPERIMENT_DESIGN,
+        to_stage=Stage.EXPERIMENT_DESIGN,
+    )
+
+    assert results[-1].status == StageStatus.FAILED
+    violations_path = run_dir / "stage-09" / "spec_violations.json"
+    assert violations_path.exists()
+    violations = json.loads(violations_path.read_text(encoding="utf-8"))
+    assert "at least one condition is required" in violations
+
+
+def test_result_analysis_missing_metric_contract_fails_stage(
+    monkeypatch: pytest.MonkeyPatch,
+    run_dir: Path,
+    rc_config: RCConfig,
+    adapters: AdapterBundle,
+) -> None:
+    spec_dir = run_dir / "stage-09"
+    spec_dir.mkdir(parents=True)
+    spec = {
+        "schema_version": "1.0",
+        "experiment_type": "comparison",
+        "domain_id": "ml_vision",
+        "problem_description": "Compare methods",
+        "conditions": [
+            {
+                "name": "baseline",
+                "role": "reference",
+                "description": "",
+                "varies_from": "",
+                "variation": "",
+                "parameters": {},
+            },
+            {
+                "name": "proposed",
+                "role": "proposed",
+                "description": "",
+                "varies_from": "",
+                "variation": "",
+                "parameters": {},
+            },
+        ],
+        "input_type": "generated",
+        "input_description": "",
+        "evaluation": {
+            "primary_metric": {
+                "name": "accuracy",
+                "direction": "maximize",
+                "unit": "",
+                "description": "",
+            },
+            "secondary_metrics": [
+                {
+                    "name": "loss",
+                    "direction": "minimize",
+                    "unit": "",
+                    "description": "",
+                },
+            ],
+            "protocol": "",
+            "statistical_test": "paired_t_test",
+            "num_seeds": 3,
+        },
+        "main_figure_type": "bar_chart",
+        "main_table_type": "comparison_table",
+        "raw_yaml": "",
+        "mode": "falsify",
+        "budget": {"wall_clock_seconds": 3600, "max_cost_usd": None},
+        "seeds": [1],
+        "prediction": {
+            "statement": "Proposed improves accuracy",
+            "metric": "accuracy",
+            "condition": "proposed",
+            "baseline": "baseline",
+            "comparison": "greater_than",
+            "min_effect_size": 0.01,
+        },
+    }
+    (spec_dir / "experiment_spec.yaml").write_text(
+        json.dumps(spec),
+        encoding="utf-8",
+    )
+
+    def mock_execute_stage(stage: Stage, **kwargs) -> StageResult:
+        _ = kwargs
+        stage_dir = run_dir / f"stage-{int(stage):02d}"
+        stage_dir.mkdir(parents=True, exist_ok=True)
+        (run_dir / "results.json").write_text(
+            json.dumps({"accuracy": 0.82}),
+            encoding="utf-8",
+        )
+        return _done(stage)
+
+    monkeypatch.setattr(rc_runner, "execute_stage", mock_execute_stage)
+
+    results = rc_runner.execute_pipeline(
+        run_dir=run_dir,
+        run_id="run-results-spec-gate",
+        config=rc_config,
+        adapters=adapters,
+        from_stage=Stage.RESULT_ANALYSIS,
+        to_stage=Stage.RESULT_ANALYSIS,
+    )
+
+    assert results[-1].status == StageStatus.FAILED
+    violations_path = run_dir / "stage-14" / "spec_violations.json"
+    assert violations_path.exists()
+    violations = json.loads(violations_path.read_text(encoding="utf-8"))
+    assert "missing result metric: loss" in violations
+
+
+def test_result_analysis_non_numeric_metric_contract_fails_stage(
+    monkeypatch: pytest.MonkeyPatch,
+    run_dir: Path,
+    rc_config: RCConfig,
+    adapters: AdapterBundle,
+) -> None:
+    from researchclaw.domains.experiment_schema import (
+        Condition,
+        EvaluationSpec,
+        MetricSpec,
+        PreregisteredPrediction,
+        UniversalExperimentPlan,
+    )
+
+    spec_dir = run_dir / "stage-09"
+    spec_dir.mkdir(parents=True)
+    spec = UniversalExperimentPlan(
+        domain_id="ml_vision",
+        conditions=[
+            Condition(name="baseline", role="reference"),
+            Condition(name="proposed", role="proposed"),
+        ],
+        evaluation=EvaluationSpec(
+            primary_metric=MetricSpec(name="accuracy", direction="maximize"),
+        ),
+        seeds=[1],
+        prediction=PreregisteredPrediction(
+            statement="Proposed improves accuracy",
+            metric="accuracy",
+            condition="proposed",
+            baseline="baseline",
+            comparison="greater_than",
+            min_effect_size=0.01,
+        ),
+    )
+    (spec_dir / "experiment_spec.yaml").write_text(
+        spec.to_yaml_v1(),
+        encoding="utf-8",
+    )
+
+    def mock_execute_stage(stage: Stage, **kwargs) -> StageResult:
+        _ = kwargs
+        stage_dir = run_dir / f"stage-{int(stage):02d}"
+        stage_dir.mkdir(parents=True, exist_ok=True)
+        (run_dir / "results.json").write_text(
+            json.dumps({"accuracy": "0.82"}),
+            encoding="utf-8",
+        )
+        return _done(stage)
+
+    monkeypatch.setattr(rc_runner, "execute_stage", mock_execute_stage)
+
+    results = rc_runner.execute_pipeline(
+        run_dir=run_dir,
+        run_id="run-results-spec-nonnumeric-gate",
+        config=rc_config,
+        adapters=adapters,
+        from_stage=Stage.RESULT_ANALYSIS,
+        to_stage=Stage.RESULT_ANALYSIS,
+    )
+
+    assert results[-1].status == StageStatus.FAILED
+    violations_path = run_dir / "stage-14" / "spec_violations.json"
+    assert violations_path.exists()
+    violations = json.loads(violations_path.read_text(encoding="utf-8"))
+    assert "non-numeric result metric: accuracy" in violations
+
+
 @pytest.mark.parametrize(
     ("stage", "started", "expected"),
     [


### PR DESCRIPTION
## Problem

`execute_pipeline` imports a module that does not exist. Both post-stage hooks around experiment specs (`researchclaw.pipeline.experiment_spec`, imported after `EXPERIMENT_DESIGN` and after `RESULT_ANALYSIS`) are wrapped in bare `except Exception` blocks that log at DEBUG, so every run silently skips spec generation and results-vs-spec validation. Spec compliance has effectively been dead code: a malformed experiment plan, or results that miss the contracted metrics, sail through with `StageStatus.DONE`.

Separately, `UniversalExperimentPlan` has no schema version, no validation, and no round-trip serialization (`to_yaml()` output is not readable back; `from_legacy_exp_plan` only understands the legacy dict shape).

## What this PR does

**Schema (`researchclaw/domains/experiment_schema.py`)**

- Adds the v1 contract fields to `UniversalExperimentPlan`: `schema_version`, `mode` (`falsify` | `optimize`), `budget` (new `ExperimentBudget`), `seeds`, and `prediction` (new `PreregisteredPrediction`: statement, metric, condition, baseline, comparison, minimum effect size). Existing fields, positional construction order, `to_legacy_format`, `from_legacy_exp_plan`, and the `to_yaml()` output shape are unchanged.
- Adds exact round-trip serialization: `to_dict`/`from_dict` are inverses field-for-field, and `to_yaml_v1`/`from_yaml_v1` provide the file form. `from_dict` rejects unknown keys at every level (raising `SpecValidationError` with the violation list), so silent field loss is impossible.
- Adds two-level validation: `validate(strict=False)` checks structure (non-empty conditions, valid role/experiment-type/mode enums, positive budget, prediction references resolve to declared metrics and conditions); `strict=True` additionally requires the pre-registered prediction, non-empty seeds, and a matching schema version. The split exists because stage 9's legacy `exp_plan.yaml` cannot carry the new fields: the runner lane validates structurally, while spec producers (e.g. exporters feeding the executor) get the full contract.

**Runner (`researchclaw/pipeline/runner.py`)**

- Replaces both phantom-import hooks with live wiring. After `EXPERIMENT_DESIGN`: the stage's `exp_plan.yaml` is converted via `from_legacy_exp_plan`, validated, and written as the canonical `stage-09/experiment_spec.yaml`; violations write `spec_violations.json`, log at WARNING, and flip the stage result to FAILED through the same path an ordinary stage failure takes. After `RESULT_ANALYSIS`: `results.json` is validated against the spec's metric contract (missing or non-numeric contracted metrics are violations) with the same gating.
- The only tolerated skip is an explicit WARNING when stage 9 predates this change and left no spec file.

## Verification

- Round-trip and gating tests were written failing-first: a fully populated v1 spec survives spec -> file -> spec field-for-field; unknown keys are rejected; strict validation catches a missing prediction and empty seeds; a violating spec or a results file missing a contracted metric now fails the stage and writes `spec_violations.json` (both scenarios passed silently before this change).
- Full suite on this branch: 2833 passed, 56 skipped.

## Notes for reviewers

- Gating semantics: `EXPERIMENT_DESIGN` and `RESULT_ANALYSIS` are not in `NONCRITICAL_STAGES`, so a spec violation now stops the pipeline rather than warning. This is the intended behavior change and the reason for the PR; the lenient structural lane keeps existing legacy plans passing.
- `Condition`, `MetricSpec`, and `EvaluationSpec` are intentionally untouched; the metric contract reuses `EvaluationSpec` as its home.
