### PR TITLE
Fail-open audit of the experiment path: surface or record failures that vanished at debug level

### DIFF
--- a/docs/fail_open_audit.md
+++ b/docs/fail_open_audit.md
@@ -1,0 +1,131 @@
+# Fail-open audit of the experiment path
+
+Scope audited: `execute_pipeline` and helpers that fire between
+`Stage.EXPERIMENT_DESIGN` and `Stage.RESULT_ANALYSIS`, plus the stage
+implementations for experiment design, code generation, resource planning,
+experiment run, iterative refine, result analysis, and sandbox or dataset
+helpers called by those stages.
+
+Out of scope per brief: literature, survey, paper writing, export, publishing,
+MetaClaw bridge, and the ExperimentSpec v1 gates introduced in the preceding commit (`3724cff`).
+
+Disposition values:
+
+- `converted-surface`: a previously swallowed failure now fails the stage or run.
+- `converted-record`: an optional feature now warns once per run and records the
+  degradation in `pipeline_summary.json`.
+- `removed-dead`: a phantom integration was removed because the module does not
+  exist in this fork.
+- `kept-with-reason`: the catch is still present and the reason is documented.
+
+| File | Line | What it guards | Failure mode before audit | Disposition | Test | Commit |
+|---|---:|---|---|---|---|---|
+| `researchclaw/pipeline/runner.py` | 111 | Optional HITL data inside checkpoint write | HITL metadata omitted from checkpoint | kept-with-reason: core checkpoint still writes atomically and the optional HITL adapter must not corrupt checkpoint persistence | N/A | N/A |
+| `researchclaw/pipeline/runner.py` | 120 | Checkpoint temp file cleanup | No swallow, temp file is unlinked then exception is re-raised | kept-with-reason: cleanup guard re-raises and is not fail-open | Existing checkpoint tests | N/A |
+| `researchclaw/pipeline/runner.py` | 480 | Optional Stage 9 plan load for diagnosis context | Malformed plan omitted from diagnosis context | kept-with-reason: optional context only; diagnosis failures themselves now surface | N/A | N/A |
+| `researchclaw/pipeline/runner.py` | 565 | Post-Stage 14 experiment diagnosis | Diagnosis crash logged, pipeline continued | converted-surface | `test_result_analysis_diagnosis_failure_fails_stage` | `e770816` |
+| `researchclaw/pipeline/runner.py` | 654 | Post-diagnosis experiment repair | Repair crash logged and printed, pipeline continued | converted-surface | `test_result_analysis_repair_failure_fails_stage` | `0bf2290` |
+| `researchclaw/pipeline/runner.py` | 688 | Domain profile setup before stage execution | Adapter/profile setup failure swallowed, run continued with unknown profile state | converted-surface | `test_domain_profile_setup_failure_fails_before_stage` | `3118f97` |
+| `researchclaw/pipeline/runner.py` | removed | `researchclaw.pipeline.event_log` phantom import and append hooks | Missing module silently disabled all event logging | removed-dead | Smoke: `test_execute_pipeline_runs_stages_in_sequence` | `53f59a7` |
+| `researchclaw/pipeline/runner.py` | 721 | Experiment memory initialization | Wrong constructor call was swallowed, memory never initialized | converted-record | `test_experiment_memory_initialization_failure_is_recorded_once` | `9090fd7` |
+| `researchclaw/pipeline/runner.py` | 749 | CLI cost budget enforcer | Missing `researchclaw.cost_tracker` silently disabled configured CLI budgets | converted-surface | `test_cli_cost_budget_without_enforcer_fails_before_stage` | `54bb936` |
+| `researchclaw/pipeline/runner.py` | removed | `researchclaw.pipeline.pitfall_detector` phantom import after stages 10 and 12 | Missing module silently disabled pitfall detection | removed-dead | Smoke: `test_execute_pipeline_runs_stages_in_sequence` | `b1587e7` |
+| `researchclaw/pipeline/runner.py` | 822 | Experiment memory outcome recording | Missing `ExperimentOutcome` API was swallowed, outcomes were never recorded | converted-record | `test_experiment_memory_records_outcome_after_experiment_stage`; `test_experiment_memory_recording_failure_is_recorded_once` | `6525d02` |
+| `researchclaw/pipeline/runner.py` | 861 | Knowledge base stage export | KB export failure was swallowed | converted-record | `test_kb_export_failure_is_recorded_once` | `39f6ee6` |
+| `researchclaw/pipeline/stage_impls/_experiment_design.py` | 117 | Stage 9 domain detection and `domain_profile.json` write | Debug-only fallback to generic domain | kept-with-reason: optional profile enrichment; downstream ExperimentSpec gate still fails invalid experiment plans | N/A | N/A |
+| `researchclaw/pipeline/stage_impls/_experiment_design.py` | 147 | Domain-specific experiment-design prompt context | Debug-only fallback to generic prompt context | kept-with-reason: optional prompt enrichment, no persisted result data is accepted from this block | N/A | N/A |
+| `researchclaw/pipeline/stage_impls/_experiment_design.py` | 155 | Optional `dataset_guidance` prompt block | Missing prompt block became empty guidance | kept-with-reason: PromptManager blocks are optional across profiles | N/A | N/A |
+| `researchclaw/pipeline/stage_impls/_experiment_design.py` | 165 | Optional RL prompt guidance block | Missing block silently omitted extra guidance | kept-with-reason: optional prompt enrichment only | N/A | N/A |
+| `researchclaw/pipeline/stage_impls/_experiment_design.py` | 190 | Optional framework documentation injection | Failure silently omitted docs | kept-with-reason: optional prompt enrichment; generated plan still passes schema gate | N/A | N/A |
+| `researchclaw/pipeline/stage_impls/_experiment_design.py` | 397 | BenchmarkAgent fallback domain detection | Debug-only fallback to generic benchmark eligibility | kept-with-reason: fallback only used if the first domain detection did not produce a profile | N/A | N/A |
+| `researchclaw/pipeline/stage_impls/_experiment_design.py` | 481 | BenchmarkAgent orchestration | Warning logged and Stage 9 continued without BenchmarkAgent selections | kept-with-reason: already visible at warning level and feature is optional | N/A | N/A |
+| `researchclaw/pipeline/stage_impls/_experiment_design.py` | 491 | Optional `benchmark_plan.json` write | Benchmark plan artifact skipped | kept-with-reason: selected datasets and baselines were already injected into `exp_plan.yaml`; artifact is an optional Stage 10 hint | N/A | N/A |
+| `researchclaw/pipeline/stage_impls/_experiment_design.py` | 568 | HITL guidance application | Debug-only fallback to original plan | kept-with-reason: optional human guidance file, no stage artifact is corrupted | N/A | N/A |
+| `researchclaw/pipeline/stage_impls/_experiment_design.py` | 591 | BaselineNavigator persistence | Navigator UI state skipped | kept-with-reason: HITL workshop state is optional telemetry, not experiment plan data | N/A | N/A |
+| `researchclaw/pipeline/stage_impls/_code_generation.py` | 109 | ColliderAgent LLM plan generation | Warning logged, fallback collider plan generated | kept-with-reason: explicit fallback artifact is produced when LLM is unavailable | N/A | N/A |
+| `researchclaw/pipeline/stage_impls/_code_generation.py` | 366 | `compute_budget` prompt block | Template fallback used | kept-with-reason: explicit fallback prompt text is generated | N/A | N/A |
+| `researchclaw/pipeline/stage_impls/_code_generation.py` | 392 | Offline dataset guidance prompt block | Guidance omitted | kept-with-reason: optional prompt enrichment | N/A | N/A |
+| `researchclaw/pipeline/stage_impls/_code_generation.py` | 398 | Full-network dataset guidance prompt blocks | Guidance omitted | kept-with-reason: optional prompt enrichment | N/A | N/A |
+| `researchclaw/pipeline/stage_impls/_code_generation.py` | 404 | Setup-only dataset guidance prompt block | Guidance omitted | kept-with-reason: optional prompt enrichment | N/A | N/A |
+| `researchclaw/pipeline/stage_impls/_code_generation.py` | 409 | Docker setup script guidance prompt block | Guidance omitted | kept-with-reason: optional prompt enrichment | N/A | N/A |
+| `researchclaw/pipeline/stage_impls/_code_generation.py` | 413 | Hyperparameter reporting prompt block | Guidance omitted | kept-with-reason: optional prompt enrichment | N/A | N/A |
+| `researchclaw/pipeline/stage_impls/_code_generation.py` | 418 | Multi-seed enforcement prompt block | Guidance omitted | kept-with-reason: optional prompt enrichment; downstream result gates still validate produced data | N/A | N/A |
+| `researchclaw/pipeline/stage_impls/_code_generation.py` | 454 | BenchmarkAgent plan load for Stage 10 | Debug-only omission of extra benchmark prompt block | kept-with-reason: Stage 9 `exp_plan.yaml` remains the authoritative plan | N/A | N/A |
+| `researchclaw/pipeline/stage_impls/_code_generation.py` | 479 | Optional RL code-generation prompt block | Guidance omitted | kept-with-reason: optional prompt enrichment | N/A | N/A |
+| `researchclaw/pipeline/stage_impls/_code_generation.py` | 494 | Framework API documentation injection | Debug-only omission | kept-with-reason: optional prompt enrichment | N/A | N/A |
+| `researchclaw/pipeline/stage_impls/_code_generation.py` | 500 | LLM training guidance prompt block | Guidance omitted | kept-with-reason: optional prompt enrichment | N/A | N/A |
+| `researchclaw/pipeline/stage_impls/_code_generation.py` | 504 | LLM eval guidance prompt block | Guidance omitted | kept-with-reason: optional prompt enrichment | N/A | N/A |
+| `researchclaw/pipeline/stage_impls/_code_generation.py` | 538 | Domain prompt adapter guidance | Debug-only omission | kept-with-reason: optional prompt enrichment | N/A | N/A |
+| `researchclaw/pipeline/stage_impls/_code_generation.py` | 604 | HITL route request for OpenCode | Info logged, OpenCode routing skipped unless configured auto | kept-with-reason: interactive routing is optional and has an explicit auto mode | N/A | N/A |
+| `researchclaw/pipeline/stage_impls/_code_generation.py` | 733 | Code search helper | Debug-only omission | kept-with-reason: optional retrieval augmentation | N/A | N/A |
+| `researchclaw/pipeline/stage_impls/_code_generation.py` | 735 | Domain detection around code search | Debug-only fallback to no code search | kept-with-reason: optional retrieval augmentation | N/A | N/A |
+| `researchclaw/pipeline/stage_impls/_code_generation.py` | 1138 | Deep repair helper | Debug-only omission of advisory repair | kept-with-reason: primary static validation remains active and hard stage failures still return `StageStatus.FAILED` | N/A | N/A |
+| `researchclaw/pipeline/stage_impls/_code_generation.py` | 1257 | Review-fix LLM call | Debug-only omission of advisory fix | kept-with-reason: optional review repair after generated code already exists | N/A | N/A |
+| `researchclaw/pipeline/stage_impls/_code_generation.py` | 1259 | Code review block | Debug-only omission of advisory review | kept-with-reason: optional review, not the primary code-generation result | N/A | N/A |
+| `researchclaw/pipeline/stage_impls/_code_generation.py` | 1466 | Topic-alignment check block | Debug-only omission of advisory alignment check | kept-with-reason: this remains a design risk, but converting it would make optional LLM review availability a hard dependency | N/A | N/A |
+| `researchclaw/pipeline/stage_impls/_code_generation.py` | 1532 | Ablation repair LLM call | Debug-only omission of repair | kept-with-reason: advisory repair after a warning artifact is written | N/A | N/A |
+| `researchclaw/pipeline/stage_impls/_code_generation.py` | 1534 | Ablation validation block | Debug-only omission of advisory validation | kept-with-reason: optional LLM validation; no metrics are accepted here | N/A | N/A |
+| `researchclaw/pipeline/stage_impls/_execution.py` | 63 | Parse persisted `domain_profile.json` | Malformed profile falls back to live detection | kept-with-reason: migration behavior covered by provenance resolver tests | `test_resolver_falls_back_on_malformed_artifact` | N/A |
+| `researchclaw/pipeline/stage_impls/_execution.py` | 79 | Live domain detection for provenance policy | Debug-only default to `unspecified` | kept-with-reason: explicit migration fail-open behavior currently asserted by provenance tests; changing it would be a policy change | Provenance resolver tests | N/A |
+| `researchclaw/pipeline/stage_impls/_execution.py` | 306 | ColliderAgent structured `results.json` parse and copy | Invalid structured result ignored, run payload still uses sandbox metrics | kept-with-reason: `SandboxResult.metrics` remains the primary Stage 12 result channel for this branch | N/A | N/A |
+| `researchclaw/pipeline/stage_impls/_analysis.py` | 726 | FigureAgent chart planning | Warning logged, legacy chart generation attempted | kept-with-reason: already visible and has an explicit fallback | N/A | N/A |
+| `researchclaw/pipeline/stage_impls/_analysis.py` | 749 | Legacy early chart generation | Warning logged, analysis still writes core summaries | kept-with-reason: optional visualization artifact, not metric extraction | N/A | N/A |
+| `researchclaw/pipeline/_helpers.py` | 119 | Skill registry initialization | Debug-only empty registry fallback | kept-with-reason: optional prompt skills, no experiment data altered | N/A | N/A |
+| `researchclaw/pipeline/_helpers.py` | 371 | Sandbox dependency check or install | Warning logged for failed package check/install | kept-with-reason: already visible and sandbox execution later fails if dependency is truly required | N/A | N/A |
+| `researchclaw/pipeline/_helpers.py` | 972 | LLM chat retry wrapper | Retries and raises after exhaustion | kept-with-reason: not fail-open because final exception propagates | Existing LLM helper tests | N/A |
+| `researchclaw/pipeline/_helpers.py` | 1029 | Evolution overlay prompt section | Overlay omitted | kept-with-reason: optional prompt enrichment | N/A | N/A |
+| `researchclaw/pipeline/_helpers.py` | 1041 | Matched skills prompt section | Skills omitted | kept-with-reason: optional prompt enrichment | N/A | N/A |
+| `researchclaw/pipeline/_helpers.py` | 1710 | Framework prompt LLM generation | Debug-only fallback to template prompt | kept-with-reason: explicit fallback prompt is generated | N/A | N/A |
+| `researchclaw/pipeline/_helpers.py` | 1907 | One multi-perspective debate role | Warning logged, debate continues with remaining roles | kept-with-reason: already visible and returns partial role outputs; caller can see count | N/A | N/A |
+| `researchclaw/pipeline/_domain.py` | 154 | Read `project.profile` | Falls back to empty profile | kept-with-reason: defensive config accessor for non-`RCConfig` tests | N/A | N/A |
+| `researchclaw/pipeline/_domain.py` | 169 | Read research topic and domains | Falls back to empty values | kept-with-reason: defensive config accessor for non-`RCConfig` tests | N/A | N/A |
+| `researchclaw/pipeline/_domain.py` | 186 | Coarse domain detection | Falls back to ML prompt bank | kept-with-reason: prompt-bank selection fallback, not experiment result data | N/A | N/A |
+| `researchclaw/domains/detector.py` | 250 | Loading one YAML domain profile | Warning logged, other profiles load | kept-with-reason: already visible and isolated per profile | N/A | N/A |
+| `researchclaw/domains/detector.py` | 493 | Optional LLM domain detection | Warning logged, caller falls back to deterministic detection | kept-with-reason: already visible and deterministic path remains | N/A | N/A |
+| `researchclaw/data/__init__.py` | 110 | Seminal papers YAML load | Warning logged, empty list returned | kept-with-reason: literature dataset helper is optional prompt context on this path | N/A | N/A |
+| `researchclaw/agents/benchmark_agent/surveyor.py` | 73 | Benchmark knowledge YAML load | Warning logged, empty local KB | kept-with-reason: BenchmarkAgent is optional and Stage 9 still writes `exp_plan.yaml` | N/A | N/A |
+| `researchclaw/agents/benchmark_agent/surveyor.py` | 144 | Hugging Face task search item | Debug-only skip for that task | kept-with-reason: optional remote benchmark search | N/A | N/A |
+| `researchclaw/agents/benchmark_agent/surveyor.py` | 167 | Hugging Face keyword search item | Debug-only skip for that keyword | kept-with-reason: optional remote benchmark search | N/A | N/A |
+| `researchclaw/agents/benchmark_agent/surveyor.py` | 170 | Hugging Face search wrapper | Warning logged, local benchmarks still usable | kept-with-reason: already visible and remote search is optional | N/A | N/A |
+| `researchclaw/agents/benchmark_agent/selector.py` | 231 | Benchmark selector knowledge YAML load | Empty injection list returned | kept-with-reason: optional BenchmarkAgent fallback data | N/A | N/A |
+| `researchclaw/agents/benchmark_agent/acquirer.py` | 152 | Generated torchvision download script | Generated script prints warning and continues | kept-with-reason: setup script handles optional prefetch failures explicitly | N/A | N/A |
+| `researchclaw/agents/benchmark_agent/acquirer.py` | 166 | Generated Hugging Face dataset download script | Generated script prints warning and continues | kept-with-reason: optional prefetch, experiment code can still load cached data | N/A | N/A |
+| `researchclaw/agents/benchmark_agent/acquirer.py` | 178 | Generated OGB download script | Generated script prints warning and continues | kept-with-reason: optional prefetch, experiment code can still fail if data is required | N/A | N/A |
+| `researchclaw/experiment/agentic_sandbox.py` | 153 | Agentic session run wrapper | Converts exception into failed `AgenticResult` | kept-with-reason: not silent, failure is represented in sandbox result | N/A | N/A |
+| `researchclaw/experiment/agentic_sandbox.py` | 263 | Container cleanup | Warning logged | kept-with-reason: cleanup best effort after sandbox result is already decided | N/A | N/A |
+| `researchclaw/experiment/collider_agent_sandbox.py` | 125 | ColliderAgent subprocess launch | Converts exception into failed `SandboxResult` | kept-with-reason: not silent, Stage 12 sees returncode `-1` | N/A | N/A |
+| `researchclaw/experiment/collider_agent_sandbox.py` | 145 | Incremental result merge | Warning logged, current run result remains | kept-with-reason: merge is best-effort history enrichment | N/A | N/A |
+| `researchclaw/experiment/biology_agent_sandbox.py` | 142 | BiologyAgent subprocess launch | Converts exception into failed `SandboxResult` | kept-with-reason: not silent, Stage 12 sees returncode `-1` | N/A | N/A |
+| `researchclaw/experiment/stat_agent_sandbox.py` | 114 | StatAgent subprocess launch | Converts exception into failed `SandboxResult` | kept-with-reason: not silent, Stage 12 sees returncode `-1` | N/A | N/A |
+| `researchclaw/experiment/docker_sandbox.py` | 319 | Docker sandbox run | Converts exception into failed `SandboxResult` | kept-with-reason: not silent, Stage 12 hard guards inspect failed run output | N/A | N/A |
+| `researchclaw/experiment/ssh_sandbox.py` | 399 | SSH sandbox run | Converts exception into failed result object | kept-with-reason: not silent, error is returned in result | N/A | N/A |
+| `researchclaw/experiment/colab_sandbox.py` | 104 | Colab subprocess run | Converts exception into result dict with traceback | kept-with-reason: not silent, error is returned in result | N/A | N/A |
+| `researchclaw/experiment/sandbox.py` | 343 | Single-file subprocess sandbox run | Converts exception into failed `SandboxResult` | kept-with-reason: not silent, Stage 12 hard guards inspect failed run output | N/A | N/A |
+| `researchclaw/experiment/sandbox.py` | 446 | Project subprocess sandbox run | Converts exception into failed `SandboxResult` | kept-with-reason: not silent, Stage 12 hard guards inspect failed run output | N/A | N/A |
+| `researchclaw/experiment/sandbox.py` | 543 | Temporary script cleanup | Warning logged | kept-with-reason: cleanup best effort after sandbox result is already captured | N/A | N/A |
+| `researchclaw/experiment/metrics.py` | 126 | `results.json` parser | Warning logged, CSV/stdout fallbacks attempted | kept-with-reason: visible parser fallback chain | N/A | N/A |
+| `researchclaw/experiment/metrics.py` | 137 | `results.csv` parser | Warning logged, stdout fallback attempted | kept-with-reason: visible parser fallback chain | N/A | N/A |
+| `researchclaw/experiment/metrics.py` | 150 | `stdout.log` read | Warning logged, source `none` returned | kept-with-reason: visible parser fallback chain | N/A | N/A |
+| `researchclaw/experiment/runner.py` | 271 | LLM code improvement call | Exception logged, current code returned | kept-with-reason: iterative runner keeps last known runnable code | N/A | N/A |
+| `researchclaw/experiment/code_agent.py` | 255 | LLM code generation provider | Error logged, failed `CodeAgentResult` returned | kept-with-reason: not silent, caller can inspect failure | N/A | N/A |
+| `researchclaw/experiment/code_agent.py` | 322 | LLM code refinement provider | Error logged, failed `CodeAgentResult` returned | kept-with-reason: not silent, caller can inspect failure | N/A | N/A |
+| `researchclaw/experiment/code_agent.py` | 372 | LLM code critique provider | Failed `CodeAgentResult` returned | kept-with-reason: not silent, caller can inspect failure | N/A | N/A |
+| `researchclaw/experiment/git_manager.py` | 123 | Git command wrapper for experiment worktrees | Warning logged, `None` returned | kept-with-reason: helper is advisory and does not mutate remote state | N/A | N/A |
+| `researchclaw/pipeline/experiment_repair.py` | 359 | Repair-loop LLM client creation | Error logged, failed repair result returned | kept-with-reason: not silent, runner now fails Stage 14 if repair wrapper crashes | N/A | N/A |
+| `researchclaw/pipeline/experiment_repair.py` | 703 | OpenCode repair attempt | Warning logged, falls back to LLM repair | kept-with-reason: visible fallback between repair providers | N/A | N/A |
+| `researchclaw/pipeline/experiment_repair.py` | 732 | LLM repair call | Warning logged, no patch returned for that cycle | kept-with-reason: visible repair-attempt failure inside bounded repair loop | N/A | N/A |
+| `researchclaw/pipeline/experiment_repair.py` | 824 | Sandbox execution in repair cycle | Warning logged, cycle returns no run payload | kept-with-reason: visible repair-cycle failure inside bounded repair loop | N/A | N/A |
+
+## Judgment notes
+
+- The two phantom imports called out in the brief, `event_log` and
+  `pitfall_detector`, were removed instead of converted to permanent warnings
+  because neither module exists in this fork.
+- `cost_tracker` is also absent, but it guarded a configured budget. It now
+  fails before stage execution when a non-LLM CLI provider has a positive
+  budget, while preserving the default `llm` provider behavior.
+- Experiment memory was not just made visible. The runner now constructs the
+  memory store correctly and `ExperimentMemory` has a persisted outcome API.
+- The Stage 12 provenance resolver still has an explicit fail-open migration
+  rule. Existing provenance tests assert that behavior, so this audit documents
+  it rather than converting it as a drive-by policy change.

--- a/researchclaw/domains/experiment_schema.py
+++ b/researchclaw/domains/experiment_schema.py
@@ -13,6 +13,8 @@ from typing import Any
 
 import yaml
 
+SCHEMA_VERSION = "1.0"
+
 
 class ConditionRole(str, Enum):
     """Role of an experimental condition."""
@@ -60,6 +62,32 @@ class EvaluationSpec:
 
 
 @dataclass
+class ExperimentBudget:
+    """Execution budget for an experiment."""
+    wall_clock_seconds: int = 3600
+    max_cost_usd: float | None = None
+
+
+@dataclass
+class PreregisteredPrediction:
+    """Machine-checkable preregistered prediction."""
+    statement: str
+    metric: str
+    condition: str
+    baseline: str
+    comparison: str
+    min_effect_size: float = 0.0
+
+
+class SpecValidationError(ValueError):
+    """Raised when an experiment spec cannot be parsed as v1."""
+
+    def __init__(self, violations: list[str]) -> None:
+        self.violations = violations
+        super().__init__("; ".join(violations))
+
+
+@dataclass
 class UniversalExperimentPlan:
     """Domain-agnostic experiment plan.
 
@@ -87,6 +115,13 @@ class UniversalExperimentPlan:
 
     # Raw YAML (for backward compatibility with existing pipeline)
     raw_yaml: str = ""
+
+    # ExperimentSpec v1 contract fields
+    schema_version: str = SCHEMA_VERSION
+    mode: str = "falsify"
+    budget: ExperimentBudget = field(default_factory=ExperimentBudget)
+    seeds: list[int] = field(default_factory=list)
+    prediction: PreregisteredPrediction | None = None
 
     @property
     def references(self) -> list[Condition]:
@@ -138,6 +173,221 @@ class UniversalExperimentPlan:
             },
         }
 
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to the canonical ExperimentSpec v1 dict shape."""
+        return {
+            "schema_version": self.schema_version,
+            "experiment_type": self.experiment_type,
+            "domain_id": self.domain_id,
+            "problem_description": self.problem_description,
+            "conditions": [
+                {
+                    "name": c.name,
+                    "role": c.role,
+                    "description": c.description,
+                    "varies_from": c.varies_from,
+                    "variation": c.variation,
+                    "parameters": dict(c.parameters),
+                }
+                for c in self.conditions
+            ],
+            "input_type": self.input_type,
+            "input_description": self.input_description,
+            "evaluation": {
+                "primary_metric": {
+                    "name": self.evaluation.primary_metric.name,
+                    "direction": self.evaluation.primary_metric.direction,
+                    "unit": self.evaluation.primary_metric.unit,
+                    "description": self.evaluation.primary_metric.description,
+                },
+                "secondary_metrics": [
+                    {
+                        "name": m.name,
+                        "direction": m.direction,
+                        "unit": m.unit,
+                        "description": m.description,
+                    }
+                    for m in self.evaluation.secondary_metrics
+                ],
+                "protocol": self.evaluation.protocol,
+                "statistical_test": self.evaluation.statistical_test,
+                "num_seeds": self.evaluation.num_seeds,
+            },
+            "main_figure_type": self.main_figure_type,
+            "main_table_type": self.main_table_type,
+            "raw_yaml": self.raw_yaml,
+            "mode": self.mode,
+            "budget": {
+                "wall_clock_seconds": self.budget.wall_clock_seconds,
+                "max_cost_usd": self.budget.max_cost_usd,
+            },
+            "seeds": list(self.seeds),
+            "prediction": (
+                {
+                    "statement": self.prediction.statement,
+                    "metric": self.prediction.metric,
+                    "condition": self.prediction.condition,
+                    "baseline": self.prediction.baseline,
+                    "comparison": self.prediction.comparison,
+                    "min_effect_size": self.prediction.min_effect_size,
+                }
+                if self.prediction is not None
+                else None
+            ),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "UniversalExperimentPlan":
+        """Load a canonical ExperimentSpec v1 dict."""
+        if not isinstance(data, dict):
+            raise SpecValidationError(["spec must be a mapping"])
+
+        allowed_keys = {
+            "schema_version",
+            "experiment_type",
+            "domain_id",
+            "problem_description",
+            "conditions",
+            "input_type",
+            "input_description",
+            "evaluation",
+            "main_figure_type",
+            "main_table_type",
+            "raw_yaml",
+            "mode",
+            "budget",
+            "seeds",
+            "prediction",
+        }
+        unknown_keys = sorted(set(data) - allowed_keys)
+        if unknown_keys:
+            raise SpecValidationError(
+                [f"Unknown top-level key: {key}" for key in unknown_keys]
+            )
+
+        violations: list[str] = []
+
+        conditions = _conditions_from_dict(data.get("conditions", []), violations)
+        evaluation = _evaluation_from_dict(data.get("evaluation", {}), violations)
+        budget = _budget_from_dict(data.get("budget", {}), violations)
+        prediction = _prediction_from_dict(data.get("prediction"), violations)
+        seeds = data.get("seeds", [])
+        if not isinstance(seeds, list):
+            violations.append("seeds must be a list")
+            seeds = []
+        converted_seeds: list[int] = []
+        for idx, seed in enumerate(seeds):
+            try:
+                converted_seeds.append(int(seed))
+            except (TypeError, ValueError):
+                violations.append(f"seeds[{idx}] must be an integer")
+
+        if violations:
+            raise SpecValidationError(violations)
+
+        return cls(
+            schema_version=str(data.get("schema_version", SCHEMA_VERSION)),
+            experiment_type=str(
+                data.get("experiment_type", ExperimentType.COMPARISON.value)
+            ),
+            domain_id=str(data.get("domain_id", "")),
+            problem_description=str(data.get("problem_description", "")),
+            conditions=conditions,
+            input_type=str(data.get("input_type", "generated")),
+            input_description=str(data.get("input_description", "")),
+            evaluation=evaluation,
+            main_figure_type=str(data.get("main_figure_type", "bar_chart")),
+            main_table_type=str(data.get("main_table_type", "comparison_table")),
+            raw_yaml=str(data.get("raw_yaml", "")),
+            mode=str(data.get("mode", "falsify")),
+            budget=budget,
+            seeds=converted_seeds,
+            prediction=prediction,
+        )
+
+    def to_yaml_v1(self) -> str:
+        """Serialize to canonical ExperimentSpec v1 YAML."""
+        return yaml.dump(self.to_dict(), default_flow_style=False, sort_keys=False)
+
+    @classmethod
+    def from_yaml_v1(cls, text: str) -> "UniversalExperimentPlan":
+        """Load canonical ExperimentSpec v1 YAML."""
+        try:
+            data = yaml.safe_load(text) or {}
+        except yaml.YAMLError as exc:
+            raise SpecValidationError([f"invalid YAML: {exc}"]) from exc
+        return cls.from_dict(data)
+
+    def validate(self, strict: bool = True) -> list[str]:
+        """Return validation violations for this ExperimentSpec."""
+        violations: list[str] = []
+
+        if not self.conditions:
+            violations.append("at least one condition is required")
+
+        valid_roles = {role.value for role in ConditionRole}
+        for condition in self.conditions:
+            role = (
+                condition.role.value
+                if isinstance(condition.role, ConditionRole)
+                else condition.role
+            )
+            if role not in valid_roles:
+                violations.append(
+                    f"condition role for {condition.name} is invalid: {role}"
+                )
+
+        valid_experiment_types = {item.value for item in ExperimentType}
+        experiment_type = (
+            self.experiment_type.value
+            if isinstance(self.experiment_type, ExperimentType)
+            else self.experiment_type
+        )
+        if experiment_type not in valid_experiment_types:
+            violations.append(f"experiment_type is invalid: {self.experiment_type}")
+
+        if self.mode not in {"falsify", "optimize"}:
+            violations.append("mode must be 'falsify' or 'optimize'")
+
+        if self.budget.wall_clock_seconds <= 0:
+            violations.append("budget.wall_clock_seconds must be > 0")
+
+        if self.prediction is not None:
+            metric_names = {
+                self.evaluation.primary_metric.name,
+                *(metric.name for metric in self.evaluation.secondary_metrics),
+            }
+            condition_names = {condition.name for condition in self.conditions}
+            if self.prediction.metric not in metric_names:
+                violations.append(
+                    "prediction.metric is not defined in evaluation metrics: "
+                    f"{self.prediction.metric}"
+                )
+            if self.prediction.condition not in condition_names:
+                violations.append(
+                    "prediction.condition is not defined in conditions: "
+                    f"{self.prediction.condition}"
+                )
+            if self.prediction.baseline not in condition_names:
+                violations.append(
+                    "prediction.baseline is not defined in conditions: "
+                    f"{self.prediction.baseline}"
+                )
+            if self.prediction.comparison not in {"greater_than", "less_than"}:
+                violations.append(
+                    "prediction.comparison must be 'greater_than' or 'less_than'"
+                )
+
+        if strict:
+            if self.prediction is None:
+                violations.append("prediction is required for strict v1 validation")
+            if not self.seeds:
+                violations.append("seeds must be non-empty for strict v1 validation")
+            if self.schema_version != SCHEMA_VERSION:
+                violations.append(f"schema_version must be {SCHEMA_VERSION}")
+
+        return violations
+
     def to_yaml(self) -> str:
         """Serialize to YAML string."""
         data: dict[str, Any] = {
@@ -176,6 +426,182 @@ class UniversalExperimentPlan:
         return yaml.dump(data, default_flow_style=False, sort_keys=False)
 
 
+def _reject_unknown_keys(
+    name: str,
+    data: dict[str, Any],
+    allowed_keys: set[str],
+    violations: list[str],
+) -> None:
+    for key in sorted(set(data) - allowed_keys):
+        violations.append(f"Unknown {name} key: {key}")
+
+
+def _metric_from_dict(data: Any, name: str, violations: list[str]) -> MetricSpec:
+    if not isinstance(data, dict):
+        violations.append(f"{name} must be a mapping")
+        return MetricSpec(name="")
+
+    _reject_unknown_keys(
+        name,
+        data,
+        {"name", "direction", "unit", "description"},
+        violations,
+    )
+    return MetricSpec(
+        name=str(data.get("name", "")),
+        direction=str(data.get("direction", "minimize")),
+        unit=str(data.get("unit", "")),
+        description=str(data.get("description", "")),
+    )
+
+
+def _conditions_from_dict(data: Any, violations: list[str]) -> list[Condition]:
+    if not isinstance(data, list):
+        violations.append("conditions must be a list")
+        return []
+
+    conditions: list[Condition] = []
+    for idx, item in enumerate(data):
+        if not isinstance(item, dict):
+            violations.append(f"conditions[{idx}] must be a mapping")
+            continue
+        _reject_unknown_keys(
+            f"conditions[{idx}]",
+            item,
+            {"name", "role", "description", "varies_from", "variation", "parameters"},
+            violations,
+        )
+        parameters = item.get("parameters", {})
+        if not isinstance(parameters, dict):
+            violations.append(f"conditions[{idx}].parameters must be a mapping")
+            parameters = {}
+        conditions.append(
+            Condition(
+                name=str(item.get("name", "")),
+                role=str(item.get("role", ConditionRole.PROPOSED.value)),
+                description=str(item.get("description", "")),
+                varies_from=str(item.get("varies_from", "")),
+                variation=str(item.get("variation", "")),
+                parameters=dict(parameters),
+            )
+        )
+    return conditions
+
+
+def _evaluation_from_dict(data: Any, violations: list[str]) -> EvaluationSpec:
+    if not isinstance(data, dict):
+        violations.append("evaluation must be a mapping")
+        return EvaluationSpec()
+
+    _reject_unknown_keys(
+        "evaluation",
+        data,
+        {
+            "primary_metric",
+            "secondary_metrics",
+            "protocol",
+            "statistical_test",
+            "num_seeds",
+        },
+        violations,
+    )
+    primary_metric = _metric_from_dict(
+        data.get("primary_metric", {"name": "primary_metric"}),
+        "evaluation.primary_metric",
+        violations,
+    )
+    secondary_data = data.get("secondary_metrics", [])
+    if not isinstance(secondary_data, list):
+        violations.append("evaluation.secondary_metrics must be a list")
+        secondary_data = []
+    secondary_metrics = [
+        _metric_from_dict(metric, f"evaluation.secondary_metrics[{idx}]", violations)
+        for idx, metric in enumerate(secondary_data)
+    ]
+
+    try:
+        num_seeds = int(data.get("num_seeds", 3))
+    except (TypeError, ValueError):
+        violations.append("evaluation.num_seeds must be an integer")
+        num_seeds = 3
+
+    return EvaluationSpec(
+        primary_metric=primary_metric,
+        secondary_metrics=secondary_metrics,
+        protocol=str(data.get("protocol", "")),
+        statistical_test=str(data.get("statistical_test", "paired_t_test")),
+        num_seeds=num_seeds,
+    )
+
+
+def _budget_from_dict(data: Any, violations: list[str]) -> ExperimentBudget:
+    if not isinstance(data, dict):
+        violations.append("budget must be a mapping")
+        return ExperimentBudget()
+
+    _reject_unknown_keys(
+        "budget",
+        data,
+        {"wall_clock_seconds", "max_cost_usd"},
+        violations,
+    )
+    max_cost_usd = data.get("max_cost_usd")
+    try:
+        wall_clock_seconds = int(data.get("wall_clock_seconds", 3600))
+    except (TypeError, ValueError):
+        violations.append("budget.wall_clock_seconds must be an integer")
+        wall_clock_seconds = 3600
+    try:
+        converted_max_cost = (
+            float(max_cost_usd) if max_cost_usd is not None else None
+        )
+    except (TypeError, ValueError):
+        violations.append("budget.max_cost_usd must be numeric or null")
+        converted_max_cost = None
+    return ExperimentBudget(
+        wall_clock_seconds=wall_clock_seconds,
+        max_cost_usd=converted_max_cost,
+    )
+
+
+def _prediction_from_dict(
+    data: Any,
+    violations: list[str],
+) -> PreregisteredPrediction | None:
+    if data is None:
+        return None
+    if not isinstance(data, dict):
+        violations.append("prediction must be a mapping or null")
+        return None
+
+    _reject_unknown_keys(
+        "prediction",
+        data,
+        {
+            "statement",
+            "metric",
+            "condition",
+            "baseline",
+            "comparison",
+            "min_effect_size",
+        },
+        violations,
+    )
+    try:
+        min_effect_size = float(data.get("min_effect_size", 0.0))
+    except (TypeError, ValueError):
+        violations.append("prediction.min_effect_size must be numeric")
+        min_effect_size = 0.0
+    return PreregisteredPrediction(
+        statement=str(data.get("statement", "")),
+        metric=str(data.get("metric", "")),
+        condition=str(data.get("condition", "")),
+        baseline=str(data.get("baseline", "")),
+        comparison=str(data.get("comparison", "")),
+        min_effect_size=min_effect_size,
+    )
+
+
 def from_legacy_exp_plan(
     plan_yaml: str | dict[str, Any],
     domain_id: str = "",
@@ -186,9 +612,14 @@ def from_legacy_exp_plan(
     This allows existing ML experiment plans to work with the new system.
     """
     if isinstance(plan_yaml, str):
-        data = yaml.safe_load(plan_yaml) or {}
+        try:
+            data = yaml.safe_load(plan_yaml) or {}
+        except yaml.YAMLError as exc:
+            raise SpecValidationError([f"invalid legacy YAML: {exc}"]) from exc
     else:
         data = plan_yaml
+    if not isinstance(data, dict):
+        raise SpecValidationError(["legacy exp_plan must be a mapping"])
 
     conditions: list[Condition] = []
 

--- a/researchclaw/memory/experiment_memory.py
+++ b/researchclaw/memory/experiment_memory.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+from dataclasses import dataclass
 from typing import Any
 
 from researchclaw.memory.retriever import MemoryRetriever
@@ -12,6 +13,24 @@ from researchclaw.memory.store import MemoryStore
 logger = logging.getLogger(__name__)
 
 CATEGORY = "experiment"
+
+
+@dataclass(frozen=True)
+class ExperimentOutcome:
+    run_id: str
+    stage: str
+    hypothesis: str
+    config: dict[str, Any]
+    metric_name: str
+    metric_value: float
+    baseline_value: float
+    improvement: float
+    success: bool
+    failure_mode: str | None
+    packages_used: list[str]
+    hyperparameters: dict[str, Any]
+    timestamp: float
+    duration_sec: float
 
 
 class ExperimentMemory:
@@ -146,6 +165,37 @@ class ExperimentMemory:
         return self._store.add(
             CATEGORY, content, metadata, embedding, confidence
         )
+
+    def record_outcome(self, outcome: ExperimentOutcome) -> str:
+        """Record a pipeline experiment outcome and persist it immediately."""
+        content = (
+            f"Run: {outcome.run_id}\n"
+            f"Stage: {outcome.stage}\n"
+            f"Hypothesis: {outcome.hypothesis}\n"
+            f"Metric: {outcome.metric_name}={outcome.metric_value:.6g}\n"
+            f"Success: {outcome.success}"
+        )
+        metadata = {
+            "type": "outcome",
+            "run_id": outcome.run_id,
+            "stage": outcome.stage,
+            "hypothesis": outcome.hypothesis,
+            "config": outcome.config,
+            "metric_name": outcome.metric_name,
+            "metric_value": outcome.metric_value,
+            "baseline_value": outcome.baseline_value,
+            "improvement": outcome.improvement,
+            "success": outcome.success,
+            "failure_mode": outcome.failure_mode,
+            "packages_used": outcome.packages_used,
+            "hyperparameters": outcome.hyperparameters,
+            "timestamp": outcome.timestamp,
+            "duration_sec": outcome.duration_sec,
+        }
+        confidence = 0.7 if outcome.success else 0.4
+        entry_id = self._store.add(CATEGORY, content, metadata, [], confidence)
+        self._store.save()
+        return entry_id
 
     def recall_best_configs(
         self,

--- a/researchclaw/pipeline/runner.py
+++ b/researchclaw/pipeline/runner.py
@@ -771,26 +771,6 @@ def execute_pipeline(
         if stage == Stage.RESULT_ANALYSIS and result.status == StageStatus.DONE:
             result = _post_result_analysis_spec_gate(result, run_dir)
 
-        # ── Pitfall detection after code generation / experiment run ──
-        if stage in (Stage.CODE_GENERATION, Stage.EXPERIMENT_RUN) and result.status == StageStatus.DONE:
-            try:
-                from researchclaw.pipeline.pitfall_detector import PitfallDetector
-                detector = PitfallDetector()
-                code_path = run_dir / f"stage-{int(stage):02d}"
-                code_files = list(code_path.rglob("*.py"))
-                code_text = "\n".join(f.read_text(errors="ignore") for f in code_files[:5])
-                pitfalls = detector.detect_all(code=code_text, results={}, experiment_config={})
-                if pitfalls:
-                    critical = [p for p in pitfalls if p.severity == "critical"]
-                    if critical:
-                        logger.warning("CRITICAL pitfalls detected: %s", [p.description for p in critical])
-                    pitfall_report = [{"type": p.type.value, "severity": p.severity, "description": p.description} for p in pitfalls]
-                    (run_dir / f"stage-{int(stage):02d}" / "pitfall_report.json").write_text(
-                        json.dumps(pitfall_report, indent=2), encoding="utf-8"
-                    )
-            except Exception:
-                logger.debug("Pitfall detection skipped")
-
         # ── Experiment memory: record outcome after experiment stages ──
         if stage in (Stage.EXPERIMENT_RUN, Stage.ITERATIVE_REFINE) and result.status == StageStatus.DONE and exp_memory:
             try:

--- a/researchclaw/pipeline/runner.py
+++ b/researchclaw/pipeline/runner.py
@@ -883,8 +883,12 @@ def execute_pipeline(
                     backend=config.knowledge_base.backend,
                     topic=config.research.topic,
                 )
-            except Exception:  # noqa: BLE001
-                pass
+            except Exception as exc:  # noqa: BLE001
+                message = f"Knowledge base export failed: {exc}"
+                if _record_degradation(
+                    degradations, "knowledge_base_export", message
+                ):
+                    logger.warning(message)
 
         if result.status == StageStatus.DONE:
             _write_checkpoint(run_dir, stage, run_id, adapters=adapters)

--- a/researchclaw/pipeline/runner.py
+++ b/researchclaw/pipeline/runner.py
@@ -427,7 +427,9 @@ def _collect_content_metrics(run_dir: Path | None) -> dict[str, object]:
 logger = logging.getLogger(__name__)
 
 
-def _run_experiment_diagnosis(run_dir: Path, config: RCConfig, run_id: str) -> None:
+def _run_experiment_diagnosis(
+    run_dir: Path, config: RCConfig, run_id: str
+) -> str | None:
     """Run experiment diagnosis after Stage 14 and save reports.
 
     Produces:
@@ -445,7 +447,7 @@ def _run_experiment_diagnosis(run_dir: Path, config: RCConfig, run_id: str) -> N
         for candidate in sorted(run_dir.glob("stage-14*/experiment_summary.json")):
             summary_path = candidate
         if not summary_path or not summary_path.exists():
-            return
+            return None
 
         summary = json.loads(summary_path.read_text(encoding="utf-8"))
 
@@ -561,7 +563,9 @@ def _run_experiment_diagnosis(run_dir: Path, config: RCConfig, run_id: str) -> N
             print(f"[{run_id}] Experiment diagnosis: {qa.mode.value} — quality OK")
 
     except Exception as exc:
-        logger.warning("Experiment diagnosis failed: %s", exc)
+        message = f"Experiment diagnosis failed: {exc}"
+        logger.warning(message)
+        return message
 
 
 def _run_experiment_repair(run_dir: Path, config: RCConfig, run_id: str) -> None:
@@ -861,7 +865,22 @@ def execute_pipeline(
             # belongs in stage 15 RESEARCH_DECISION.
             and config.experiment.mode not in ("collider_agent", "biology_agent", "stat_agent")
         ):
-            _run_experiment_diagnosis(run_dir, config, run_id)
+            _diagnosis_error = _run_experiment_diagnosis(run_dir, config, run_id)
+            if _diagnosis_error:
+                result = StageResult(
+                    stage=result.stage,
+                    status=StageStatus.FAILED,
+                    artifacts=result.artifacts,
+                    error=_diagnosis_error,
+                    decision="retry",
+                    evidence_refs=result.evidence_refs,
+                )
+                results[-1] = result
+                print(
+                    f"{prefix} {stage.name} -- FAILED ({elapsed:.1f}s) -- "
+                    f"{_diagnosis_error}"
+                )
+                break
 
             # Check if repair loop should run
             _diag_path = run_dir / "experiment_diagnosis.json"

--- a/researchclaw/pipeline/runner.py
+++ b/researchclaw/pipeline/runner.py
@@ -568,7 +568,9 @@ def _run_experiment_diagnosis(
         return message
 
 
-def _run_experiment_repair(run_dir: Path, config: RCConfig, run_id: str) -> None:
+def _run_experiment_repair(
+    run_dir: Path, config: RCConfig, run_id: str
+) -> str | None:
     """Execute the experiment repair loop when diagnosis finds quality issues.
 
     Calls the repair loop from ``experiment_repair.py`` which:
@@ -640,17 +642,20 @@ def _run_experiment_repair(run_dir: Path, config: RCConfig, run_id: str) -> None
 
         if repair_result.success:
             # Re-run diagnosis with updated results
-            _run_experiment_diagnosis(run_dir, config, run_id)
+            return _run_experiment_diagnosis(run_dir, config, run_id)
         else:
             logger.info(
                 "[%s] Repair loop completed without reaching full_paper quality "
                 "(best mode: %s, %d cycles)",
                 run_id, repair_result.final_mode.value, repair_result.total_cycles,
             )
+            return None
 
     except Exception as exc:
-        logger.warning("[%s] Experiment repair failed: %s", run_id, exc)
-        print(f"[{run_id}] Experiment repair failed: {exc}")
+        message = f"Experiment repair failed: {exc}"
+        logger.warning("[%s] %s", run_id, message)
+        print(f"[{run_id}] {message}")
+        return message
 
 
 def execute_pipeline(
@@ -888,7 +893,24 @@ def execute_pipeline(
                 try:
                     _diag_data = json.loads(_diag_path.read_text(encoding="utf-8"))
                     if _diag_data.get("repair_needed"):
-                        _run_experiment_repair(run_dir, config, run_id)
+                        _repair_error = _run_experiment_repair(
+                            run_dir, config, run_id
+                        )
+                        if _repair_error:
+                            result = StageResult(
+                                stage=result.stage,
+                                status=StageStatus.FAILED,
+                                artifacts=result.artifacts,
+                                error=_repair_error,
+                                decision="retry",
+                                evidence_refs=result.evidence_refs,
+                            )
+                            results[-1] = result
+                            print(
+                                f"{prefix} {stage.name} -- FAILED ({elapsed:.1f}s) "
+                                f"-- {_repair_error}"
+                            )
+                            break
                 except (json.JSONDecodeError, OSError):
                     pass
 

--- a/researchclaw/pipeline/runner.py
+++ b/researchclaw/pipeline/runner.py
@@ -679,18 +679,7 @@ def execute_pipeline(
     except Exception:  # noqa: BLE001
         pass
 
-    # ── Integration hooks: EventLog, ExperimentMemory, CostTracker ──
-    event_log = None
-    try:
-        from researchclaw.pipeline.event_log import EventLog, EventType, create_event
-        event_log = EventLog(log_dir=run_dir)
-        event_log.append(create_event(
-            EventType.PIPELINE_START, run_id=run_id,
-            stages=total_stages, from_stage=int(from_stage),
-        ))
-    except Exception:
-        logger.debug("Event log initialisation skipped")
-
+    # ── Integration hooks: ExperimentMemory, CostTracker ──
     exp_memory = None
     try:
         from researchclaw.memory.experiment_memory import ExperimentMemory
@@ -727,15 +716,6 @@ def execute_pipeline(
         stage_num = int(stage)
         prefix = f"[{run_id}] Stage {stage_num:02d}/{total_stages}"
         print(f"{prefix} {stage.name} — running...")
-
-        # ── Event log: stage start ──
-        if event_log:
-            try:
-                event_log.append(create_event(
-                    EventType.STAGE_START, run_id=run_id, stage=stage.name,
-                ))
-            except Exception:
-                pass
 
         # ── Cost budget check ──
         if enforce_cost_budget:
@@ -783,18 +763,6 @@ def execute_pipeline(
             auto_approve_gates=auto_approve_gates,
         )
         elapsed = _time.monotonic() - t0
-
-        # ── Event log: stage end ──
-        if event_log:
-            try:
-                etype = EventType.STAGE_END if result.status == StageStatus.DONE else EventType.STAGE_FAIL
-                event_log.append(create_event(
-                    etype, run_id=run_id, stage=stage.name,
-                    status=result.status.value, elapsed_sec=round(elapsed, 1),
-                    error=result.error,
-                ))
-            except Exception:
-                pass
 
         # ── ExperimentSpec: generate after design, validate after analysis ──
         if stage == Stage.EXPERIMENT_DESIGN and result.status == StageStatus.DONE:
@@ -1086,18 +1054,6 @@ def execute_pipeline(
         degradations=degradations,
     )
     _write_pipeline_summary(run_dir, summary)
-
-    # ── Event log: pipeline end ──
-    if event_log:
-        try:
-            done_count = sum(1 for r in results if r.status == StageStatus.DONE)
-            failed_count = sum(1 for r in results if r.status == StageStatus.FAILED)
-            event_log.append(create_event(
-                EventType.PIPELINE_END, run_id=run_id,
-                stages_done=done_count, stages_failed=failed_count,
-            ))
-        except Exception:
-            pass
 
     # --- Evolution: extract and store lessons ---
     lessons: list[object] = []

--- a/researchclaw/pipeline/runner.py
+++ b/researchclaw/pipeline/runner.py
@@ -10,6 +10,7 @@ import tempfile
 import threading
 import time as _time
 from pathlib import Path
+from typing import Any
 
 from researchclaw.adapters import AdapterBundle
 from researchclaw.config import RCConfig
@@ -149,6 +150,212 @@ def resume_from_checkpoint(
     """Resolve the stage to resume from using checkpoint metadata."""
     next_stage = read_checkpoint(run_dir)
     return next_stage if next_stage is not None else default_stage
+
+
+def _with_artifact_once(artifacts: tuple[str, ...], artifact: str) -> tuple[str, ...]:
+    if artifact in artifacts:
+        return artifacts
+    return (*artifacts, artifact)
+
+
+def _with_evidence_once(
+    evidence_refs: tuple[str, ...],
+    evidence_ref: str,
+) -> tuple[str, ...]:
+    if evidence_ref in evidence_refs:
+        return evidence_refs
+    return (*evidence_refs, evidence_ref)
+
+
+def _write_spec_violations(stage_dir: Path, violations: list[str]) -> Path:
+    path = stage_dir / "spec_violations.json"
+    stage_dir.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(violations, indent=2), encoding="utf-8")
+    return path
+
+
+def _fail_with_spec_violations(
+    result: StageResult,
+    stage_dir: Path,
+    violations: list[str],
+) -> StageResult:
+    violations_path = _write_spec_violations(stage_dir, violations)
+    logger.warning(
+        "Experiment spec validation failed for %s: %s",
+        result.stage.name,
+        violations,
+    )
+    return StageResult(
+        stage=result.stage,
+        status=StageStatus.FAILED,
+        artifacts=_with_artifact_once(result.artifacts, violations_path.name),
+        error="Experiment spec validation failed: " + "; ".join(violations),
+        decision="retry",
+        evidence_refs=_with_evidence_once(
+            result.evidence_refs,
+            f"{stage_dir.name}/{violations_path.name}",
+        ),
+    )
+
+
+def _post_experiment_design_spec_gate(
+    result: StageResult,
+    run_dir: Path,
+    config: RCConfig,
+) -> StageResult:
+    from researchclaw.domains.experiment_schema import (
+        SpecValidationError,
+        from_legacy_exp_plan,
+    )
+
+    stage_dir = run_dir / f"stage-{int(Stage.EXPERIMENT_DESIGN):02d}"
+    plan_path = stage_dir / "exp_plan.yaml"
+    if not plan_path.exists():
+        if "exp_plan.yaml" in result.artifacts:
+            return _fail_with_spec_violations(
+                result,
+                stage_dir,
+                ["missing exp_plan.yaml"],
+            )
+        return result
+
+    domain_id = str(getattr(getattr(config, "project", None), "profile", "") or "")
+    try:
+        plan_text = plan_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return _fail_with_spec_violations(
+            result,
+            stage_dir,
+            [f"could not read exp_plan.yaml: {exc}"],
+        )
+    try:
+        spec = from_legacy_exp_plan(
+            plan_text,
+            domain_id=domain_id,
+        )
+    except SpecValidationError as exc:
+        return _fail_with_spec_violations(result, stage_dir, exc.violations)
+    violations = spec.validate(strict=False)
+    if violations:
+        return _fail_with_spec_violations(result, stage_dir, violations)
+
+    spec_path = stage_dir / "experiment_spec.yaml"
+    spec_path.write_text(spec.to_yaml_v1(), encoding="utf-8")
+    logger.info("Experiment spec generated: %s", spec_path)
+    return StageResult(
+        stage=result.stage,
+        status=result.status,
+        artifacts=_with_artifact_once(result.artifacts, spec_path.name),
+        error=result.error,
+        decision=result.decision,
+        evidence_refs=_with_evidence_once(
+            result.evidence_refs,
+            f"{stage_dir.name}/{spec_path.name}",
+        ),
+    )
+
+
+def _metric_contract_names(spec: object) -> list[str]:
+    evaluation = getattr(spec, "evaluation")
+    names = [evaluation.primary_metric.name]
+    names.extend(metric.name for metric in evaluation.secondary_metrics)
+    return [name for name in names if name]
+
+
+def _result_metric_mapping(results: dict[str, Any]) -> dict[str, Any]:
+    metrics = results.get("metrics")
+    if isinstance(metrics, dict):
+        return metrics
+    return results
+
+
+def _validate_results_against_metric_contract(
+    spec: object,
+    results: dict[str, Any],
+) -> list[str]:
+    result_metrics = _result_metric_mapping(results)
+    violations: list[str] = []
+    for metric_name in _metric_contract_names(spec):
+        if metric_name not in result_metrics:
+            violations.append(f"missing result metric: {metric_name}")
+            continue
+        value = result_metrics[metric_name]
+        if (
+            isinstance(value, bool)
+            or not isinstance(value, (int, float))
+            or not math.isfinite(float(value))
+        ):
+            violations.append(f"non-numeric result metric: {metric_name}")
+    return violations
+
+
+def _post_result_analysis_spec_gate(
+    result: StageResult,
+    run_dir: Path,
+) -> StageResult:
+    from researchclaw.domains.experiment_schema import (
+        SpecValidationError,
+        UniversalExperimentPlan,
+    )
+
+    stage_dir = run_dir / f"stage-{int(Stage.RESULT_ANALYSIS):02d}"
+    spec_path = run_dir / "stage-09" / "experiment_spec.yaml"
+    if not spec_path.exists():
+        logger.warning(
+            "Experiment spec validation skipped: %s is missing, likely from a pre-v1 stage 9 run",
+            spec_path,
+        )
+        return result
+
+    try:
+        spec_text = spec_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return _fail_with_spec_violations(
+            result,
+            stage_dir,
+            [f"could not read experiment_spec.yaml: {exc}"],
+        )
+    try:
+        spec = UniversalExperimentPlan.from_yaml_v1(spec_text)
+    except SpecValidationError as exc:
+        return _fail_with_spec_violations(result, stage_dir, exc.violations)
+
+    spec_violations = spec.validate(strict=False)
+    if spec_violations:
+        return _fail_with_spec_violations(result, stage_dir, spec_violations)
+
+    results_path = run_dir / "results.json"
+    exp_results: dict[str, Any] = {}
+    if results_path.exists():
+        try:
+            results_text = results_path.read_text(encoding="utf-8")
+        except OSError as exc:
+            return _fail_with_spec_violations(
+                result,
+                stage_dir,
+                [f"could not read results.json: {exc}"],
+            )
+        try:
+            loaded = json.loads(results_text)
+        except json.JSONDecodeError as exc:
+            return _fail_with_spec_violations(
+                result,
+                stage_dir,
+                [f"results.json is invalid JSON: {exc}"],
+            )
+        if isinstance(loaded, dict):
+            exp_results = loaded
+        else:
+            return _fail_with_spec_violations(
+                result,
+                stage_dir,
+                ["results.json must contain a JSON object"],
+            )
+
+    violations = _validate_results_against_metric_contract(spec, exp_results)
+    if violations:
+        return _fail_with_spec_violations(result, stage_dir, violations)
+    return result
 
 
 def _collect_content_metrics(run_dir: Path | None) -> dict[str, object]:
@@ -550,33 +757,10 @@ def execute_pipeline(
 
         # ── ExperimentSpec: generate after design, validate after analysis ──
         if stage == Stage.EXPERIMENT_DESIGN and result.status == StageStatus.DONE:
-            try:
-                from researchclaw.pipeline.experiment_spec import ExperimentSpec, MetricDef, generate_spec
-                spec_text = generate_spec(config.research.topic, "")
-                spec_path = run_dir / f"stage-{int(stage):02d}" / "experiment_spec.md"
-                spec_path.write_text(spec_text, encoding="utf-8")
-                logger.info("Experiment spec generated: %s", spec_path)
-            except Exception:
-                logger.debug("Experiment spec generation skipped")
+            result = _post_experiment_design_spec_gate(result, run_dir, config)
 
         if stage == Stage.RESULT_ANALYSIS and result.status == StageStatus.DONE:
-            try:
-                from researchclaw.pipeline.experiment_spec import parse_spec, validate_results_against_spec
-                spec_path = run_dir / "stage-09" / "experiment_spec.md"
-                if spec_path.exists():
-                    spec = parse_spec(spec_path.read_text(encoding="utf-8"))
-                    results_path = run_dir / "results.json"
-                    exp_results = {}
-                    if results_path.exists():
-                        exp_results = json.loads(results_path.read_text(encoding="utf-8"))
-                    violations = validate_results_against_spec(spec, exp_results)
-                    if violations:
-                        logger.warning("Spec violations: %s", violations)
-                        (run_dir / f"stage-{int(stage):02d}" / "spec_violations.json").write_text(
-                            json.dumps(violations, indent=2), encoding="utf-8"
-                        )
-            except Exception:
-                logger.debug("Experiment spec validation skipped")
+            result = _post_result_analysis_spec_gate(result, run_dir)
 
         # ── Pitfall detection after code generation / experiment run ──
         if stage in (Stage.CODE_GENERATION, Stage.EXPERIMENT_RUN) and result.status == StageStatus.DONE:

--- a/researchclaw/pipeline/runner.py
+++ b/researchclaw/pipeline/runner.py
@@ -45,6 +45,7 @@ def _build_pipeline_summary(
     results: list[StageResult],
     from_stage: Stage,
     run_dir: Path | None = None,
+    degradations: list[dict[str, str]] | None = None,
 ) -> dict[str, object]:
     summary: dict[str, object] = {
         "run_id": run_id,
@@ -66,6 +67,8 @@ def _build_pipeline_summary(
         "generated": _utcnow_iso(),
         "content_metrics": _collect_content_metrics(run_dir),
     }
+    if degradations:
+        summary["degradations"] = list(degradations)
     return summary
 
 
@@ -74,6 +77,17 @@ def _write_pipeline_summary(run_dir: Path, summary: dict[str, object]) -> None:
         json.dumps(summary, indent=2),
         encoding="utf-8",
     )
+
+
+def _record_degradation(
+    degradations: list[dict[str, str]],
+    key: str,
+    message: str,
+) -> bool:
+    if any(item.get("key") == key for item in degradations):
+        return False
+    degradations.append({"key": key, "message": message})
+    return True
 
 
 def _write_checkpoint(
@@ -652,6 +666,7 @@ def execute_pipeline(
     """Execute pipeline stages sequentially from *from_stage* to *to_stage* (inclusive)."""
 
     results: list[StageResult] = []
+    degradations: list[dict[str, str]] = []
     started = False
     total_stages = len(STAGE_SEQUENCE)
 
@@ -679,11 +694,18 @@ def execute_pipeline(
     exp_memory = None
     try:
         from researchclaw.memory.experiment_memory import ExperimentMemory
+        from researchclaw.memory.retriever import MemoryRetriever
+        from researchclaw.memory.store import MemoryStore
+
         _mem_dir = run_dir / "experiment_memory"
         _mem_dir.mkdir(parents=True, exist_ok=True)
-        exp_memory = ExperimentMemory(store_dir=str(_mem_dir))
-    except Exception:
-        logger.debug("Experiment memory initialisation skipped")
+        _mem_store = MemoryStore(_mem_dir)
+        _mem_store.load()
+        exp_memory = ExperimentMemory(_mem_store, MemoryRetriever(_mem_store))
+    except Exception as exc:
+        message = f"Experiment memory initialization failed: {exc}"
+        if _record_degradation(degradations, "experiment_memory_init", message):
+            logger.warning(message)
 
     cli_agent_provider = (
         getattr(config.experiment.cli_agent, "provider", "llm") or "llm"
@@ -1053,6 +1075,7 @@ def execute_pipeline(
         results=results,
         from_stage=from_stage,
         run_dir=run_dir,
+        degradations=degradations,
     )
     _write_pipeline_summary(run_dir, summary)
 

--- a/researchclaw/pipeline/runner.py
+++ b/researchclaw/pipeline/runner.py
@@ -685,8 +685,26 @@ def execute_pipeline(
         from researchclaw.domains.detector import set_forced_profile
         forced = getattr(config.project, "profile", "") or ""
         set_forced_profile(forced)
-    except Exception:  # noqa: BLE001
-        pass
+    except Exception as exc:  # noqa: BLE001
+        error = f"Domain profile setup failed: {exc}"
+        logger.error(error)
+        result = StageResult(
+            stage=from_stage,
+            status=StageStatus.FAILED,
+            artifacts=(),
+            error=error,
+            decision="abort",
+        )
+        _write_pipeline_summary(
+            run_dir,
+            _build_pipeline_summary(
+                run_id=run_id,
+                results=[result],
+                from_stage=from_stage,
+                run_dir=run_dir,
+            ),
+        )
+        return [result]
 
     # ── Integration hooks: ExperimentMemory, CostTracker ──
     exp_memory = None

--- a/researchclaw/pipeline/runner.py
+++ b/researchclaw/pipeline/runner.py
@@ -685,7 +685,11 @@ def execute_pipeline(
     except Exception:
         logger.debug("Experiment memory initialisation skipped")
 
+    cli_agent_provider = (
+        getattr(config.experiment.cli_agent, "provider", "llm") or "llm"
+    )
     cost_budget = getattr(config.experiment.cli_agent, "max_budget_usd", 0.0) or 0.0
+    enforce_cost_budget = cost_budget > 0 and cli_agent_provider != "llm"
 
     for stage in STAGE_SEQUENCE:
         started = _should_start(stage, from_stage, started)
@@ -712,15 +716,30 @@ def execute_pipeline(
                 pass
 
         # ── Cost budget check ──
-        if cost_budget > 0:
-            try:
-                from researchclaw.cost_tracker import get_global_tracker
-                if not get_global_tracker().check_budget(cost_budget):
-                    logger.warning("Cost budget $%.2f exceeded — pausing pipeline", cost_budget)
-                    print(f"{prefix} BUDGET EXCEEDED ($%.2f) — stopping" % cost_budget)
-                    break
-            except Exception:
-                pass
+        if enforce_cost_budget:
+            if importlib.util.find_spec("researchclaw.cost_tracker") is None:
+                error = (
+                    "Cost budget enforcement is configured for CLI agent provider "
+                    f"'{cli_agent_provider}', but researchclaw.cost_tracker is unavailable"
+                )
+                logger.error(error)
+                result = StageResult(
+                    stage=stage,
+                    status=StageStatus.FAILED,
+                    artifacts=(),
+                    error=error,
+                    decision="abort",
+                )
+                print(f"{prefix} {stage.name} -- FAILED (0.0s) -- {error}")
+                results.append(result)
+                break
+
+            from researchclaw.cost_tracker import get_global_tracker
+
+            if not get_global_tracker().check_budget(cost_budget):
+                logger.warning("Cost budget $%.2f exceeded; pausing pipeline", cost_budget)
+                print(f"{prefix} BUDGET EXCEEDED ($%.2f) -- stopping" % cost_budget)
+                break
 
         # BUG-218: Ensure the best stage-14 experiment data is promoted
         # BEFORE paper writing begins.  Without this, the recursive REFINE

--- a/researchclaw/pipeline/runner.py
+++ b/researchclaw/pipeline/runner.py
@@ -844,8 +844,12 @@ def execute_pipeline(
                     packages_used=[], hyperparameters={},
                     timestamp=_time_mod.time(), duration_sec=elapsed,
                 ))
-            except Exception:
-                logger.debug("Experiment memory recording skipped")
+            except Exception as exc:
+                message = f"Experiment memory recording failed: {exc}"
+                if _record_degradation(
+                    degradations, "experiment_memory_record", message
+                ):
+                    logger.warning(message)
 
         if result.status == StageStatus.DONE:
             arts = ", ".join(result.artifacts) if result.artifacts else "none"

--- a/tests/test_experiment_schema.py
+++ b/tests/test_experiment_schema.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 import yaml
 
+import researchclaw.domains.experiment_schema as experiment_schema
 from researchclaw.domains.experiment_schema import (
     Condition,
     ConditionRole,
@@ -14,6 +15,69 @@ from researchclaw.domains.experiment_schema import (
     UniversalExperimentPlan,
     from_legacy_exp_plan,
 )
+
+
+def _full_v1_plan() -> UniversalExperimentPlan:
+    return UniversalExperimentPlan(
+        experiment_type=ExperimentType.COMPARISON.value,
+        domain_id="ml_vision",
+        problem_description="Compare classifier variants",
+        conditions=[
+            Condition(
+                name="baseline",
+                role=ConditionRole.REFERENCE.value,
+                description="Reference classifier",
+                parameters={"depth": 18},
+            ),
+            Condition(
+                name="proposed",
+                role=ConditionRole.PROPOSED.value,
+                description="New classifier",
+                parameters={"depth": 34},
+            ),
+            Condition(
+                name="proposed_no_aug",
+                role=ConditionRole.VARIANT.value,
+                description="No augmentation variant",
+                varies_from="proposed",
+                variation="disable augmentation",
+                parameters={"augmentation": False},
+            ),
+        ],
+        input_type="benchmark_dataset",
+        input_description="CIFAR-like benchmark",
+        evaluation=EvaluationSpec(
+            primary_metric=MetricSpec(
+                name="accuracy",
+                direction="maximize",
+                unit="fraction",
+                description="Held-out accuracy",
+            ),
+            secondary_metrics=[
+                MetricSpec(name="latency", direction="minimize", unit="ms"),
+            ],
+            protocol="train on train split, evaluate on holdout",
+            statistical_test="bootstrap_ci",
+            num_seeds=5,
+        ),
+        main_figure_type="line_chart",
+        main_table_type="metric_table",
+        raw_yaml="raw: yaml\n",
+        mode="falsify",
+        budget=experiment_schema.ExperimentBudget(
+            wall_clock_seconds=7200,
+            max_cost_usd=12.5,
+        ),
+        seeds=[1, 2, 3],
+        prediction=experiment_schema.PreregisteredPrediction(
+            statement="The proposed method improves accuracy",
+            metric="accuracy",
+            condition="proposed",
+            baseline="baseline",
+            comparison="greater_than",
+            min_effect_size=0.02,
+        ),
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -50,6 +114,14 @@ class TestUniversalExperimentPlan:
         plan = UniversalExperimentPlan()
         assert plan.conditions == []
         assert plan.experiment_type == "comparison"
+
+    def test_legacy_positional_constructor_order_is_preserved(self):
+        plan = UniversalExperimentPlan("convergence", "physics_pde", "Track error")
+
+        assert plan.experiment_type == "convergence"
+        assert plan.domain_id == "physics_pde"
+        assert plan.problem_description == "Track error"
+        assert plan.schema_version == experiment_schema.SCHEMA_VERSION
 
     def test_plan_with_conditions(self):
         plan = UniversalExperimentPlan(
@@ -96,6 +168,63 @@ class TestUniversalExperimentPlan:
         assert data["experiment"]["type"] == "convergence"
         assert data["experiment"]["domain"] == "physics_pde"
         assert len(data["experiment"]["conditions"]) == 2
+
+    def test_v1_yaml_file_roundtrip_preserves_every_field(self, tmp_path):
+        plan = _full_v1_plan()
+        path = tmp_path / "experiment_spec.yaml"
+
+        path.write_text(plan.to_yaml_v1(), encoding="utf-8")
+        plan2 = UniversalExperimentPlan.from_yaml_v1(
+            path.read_text(encoding="utf-8")
+        )
+
+        assert plan2 == plan
+        assert plan2.to_dict() == plan.to_dict()
+
+    def test_from_dict_rejects_unknown_top_level_keys(self):
+        data = _full_v1_plan().to_dict()
+        data["silently_lost"] = True
+        error_type = experiment_schema.SpecValidationError
+
+        with pytest.raises(error_type) as excinfo:
+            UniversalExperimentPlan.from_dict(data)
+
+        assert "Unknown top-level key: silently_lost" in excinfo.value.violations
+
+    def test_validate_strict_requires_prediction_seeds_and_schema_version(self):
+        plan = _full_v1_plan()
+        plan.prediction = None
+        plan.seeds = []
+        plan.schema_version = "0.9"
+
+        violations = plan.validate(strict=True)
+
+        assert "prediction is required for strict v1 validation" in violations
+        assert "seeds must be non-empty for strict v1 validation" in violations
+        assert "schema_version must be 1.0" in violations
+
+    def test_validate_structural_checks(self):
+        plan = _full_v1_plan()
+        plan.experiment_type = "unsupported"
+        plan.mode = "explore"
+        plan.budget.wall_clock_seconds = 0
+        plan.conditions[0].role = "control"
+        assert plan.prediction is not None
+        plan.prediction.metric = "missing_metric"
+        plan.prediction.condition = "missing_condition"
+        plan.prediction.baseline = "missing_baseline"
+        plan.prediction.comparison = "equal_to"
+
+        violations = plan.validate(strict=False)
+
+        assert "experiment_type is invalid: unsupported" in violations
+        assert "mode must be 'falsify' or 'optimize'" in violations
+        assert "budget.wall_clock_seconds must be > 0" in violations
+        assert "condition role for baseline is invalid: control" in violations
+        assert "prediction.metric is not defined in evaluation metrics: missing_metric" in violations
+        assert "prediction.condition is not defined in conditions: missing_condition" in violations
+        assert "prediction.baseline is not defined in conditions: missing_baseline" in violations
+        assert "prediction.comparison must be 'greater_than' or 'less_than'" in violations
 
 
 # ---------------------------------------------------------------------------
@@ -180,6 +309,19 @@ metrics:
         legacy = {"metrics": ["accuracy", "f1"]}
         plan = from_legacy_exp_plan(legacy)
         assert plan.evaluation.primary_metric.name == "accuracy"
+
+    def test_legacy_converted_plan_passes_structural_not_strict_validation(self):
+        legacy = {
+            "baselines": [{"name": "baseline"}],
+            "proposed_methods": [{"name": "proposed"}],
+            "metrics": {"accuracy": {"direction": "maximize"}},
+        }
+        plan = from_legacy_exp_plan(legacy)
+
+        assert plan.validate(strict=False) == []
+        assert "prediction is required for strict v1 validation" in plan.validate(
+            strict=True
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_rc_runner.py
+++ b/tests/test_rc_runner.py
@@ -362,6 +362,208 @@ def test_execute_pipeline_passes_auto_approve_flag_to_execute_stage(
     assert all(received)
 
 
+def test_experiment_design_spec_violations_fail_stage(
+    monkeypatch: pytest.MonkeyPatch,
+    run_dir: Path,
+    rc_config: RCConfig,
+    adapters: AdapterBundle,
+) -> None:
+    def mock_execute_stage(stage: Stage, **kwargs) -> StageResult:
+        _ = kwargs
+        stage_dir = run_dir / f"stage-{int(stage):02d}"
+        stage_dir.mkdir(parents=True, exist_ok=True)
+        (stage_dir / "exp_plan.yaml").write_text(
+            "metrics:\n  accuracy:\n    direction: maximize\n",
+            encoding="utf-8",
+        )
+        return _done(stage, artifacts=("exp_plan.yaml",))
+
+    monkeypatch.setattr(rc_runner, "execute_stage", mock_execute_stage)
+
+    results = rc_runner.execute_pipeline(
+        run_dir=run_dir,
+        run_id="run-exp-spec-gate",
+        config=rc_config,
+        adapters=adapters,
+        from_stage=Stage.EXPERIMENT_DESIGN,
+        to_stage=Stage.EXPERIMENT_DESIGN,
+    )
+
+    assert results[-1].status == StageStatus.FAILED
+    violations_path = run_dir / "stage-09" / "spec_violations.json"
+    assert violations_path.exists()
+    violations = json.loads(violations_path.read_text(encoding="utf-8"))
+    assert "at least one condition is required" in violations
+
+
+def test_result_analysis_missing_metric_contract_fails_stage(
+    monkeypatch: pytest.MonkeyPatch,
+    run_dir: Path,
+    rc_config: RCConfig,
+    adapters: AdapterBundle,
+) -> None:
+    spec_dir = run_dir / "stage-09"
+    spec_dir.mkdir(parents=True)
+    spec = {
+        "schema_version": "1.0",
+        "experiment_type": "comparison",
+        "domain_id": "ml_vision",
+        "problem_description": "Compare methods",
+        "conditions": [
+            {
+                "name": "baseline",
+                "role": "reference",
+                "description": "",
+                "varies_from": "",
+                "variation": "",
+                "parameters": {},
+            },
+            {
+                "name": "proposed",
+                "role": "proposed",
+                "description": "",
+                "varies_from": "",
+                "variation": "",
+                "parameters": {},
+            },
+        ],
+        "input_type": "generated",
+        "input_description": "",
+        "evaluation": {
+            "primary_metric": {
+                "name": "accuracy",
+                "direction": "maximize",
+                "unit": "",
+                "description": "",
+            },
+            "secondary_metrics": [
+                {
+                    "name": "loss",
+                    "direction": "minimize",
+                    "unit": "",
+                    "description": "",
+                },
+            ],
+            "protocol": "",
+            "statistical_test": "paired_t_test",
+            "num_seeds": 3,
+        },
+        "main_figure_type": "bar_chart",
+        "main_table_type": "comparison_table",
+        "raw_yaml": "",
+        "mode": "falsify",
+        "budget": {"wall_clock_seconds": 3600, "max_cost_usd": None},
+        "seeds": [1],
+        "prediction": {
+            "statement": "Proposed improves accuracy",
+            "metric": "accuracy",
+            "condition": "proposed",
+            "baseline": "baseline",
+            "comparison": "greater_than",
+            "min_effect_size": 0.01,
+        },
+    }
+    (spec_dir / "experiment_spec.yaml").write_text(
+        json.dumps(spec),
+        encoding="utf-8",
+    )
+
+    def mock_execute_stage(stage: Stage, **kwargs) -> StageResult:
+        _ = kwargs
+        stage_dir = run_dir / f"stage-{int(stage):02d}"
+        stage_dir.mkdir(parents=True, exist_ok=True)
+        (run_dir / "results.json").write_text(
+            json.dumps({"accuracy": 0.82}),
+            encoding="utf-8",
+        )
+        return _done(stage)
+
+    monkeypatch.setattr(rc_runner, "execute_stage", mock_execute_stage)
+
+    results = rc_runner.execute_pipeline(
+        run_dir=run_dir,
+        run_id="run-results-spec-gate",
+        config=rc_config,
+        adapters=adapters,
+        from_stage=Stage.RESULT_ANALYSIS,
+        to_stage=Stage.RESULT_ANALYSIS,
+    )
+
+    assert results[-1].status == StageStatus.FAILED
+    violations_path = run_dir / "stage-14" / "spec_violations.json"
+    assert violations_path.exists()
+    violations = json.loads(violations_path.read_text(encoding="utf-8"))
+    assert "missing result metric: loss" in violations
+
+
+def test_result_analysis_non_numeric_metric_contract_fails_stage(
+    monkeypatch: pytest.MonkeyPatch,
+    run_dir: Path,
+    rc_config: RCConfig,
+    adapters: AdapterBundle,
+) -> None:
+    from researchclaw.domains.experiment_schema import (
+        Condition,
+        EvaluationSpec,
+        MetricSpec,
+        PreregisteredPrediction,
+        UniversalExperimentPlan,
+    )
+
+    spec_dir = run_dir / "stage-09"
+    spec_dir.mkdir(parents=True)
+    spec = UniversalExperimentPlan(
+        domain_id="ml_vision",
+        conditions=[
+            Condition(name="baseline", role="reference"),
+            Condition(name="proposed", role="proposed"),
+        ],
+        evaluation=EvaluationSpec(
+            primary_metric=MetricSpec(name="accuracy", direction="maximize"),
+        ),
+        seeds=[1],
+        prediction=PreregisteredPrediction(
+            statement="Proposed improves accuracy",
+            metric="accuracy",
+            condition="proposed",
+            baseline="baseline",
+            comparison="greater_than",
+            min_effect_size=0.01,
+        ),
+    )
+    (spec_dir / "experiment_spec.yaml").write_text(
+        spec.to_yaml_v1(),
+        encoding="utf-8",
+    )
+
+    def mock_execute_stage(stage: Stage, **kwargs) -> StageResult:
+        _ = kwargs
+        stage_dir = run_dir / f"stage-{int(stage):02d}"
+        stage_dir.mkdir(parents=True, exist_ok=True)
+        (run_dir / "results.json").write_text(
+            json.dumps({"accuracy": "0.82"}),
+            encoding="utf-8",
+        )
+        return _done(stage)
+
+    monkeypatch.setattr(rc_runner, "execute_stage", mock_execute_stage)
+
+    results = rc_runner.execute_pipeline(
+        run_dir=run_dir,
+        run_id="run-results-spec-nonnumeric-gate",
+        config=rc_config,
+        adapters=adapters,
+        from_stage=Stage.RESULT_ANALYSIS,
+        to_stage=Stage.RESULT_ANALYSIS,
+    )
+
+    assert results[-1].status == StageStatus.FAILED
+    violations_path = run_dir / "stage-14" / "spec_violations.json"
+    assert violations_path.exists()
+    violations = json.loads(violations_path.read_text(encoding="utf-8"))
+    assert "non-numeric result metric: accuracy" in violations
+
+
 @pytest.mark.parametrize(
     ("stage", "started", "expected"),
     [

--- a/tests/test_rc_runner.py
+++ b/tests/test_rc_runner.py
@@ -806,6 +806,48 @@ def test_kb_export_failure_is_recorded_once(
     ]
 
 
+def test_result_analysis_diagnosis_failure_fails_stage(
+    monkeypatch: pytest.MonkeyPatch,
+    run_dir: Path,
+    rc_config: RCConfig,
+    adapters: AdapterBundle,
+) -> None:
+    import researchclaw.pipeline.experiment_diagnosis as diagnosis_module
+
+    def broken_diagnose_experiment(*args: object, **kwargs: object) -> object:
+        _ = args, kwargs
+        raise RuntimeError("diagnosis boom")
+
+    def mock_execute_stage(stage: Stage, **kwargs) -> StageResult:
+        _ = kwargs
+        stage_dir = run_dir / f"stage-{int(stage):02d}"
+        stage_dir.mkdir(parents=True, exist_ok=True)
+        if stage == Stage.RESULT_ANALYSIS:
+            (stage_dir / "experiment_summary.json").write_text(
+                json.dumps({"metrics": {"primary_metric": 0.42}}),
+                encoding="utf-8",
+            )
+        return _done(stage)
+
+    monkeypatch.setattr(
+        diagnosis_module, "diagnose_experiment", broken_diagnose_experiment
+    )
+    monkeypatch.setattr(rc_runner, "execute_stage", mock_execute_stage)
+
+    results = rc_runner.execute_pipeline(
+        run_dir=run_dir,
+        run_id="run-diagnosis-fail",
+        config=rc_config,
+        adapters=adapters,
+        from_stage=Stage.RESULT_ANALYSIS,
+    )
+
+    assert len(results) == 1
+    assert results[0].stage == Stage.RESULT_ANALYSIS
+    assert results[0].status == StageStatus.FAILED
+    assert results[0].error == "Experiment diagnosis failed: diagnosis boom"
+
+
 @pytest.mark.parametrize(
     ("stage", "started", "expected"),
     [

--- a/tests/test_rc_runner.py
+++ b/tests/test_rc_runner.py
@@ -659,6 +659,103 @@ def test_experiment_memory_initialization_failure_is_recorded_once(
     ]
 
 
+def test_experiment_memory_records_outcome_after_experiment_stage(
+    monkeypatch: pytest.MonkeyPatch,
+    run_dir: Path,
+    rc_config: RCConfig,
+    adapters: AdapterBundle,
+) -> None:
+    def mock_execute_stage(stage: Stage, **kwargs) -> StageResult:
+        _ = kwargs
+        (run_dir / "results.json").write_text(
+            json.dumps({"primary_metric": 0.42}),
+            encoding="utf-8",
+        )
+        return _done(stage)
+
+    monkeypatch.setattr(rc_runner, "execute_stage", mock_execute_stage)
+
+    rc_runner.execute_pipeline(
+        run_dir=run_dir,
+        run_id="run-memory-record",
+        config=rc_config,
+        adapters=adapters,
+        from_stage=Stage.EXPERIMENT_RUN,
+        to_stage=Stage.EXPERIMENT_RUN,
+    )
+
+    memory_path = run_dir / "experiment_memory" / "experiment.jsonl"
+    assert memory_path.exists()
+    entries = [
+        json.loads(line)
+        for line in memory_path.read_text(encoding="utf-8").splitlines()
+    ]
+    assert len(entries) == 1
+    metadata = entries[0]["metadata"]
+    assert metadata["run_id"] == "run-memory-record"
+    assert metadata["stage"] == "EXPERIMENT_RUN"
+    assert metadata["metric_name"] == "primary_metric"
+    assert metadata["metric_value"] == 0.42
+
+
+def test_experiment_memory_recording_failure_is_recorded_once(
+    monkeypatch: pytest.MonkeyPatch,
+    run_dir: Path,
+    rc_config: RCConfig,
+    adapters: AdapterBundle,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    import researchclaw.memory.experiment_memory as memory_module
+
+    class DummyOutcome:
+        def __init__(self, **kwargs: object) -> None:
+            self.__dict__.update(kwargs)
+
+    class BrokenExperimentMemory:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            _ = args, kwargs
+
+        def record_outcome(self, outcome: object) -> str:
+            _ = outcome
+            raise RuntimeError("memory write failed")
+
+    def mock_execute_stage(stage: Stage, **kwargs) -> StageResult:
+        _ = stage, kwargs
+        (run_dir / "results.json").write_text(
+            json.dumps({"primary_metric": 0.42}),
+            encoding="utf-8",
+        )
+        return _done(stage)
+
+    monkeypatch.setattr(memory_module, "ExperimentMemory", BrokenExperimentMemory)
+    monkeypatch.setattr(memory_module, "ExperimentOutcome", DummyOutcome, raising=False)
+    monkeypatch.setattr(rc_runner, "execute_stage", mock_execute_stage)
+
+    with caplog.at_level("WARNING", logger="researchclaw.pipeline.runner"):
+        rc_runner.execute_pipeline(
+            run_dir=run_dir,
+            run_id="run-memory-record-fail",
+            config=rc_config,
+            adapters=adapters,
+            from_stage=Stage.EXPERIMENT_RUN,
+            to_stage=Stage.ITERATIVE_REFINE,
+        )
+
+    warnings = [
+        record
+        for record in caplog.records
+        if "Experiment memory recording failed" in record.message
+    ]
+    assert len(warnings) == 1
+    summary = json.loads((run_dir / "pipeline_summary.json").read_text())
+    assert summary["degradations"] == [
+        {
+            "key": "experiment_memory_record",
+            "message": "Experiment memory recording failed: memory write failed",
+        }
+    ]
+
+
 @pytest.mark.parametrize(
     ("stage", "started", "expected"),
     [

--- a/tests/test_rc_runner.py
+++ b/tests/test_rc_runner.py
@@ -848,6 +848,50 @@ def test_result_analysis_diagnosis_failure_fails_stage(
     assert results[0].error == "Experiment diagnosis failed: diagnosis boom"
 
 
+def test_result_analysis_repair_failure_fails_stage(
+    monkeypatch: pytest.MonkeyPatch,
+    run_dir: Path,
+    rc_config: RCConfig,
+    adapters: AdapterBundle,
+) -> None:
+    import researchclaw.pipeline.experiment_repair as repair_module
+
+    def fake_diagnosis(run_dir_arg: Path, config: RCConfig, run_id: str) -> str | None:
+        _ = config, run_id
+        (run_dir_arg / "experiment_diagnosis.json").write_text(
+            json.dumps({"repair_needed": True}),
+            encoding="utf-8",
+        )
+        return None
+
+    def broken_repair_loop(*args: object, **kwargs: object) -> object:
+        _ = args, kwargs
+        raise RuntimeError("repair boom")
+
+    def mock_execute_stage(stage: Stage, **kwargs) -> StageResult:
+        _ = kwargs
+        stage_dir = run_dir / f"stage-{int(stage):02d}"
+        stage_dir.mkdir(parents=True, exist_ok=True)
+        return _done(stage)
+
+    monkeypatch.setattr(rc_runner, "_run_experiment_diagnosis", fake_diagnosis)
+    monkeypatch.setattr(repair_module, "run_repair_loop", broken_repair_loop)
+    monkeypatch.setattr(rc_runner, "execute_stage", mock_execute_stage)
+
+    results = rc_runner.execute_pipeline(
+        run_dir=run_dir,
+        run_id="run-repair-fail",
+        config=rc_config,
+        adapters=adapters,
+        from_stage=Stage.RESULT_ANALYSIS,
+    )
+
+    assert len(results) == 1
+    assert results[0].stage == Stage.RESULT_ANALYSIS
+    assert results[0].status == StageStatus.FAILED
+    assert results[0].error == "Experiment repair failed: repair boom"
+
+
 @pytest.mark.parametrize(
     ("stage", "started", "expected"),
     [

--- a/tests/test_rc_runner.py
+++ b/tests/test_rc_runner.py
@@ -613,6 +613,53 @@ def test_cli_cost_budget_without_enforcer_fails_before_stage(
     ]
 
 
+def test_domain_profile_setup_failure_fails_before_stage(
+    monkeypatch: pytest.MonkeyPatch,
+    run_dir: Path,
+    rc_config: RCConfig,
+    adapters: AdapterBundle,
+) -> None:
+    import researchclaw.domains.detector as detector_module
+
+    seen: list[Stage] = []
+
+    def broken_set_forced_profile(profile: str) -> None:
+        _ = profile
+        raise RuntimeError("profile registry locked")
+
+    def mock_execute_stage(stage: Stage, **kwargs) -> StageResult:
+        _ = kwargs
+        seen.append(stage)
+        return _done(stage)
+
+    monkeypatch.setattr(
+        detector_module, "set_forced_profile", broken_set_forced_profile
+    )
+    monkeypatch.setattr(rc_runner, "execute_stage", mock_execute_stage)
+
+    results = rc_runner.execute_pipeline(
+        run_dir=run_dir,
+        run_id="run-domain-profile",
+        config=rc_config,
+        adapters=adapters,
+        from_stage=Stage.EXPERIMENT_DESIGN,
+        to_stage=Stage.EXPERIMENT_DESIGN,
+    )
+
+    assert seen == []
+    assert results == [
+        StageResult(
+            stage=Stage.EXPERIMENT_DESIGN,
+            status=StageStatus.FAILED,
+            artifacts=(),
+            error="Domain profile setup failed: profile registry locked",
+            decision="abort",
+        )
+    ]
+    summary = json.loads((run_dir / "pipeline_summary.json").read_text())
+    assert summary["final_status"] == "failed"
+
+
 def test_experiment_memory_initialization_failure_is_recorded_once(
     monkeypatch: pytest.MonkeyPatch,
     run_dir: Path,

--- a/tests/test_rc_runner.py
+++ b/tests/test_rc_runner.py
@@ -1,6 +1,7 @@
 # pyright: reportPrivateUsage=false, reportUnknownParameterType=false, reportMissingParameterType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnusedCallResult=false, reportAttributeAccessIssue=false, reportUnknownLambdaType=false
 from __future__ import annotations
 
+from dataclasses import replace
 import json
 from pathlib import Path
 from typing import Any, cast
@@ -562,6 +563,54 @@ def test_result_analysis_non_numeric_metric_contract_fails_stage(
     assert violations_path.exists()
     violations = json.loads(violations_path.read_text(encoding="utf-8"))
     assert "non-numeric result metric: accuracy" in violations
+
+
+def test_cli_cost_budget_without_enforcer_fails_before_stage(
+    monkeypatch: pytest.MonkeyPatch,
+    run_dir: Path,
+    rc_config: RCConfig,
+    adapters: AdapterBundle,
+) -> None:
+    cli_agent = replace(
+        rc_config.experiment.cli_agent,
+        provider="codex",
+        max_budget_usd=0.01,
+    )
+    config = replace(
+        rc_config,
+        experiment=replace(rc_config.experiment, cli_agent=cli_agent),
+    )
+    seen: list[Stage] = []
+
+    def mock_execute_stage(stage: Stage, **kwargs) -> StageResult:
+        _ = kwargs
+        seen.append(stage)
+        return _done(stage)
+
+    monkeypatch.setattr(rc_runner, "execute_stage", mock_execute_stage)
+
+    results = rc_runner.execute_pipeline(
+        run_dir=run_dir,
+        run_id="run-cost-budget",
+        config=config,
+        adapters=adapters,
+        from_stage=Stage.EXPERIMENT_DESIGN,
+        to_stage=Stage.EXPERIMENT_DESIGN,
+    )
+
+    assert seen == []
+    assert results == [
+        StageResult(
+            stage=Stage.EXPERIMENT_DESIGN,
+            status=StageStatus.FAILED,
+            artifacts=(),
+            error=(
+                "Cost budget enforcement is configured for CLI agent provider "
+                "'codex', but researchclaw.cost_tracker is unavailable"
+            ),
+            decision="abort",
+        )
+    ]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_rc_runner.py
+++ b/tests/test_rc_runner.py
@@ -756,6 +756,56 @@ def test_experiment_memory_recording_failure_is_recorded_once(
     ]
 
 
+def test_kb_export_failure_is_recorded_once(
+    monkeypatch: pytest.MonkeyPatch,
+    run_dir: Path,
+    rc_config: RCConfig,
+    adapters: AdapterBundle,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    def mock_execute_stage(stage: Stage, **kwargs) -> StageResult:
+        _ = kwargs
+        stage_dir = run_dir / f"stage-{int(stage):02d}"
+        stage_dir.mkdir(parents=True, exist_ok=True)
+        (stage_dir / "out.md").write_text(f"stage {int(stage)}", encoding="utf-8")
+        return _done(stage)
+
+    def broken_write_stage_to_kb(*args: object, **kwargs: object) -> list[object]:
+        _ = args, kwargs
+        raise RuntimeError("kb offline")
+
+    monkeypatch.setattr(rc_runner, "execute_stage", mock_execute_stage)
+    monkeypatch.setattr(rc_runner, "write_stage_to_kb", broken_write_stage_to_kb)
+
+    with caplog.at_level("WARNING", logger="researchclaw.pipeline.runner"):
+        results = rc_runner.execute_pipeline(
+            run_dir=run_dir,
+            run_id="run-kb-fail",
+            config=rc_config,
+            adapters=adapters,
+            from_stage=Stage.EXPERIMENT_DESIGN,
+            to_stage=Stage.RESULT_ANALYSIS,
+            kb_root=tmp_path / "kb-fail",
+        )
+
+    assert len(results) == 6
+    assert all(result.status == StageStatus.DONE for result in results)
+    warnings = [
+        record
+        for record in caplog.records
+        if "Knowledge base export failed" in record.message
+    ]
+    assert len(warnings) == 1
+    summary = json.loads((run_dir / "pipeline_summary.json").read_text())
+    assert summary["degradations"] == [
+        {
+            "key": "knowledge_base_export",
+            "message": "Knowledge base export failed: kb offline",
+        }
+    ]
+
+
 @pytest.mark.parametrize(
     ("stage", "started", "expected"),
     [

--- a/tests/test_rc_runner.py
+++ b/tests/test_rc_runner.py
@@ -613,6 +613,52 @@ def test_cli_cost_budget_without_enforcer_fails_before_stage(
     ]
 
 
+def test_experiment_memory_initialization_failure_is_recorded_once(
+    monkeypatch: pytest.MonkeyPatch,
+    run_dir: Path,
+    rc_config: RCConfig,
+    adapters: AdapterBundle,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    import researchclaw.memory.experiment_memory as memory_module
+
+    class BrokenExperimentMemory:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            _ = args, kwargs
+            raise RuntimeError("memory offline")
+
+    def mock_execute_stage(stage: Stage, **kwargs) -> StageResult:
+        _ = kwargs
+        return _done(stage)
+
+    monkeypatch.setattr(memory_module, "ExperimentMemory", BrokenExperimentMemory)
+    monkeypatch.setattr(rc_runner, "execute_stage", mock_execute_stage)
+
+    with caplog.at_level("WARNING", logger="researchclaw.pipeline.runner"):
+        rc_runner.execute_pipeline(
+            run_dir=run_dir,
+            run_id="run-memory-init",
+            config=rc_config,
+            adapters=adapters,
+            from_stage=Stage.EXPERIMENT_RUN,
+            to_stage=Stage.ITERATIVE_REFINE,
+        )
+
+    warnings = [
+        record
+        for record in caplog.records
+        if "Experiment memory initialization failed" in record.message
+    ]
+    assert len(warnings) == 1
+    summary = json.loads((run_dir / "pipeline_summary.json").read_text())
+    assert summary["degradations"] == [
+        {
+            "key": "experiment_memory_init",
+            "message": "Experiment memory initialization failed: memory offline",
+        }
+    ]
+
+
 @pytest.mark.parametrize(
     ("stage", "started", "expected"),
     [


### PR DESCRIPTION
## Problem

`execute_pipeline` grew a repeated pattern: a feature block wrapped in `try/except Exception` with a DEBUG-level log on failure. Several of those blocks import modules that do not exist in the repo (`researchclaw.pipeline.event_log`, `researchclaw.pipeline.pitfall_detector`, `researchclaw.cost_tracker`), so the features they guard have silently never run; others swallow real failures (experiment diagnosis, repair, domain-profile setup, memory recording, KB export) and let the pipeline report DONE. The experiment-spec validation hooks were the worst instance of this class (fixed in #301); this PR audits the rest of the experiment path so a failure can never again no-op invisibly.

## Approach

Every catch-all handler on the experiment execution path (`EXPERIMENT_DESIGN` through `RESULT_ANALYSIS` in the runner, plus the stage implementations and sandbox/dataset helpers they call) was inventoried and given exactly one disposition:

- **converted-surface**: the failure now fails the stage or run through the existing failure handling.
- **converted-record**: the feature is genuinely optional, but its absence is now visible: one WARNING per run and a `degradations` entry in `pipeline_summary.json` (new keyed once-per-run mechanism, so a repeating failure does not spam).
- **removed-dead**: phantom integrations whose modules do not exist were removed rather than left warning forever.
- **kept-with-reason**: narrow, correct catches (cleanup guards, visible fallback chains, optional prompt enrichment) stay, each documented.

One commit per converted site, each with a test that demonstrates the previously silent behavior and asserts the surfaced one, so every conversion is independently revertable and bisectable.

The full inventory (~90 handlers: file, line, what it guards, failure mode before, disposition, covering test, commit) is in `docs/fail_open_audit.md`, including everything deliberately NOT converted and why.

## Highlights

- **Experiment diagnosis / repair / domain-profile setup failures now fail the stage** instead of continuing with unknown state (`e770816`, `0bf2290`, `3118f97`).
- **Configured CLI cost budgets fail fast when unenforceable** (`54bb936`): previously a positive `max_budget_usd` with the missing `cost_tracker` module meant the budget was silently ignored; a budget you set and cannot enforce should stop the run, not pretend. Default `llm` provider behavior is unchanged.
- **Dead `event_log` and `pitfall_detector` hooks removed** (`53f59a7`, `b1587e7`).
- **Experiment memory actually works now** (`9090fd7`, `6525d02`): the runner already called `ExperimentMemory.record_outcome(ExperimentOutcome(...))`, but neither the dataclass nor the method existed, so every call raised and was swallowed. Rather than delete an intended feature, the missing API is implemented to the call site's contract, and init/recording failures are recorded once per run.
- **KB export failures are recorded** (`39f6ee6`).
- **Deliberately kept**: the Stage 12 provenance resolver's explicit fail-open migration rule (existing tests assert it as policy; changing it belongs in its own discussion, not a drive-by), sandbox wrappers that already convert exceptions into failed results, and optional prompt-enrichment blocks.

## Verification

- Each converted site has a red-first test in `tests/test_rc_runner.py` (test names in the inventory table).
- Full suite on this branch: 2841 passed, 56 skipped.

## Dependencies

Includes the commit from #301 (the spec-gating work this audit builds on); review that PR first. If #301 lands, this rebases to just the audit commits.
