### PR TITLE
feat: add MiniMax regional endpoint presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -601,7 +601,7 @@ runtime:
 
 # === LLM ===
 llm:
-  provider: "openai-compatible"    # openai | openrouter | deepseek | minimax | acp | openai-compatible
+  provider: "openai-compatible"    # See the provider presets below
   base_url: "https://..."          # API endpoint (required for openai-compatible)
   api_key_env: "OPENAI_API_KEY"    # Env var for API key (required for openai-compatible)
   api_key: ""                      # Or hardcode key here
@@ -759,6 +759,21 @@ openclaw_bridge:
   use_web_fetch: false             # Live web search
   use_browser: false               # Browser-based paper collection
 ```
+
+MiniMax presets use `MINIMAX_API_KEY`, `MiniMax-M3` as the primary model,
+and `MiniMax-M2.7` in the fallback chain.
+
+| Provider preset | Region | Protocol | Base URL |
+|---|---|---|---|
+| `minimax-global` | Global | OpenAI-compatible | `https://api.minimax.io/v1` |
+| `minimax` | China | OpenAI-compatible | `https://api.minimaxi.com/v1` |
+| `minimax-anthropic` | Global | Anthropic-compatible | `https://api.minimax.io/anthropic` |
+| `minimax-anthropic-cn` | China | Anthropic-compatible | `https://api.minimaxi.com/anthropic` |
+
+Anthropic-compatible presets require `pip install "researchclaw[anthropic]"`.
+The global and China API references are available from the
+[MiniMax platform](https://platform.minimax.io/docs) and
+[MiniMax China platform](https://platform.minimaxi.com/docs).
 
 </details>
 

--- a/config.researchclaw.example.yaml
+++ b/config.researchclaw.example.yaml
@@ -44,13 +44,19 @@ llm:
   fallback_models:
     - "gpt-4.1"
     - "gpt-4o-mini"
-  # --- MiniMax provider example ---
-  # provider: "minimax"
+  # --- MiniMax provider example (global OpenAI-compatible endpoint) ---
+  # provider: "minimax-global"
+  # base_url: "https://api.minimax.io/v1"
   # api_key_env: "MINIMAX_API_KEY"
   # primary_model: "MiniMax-M3"
   # fallback_models:
   #   - "MiniMax-M2.7"
   #   - "MiniMax-M2.7-highspeed"
+  # Other endpoint presets:
+  #   minimax: https://api.minimaxi.com/v1
+  #   minimax-anthropic: https://api.minimax.io/anthropic
+  #   minimax-anthropic-cn: https://api.minimaxi.com/anthropic
+  # Anthropic-compatible presets require: pip install "researchclaw[anthropic]"
   # --- Ollama (local) example ---
   # provider: "ollama"
   # base_url: "http://localhost:11434/v1"

--- a/config.researchclaw.example.yaml
+++ b/config.researchclaw.example.yaml
@@ -51,7 +51,6 @@ llm:
   # primary_model: "MiniMax-M3"
   # fallback_models:
   #   - "MiniMax-M2.7"
-  #   - "MiniMax-M2.7-highspeed"
   # Other endpoint presets:
   #   minimax: https://api.minimaxi.com/v1
   #   minimax-anthropic: https://api.minimax.io/anthropic

--- a/researchclaw/cli.py
+++ b/researchclaw/cli.py
@@ -776,6 +776,9 @@ _PROVIDER_CHOICES = {
     "4": ("minimax", "MINIMAX_API_KEY"),
     "5": ("acp", ""),
     "6": ("ollama", ""),
+    "7": ("minimax-global", "MINIMAX_API_KEY"),
+    "8": ("minimax-anthropic", "MINIMAX_API_KEY"),
+    "9": ("minimax-anthropic-cn", "MINIMAX_API_KEY"),
 }
 
 _PROVIDER_URLS = {
@@ -783,8 +786,16 @@ _PROVIDER_URLS = {
     "openrouter": "https://openrouter.ai/api/v1",
     "deepseek": "https://api.deepseek.com/v1",
     "minimax": "https://api.minimaxi.com/v1",
+    "minimax-global": "https://api.minimax.io/v1",
+    "minimax-anthropic": "https://api.minimax.io/anthropic",
+    "minimax-anthropic-cn": "https://api.minimaxi.com/anthropic",
     "ollama": "http://localhost:11434/v1",
 }
+
+_MINIMAX_MODELS = (
+    "MiniMax-M3",
+    ["MiniMax-M2.7", "MiniMax-M2.7-highspeed"],
+)
 
 _PROVIDER_MODELS = {
     "openai": ("gpt-4o", ["gpt-4.1", "gpt-4o-mini"]),
@@ -793,7 +804,10 @@ _PROVIDER_MODELS = {
         ["google/gemini-pro-1.5", "meta-llama/llama-3.1-70b-instruct"],
     ),
     "deepseek": ("deepseek-chat", ["deepseek-reasoner"]),
-    "minimax": ("MiniMax-M3", ["MiniMax-M2.7", "MiniMax-M2.7-highspeed"]),
+    "minimax": _MINIMAX_MODELS,
+    "minimax-global": _MINIMAX_MODELS,
+    "minimax-anthropic": _MINIMAX_MODELS,
+    "minimax-anthropic-cn": _MINIMAX_MODELS,
     "ollama": ("llama3.2", ["mistral", "qwen2.5:7b"]),
 }
 
@@ -829,9 +843,12 @@ def cmd_init(args: argparse.Namespace) -> int:
         print("  1) openai       (requires OPENAI_API_KEY)")
         print("  2) openrouter   (requires OPENROUTER_API_KEY)")
         print("  3) deepseek     (requires DEEPSEEK_API_KEY)")
-        print("  4) minimax      (requires MINIMAX_API_KEY)")
+        print("  4) minimax-cn-openai        (requires MINIMAX_API_KEY)")
         print("  5) acp          (local AI agent — no API key needed)")
         print("  6) ollama       (local Ollama server — no API key needed)")
+        print("  7) minimax-global-openai    (requires MINIMAX_API_KEY)")
+        print("  8) minimax-global-anthropic (requires MINIMAX_API_KEY)")
+        print("  9) minimax-cn-anthropic     (requires MINIMAX_API_KEY)")
         try:
             raw = input("Choice [1]: ").strip()
         except (EOFError, KeyboardInterrupt):
@@ -900,6 +917,12 @@ def cmd_init(args: argparse.Namespace) -> int:
         print("  1. Ensure Ollama is running: ollama serve")
         print("  2. Pull your model: ollama pull llama3.2")
         print("  3. Edit config.arc.yaml to set llm.primary_model to your model name")
+        print("  4. Run: researchclaw doctor")
+    elif provider in ("minimax-anthropic", "minimax-anthropic-cn"):
+        print("\nNext steps:")
+        print('  1. Install the adapter: pip install "researchclaw[anthropic]"')
+        print("  2. Export your API key: export MINIMAX_API_KEY=...")
+        print("  3. Edit config.arc.yaml to customize your settings")
         print("  4. Run: researchclaw doctor")
     else:
         env_var = api_key_env or "OPENAI_API_KEY"

--- a/researchclaw/cli.py
+++ b/researchclaw/cli.py
@@ -794,7 +794,7 @@ _PROVIDER_URLS = {
 
 _MINIMAX_MODELS = (
     "MiniMax-M3",
-    ["MiniMax-M2.7", "MiniMax-M2.7-highspeed"],
+    ["MiniMax-M2.7"],
 )
 
 _PROVIDER_MODELS = {

--- a/researchclaw/llm/__init__.py
+++ b/researchclaw/llm/__init__.py
@@ -22,15 +22,28 @@ PROVIDER_PRESETS = {
     },
     "anthropic": {
         "base_url": "https://api.anthropic.com",
+        "adapter": "anthropic",
     },
     "kimi-anthropic": {
         "base_url": "https://api.kimi.com/coding/",
+        "adapter": "anthropic",
     },
     "novita": {
         "base_url": "https://api.novita.ai/openai",
     },
     "minimax": {
         "base_url": "https://api.minimaxi.com/v1",
+    },
+    "minimax-global": {
+        "base_url": "https://api.minimax.io/v1",
+    },
+    "minimax-anthropic": {
+        "base_url": "https://api.minimax.io/anthropic",
+        "adapter": "anthropic",
+    },
+    "minimax-anthropic-cn": {
+        "base_url": "https://api.minimaxi.com/anthropic",
+        "adapter": "anthropic",
     },
     "ollama": {
         "base_url": "http://localhost:11434/v1",
@@ -45,8 +58,8 @@ def create_llm_client(config: RCConfig) -> LLMClient | ACPClient:
     """Factory: return the right LLM client based on ``config.llm.provider``.
 
     - ``"acp"`` → :class:`ACPClient` (spawns an ACP-compatible agent)
-    - ``"anthropic"`` → :class:`LLMClient` with Anthropic Messages API adapter
-    - ``"kimi-anthropic"`` → :class:`LLMClient` with Kimi Coding Anthropic adapter
+    - providers with an ``"anthropic"`` adapter → :class:`LLMClient` with
+      Anthropic Messages API support
     - ``"openrouter"`` → :class:`LLMClient` with OpenRouter base URL
     - ``"openai"`` → :class:`LLMClient` with OpenAI base URL
     - ``"deepseek"`` → :class:`LLMClient` with DeepSeek base URL

--- a/researchclaw/llm/client.py
+++ b/researchclaw/llm/client.py
@@ -166,9 +166,9 @@ class LLMClient:
         )
         client = cls(config)
 
-        # Detect Anthropic or Kimi-Anthropic provider — use original URL/key (not the
-        # MetaClaw proxy URL which is OpenAI-compatible only).
-        if provider in ("anthropic", "kimi-anthropic"):
+        # Anthropic-compatible providers use the original URL/key, not the
+        # MetaClaw proxy URL, which is OpenAI-compatible only.
+        if preset.get("adapter") == "anthropic":
             from .anthropic_adapter import AnthropicAdapter
 
             client._anthropic = AnthropicAdapter(

--- a/tests/test_minimax_provider.py
+++ b/tests/test_minimax_provider.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import json
 import os
 import urllib.request
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, Mapping
 
@@ -67,6 +68,33 @@ class TestMiniMaxPreset:
     def test_minimax_base_url(self):
         assert PROVIDER_PRESETS["minimax"]["base_url"] == "https://api.minimaxi.com/v1"
 
+    @pytest.mark.parametrize(
+        ("provider", "base_url", "adapter"),
+        [
+            ("minimax-global", "https://api.minimax.io/v1", None),
+            ("minimax", "https://api.minimaxi.com/v1", None),
+            (
+                "minimax-anthropic",
+                "https://api.minimax.io/anthropic",
+                "anthropic",
+            ),
+            (
+                "minimax-anthropic-cn",
+                "https://api.minimaxi.com/anthropic",
+                "anthropic",
+            ),
+        ],
+    )
+    def test_minimax_endpoint_presets(
+        self,
+        provider: str,
+        base_url: str,
+        adapter: str | None,
+    ) -> None:
+        preset = PROVIDER_PRESETS[provider]
+        assert preset["base_url"] == base_url
+        assert preset.get("adapter") == adapter
+
 
 # ---------------------------------------------------------------------------
 # Unit tests — from_rc_config wiring
@@ -121,6 +149,76 @@ class TestMiniMaxFromRCConfig:
         )
         client = LLMClient.from_rc_config(rc_config)
         assert client.config.base_url == "https://custom-proxy.example/v1"
+
+    @pytest.mark.parametrize(
+        ("provider", "base_url", "request_url"),
+        [
+            (
+                "minimax-anthropic",
+                "https://api.minimax.io/anthropic",
+                "https://api.minimax.io/anthropic/v1/messages",
+            ),
+            (
+                "minimax-anthropic-cn",
+                "https://api.minimaxi.com/anthropic",
+                "https://api.minimaxi.com/anthropic/v1/messages",
+            ),
+        ],
+    )
+    def test_anthropic_presets_append_messages_path(
+        self,
+        provider: str,
+        base_url: str,
+        request_url: str,
+    ) -> None:
+        rc_config = SimpleNamespace(
+            llm=SimpleNamespace(
+                provider=provider,
+                base_url="",
+                api_key="mk-test",
+                api_key_env="",
+                primary_model="MiniMax-M3",
+                fallback_models=("MiniMax-M2.7",),
+            ),
+        )
+        client = LLMClient.from_rc_config(rc_config)
+        captured: dict[str, Any] = {}
+
+        class _Response:
+            def raise_for_status(self) -> None:
+                return None
+
+            def json(self) -> dict[str, Any]:
+                return {
+                    "type": "message",
+                    "model": "MiniMax-M3",
+                    "content": [{"type": "text", "text": "ok"}],
+                    "stop_reason": "end_turn",
+                    "usage": {"input_tokens": 1, "output_tokens": 1},
+                }
+
+        class _Client:
+            def post(
+                self,
+                url: str,
+                headers: dict[str, str],
+                json: dict[str, Any],
+            ) -> _Response:
+                captured["url"] = url
+                return _Response()
+
+        assert client.config.base_url == base_url
+        assert client._anthropic is not None
+        client._anthropic._client = _Client()
+        response = client._raw_call(
+            "MiniMax-M3",
+            [{"role": "user", "content": "ping"}],
+            64,
+            0.5,
+            False,
+        )
+        assert captured["url"] == request_url
+        assert response.content == "ok"
 
 
 # ---------------------------------------------------------------------------
@@ -300,21 +398,88 @@ class TestMiniMaxCLI:
     def test_minimax_in_provider_choices(self):
         from researchclaw.cli import _PROVIDER_CHOICES
 
-        found = any(v[0] == "minimax" for v in _PROVIDER_CHOICES.values())
-        assert found, "minimax not found in _PROVIDER_CHOICES"
+        providers = {value[0] for value in _PROVIDER_CHOICES.values()}
+        assert {
+            "minimax-global",
+            "minimax",
+            "minimax-anthropic",
+            "minimax-anthropic-cn",
+        } <= providers
 
-    def test_minimax_in_provider_urls(self):
+    @pytest.mark.parametrize(
+        ("provider", "base_url"),
+        [
+            ("minimax-global", "https://api.minimax.io/v1"),
+            ("minimax", "https://api.minimaxi.com/v1"),
+            ("minimax-anthropic", "https://api.minimax.io/anthropic"),
+            ("minimax-anthropic-cn", "https://api.minimaxi.com/anthropic"),
+        ],
+    )
+    def test_minimax_in_provider_urls(
+        self,
+        provider: str,
+        base_url: str,
+    ) -> None:
         from researchclaw.cli import _PROVIDER_URLS
 
-        assert _PROVIDER_URLS["minimax"] == "https://api.minimaxi.com/v1"
+        assert _PROVIDER_URLS[provider] == base_url
 
     def test_minimax_in_provider_models(self):
         from researchclaw.cli import _PROVIDER_MODELS
 
-        primary, fallbacks = _PROVIDER_MODELS["minimax"]
-        assert primary == "MiniMax-M3"
-        assert "MiniMax-M2.7" in fallbacks
-        assert "MiniMax-M2.7-highspeed" in fallbacks
+        for provider in (
+            "minimax-global",
+            "minimax",
+            "minimax-anthropic",
+            "minimax-anthropic-cn",
+        ):
+            primary, fallbacks = _PROVIDER_MODELS[provider]
+            assert primary == "MiniMax-M3"
+            assert "MiniMax-M2.7" in fallbacks
+            assert "MiniMax-M2.7-highspeed" in fallbacks
+
+    @pytest.mark.parametrize(
+        ("choice", "provider", "base_url"),
+        [
+            ("4", "minimax", "https://api.minimaxi.com/v1"),
+            ("7", "minimax-global", "https://api.minimax.io/v1"),
+            (
+                "8",
+                "minimax-anthropic",
+                "https://api.minimax.io/anthropic",
+            ),
+            (
+                "9",
+                "minimax-anthropic-cn",
+                "https://api.minimaxi.com/anthropic",
+            ),
+        ],
+    )
+    def test_init_generates_minimax_endpoint_config(
+        self,
+        choice: str,
+        provider: str,
+        base_url: str,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from researchclaw import cli as rc_cli
+
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(
+            "sys.stdin",
+            type("FakeStdin", (), {"isatty": lambda self: True})(),
+        )
+        monkeypatch.setattr("builtins.input", lambda _prompt: choice)
+        monkeypatch.setattr(rc_cli, "_prompt_opencode_install", lambda: None)
+
+        assert rc_cli.cmd_init(SimpleNamespace(force=False)) == 0
+        config = (tmp_path / "config.arc.yaml").read_text(encoding="utf-8")
+        assert f'provider: "{provider}"' in config
+        assert f'base_url: "{base_url}"' in config
+        assert 'api_key_env: "MINIMAX_API_KEY"' in config
+        assert 'primary_model: "MiniMax-M3"' in config
+        assert '    - "MiniMax-M2.7"' in config
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_minimax_provider.py
+++ b/tests/test_minimax_provider.py
@@ -49,7 +49,7 @@ def _make_minimax_client(
         base_url="https://api.minimaxi.com/v1",
         api_key=api_key,
         primary_model=primary_model,
-        fallback_models=fallback_models or ["MiniMax-M2.7", "MiniMax-M2.7-highspeed"],
+        fallback_models=fallback_models or ["MiniMax-M2.7"],
     )
     return LLMClient(config)
 
@@ -112,14 +112,14 @@ class TestMiniMaxFromRCConfig:
                 api_key="mk-test",
                 api_key_env="",
                 primary_model="MiniMax-M3",
-                fallback_models=("MiniMax-M2.7", "MiniMax-M2.7-highspeed"),
+                fallback_models=("MiniMax-M2.7",),
             ),
         )
         client = LLMClient.from_rc_config(rc_config)
         assert client.config.base_url == "https://api.minimaxi.com/v1"
         assert client.config.api_key == "mk-test"
         assert client.config.primary_model == "MiniMax-M3"
-        assert client.config.fallback_models == ["MiniMax-M2.7", "MiniMax-M2.7-highspeed"]
+        assert client.config.fallback_models == ["MiniMax-M2.7"]
 
     def test_from_rc_config_reads_minimax_api_key_from_env(self, monkeypatch):
         monkeypatch.setenv("MINIMAX_API_KEY", "env-minimax-key")
@@ -307,17 +307,16 @@ class TestMiniMaxModelChain:
         assert client._model_chain == [
             "MiniMax-M3",
             "MiniMax-M2.7",
-            "MiniMax-M2.7-highspeed",
         ]
 
     def test_model_chain_custom_fallbacks(self):
         client = _make_minimax_client(
             primary_model="MiniMax-M2.7",
-            fallback_models=["MiniMax-M2.7-highspeed"],
+            fallback_models=["MiniMax-M3"],
         )
         assert client._model_chain == [
             "MiniMax-M2.7",
-            "MiniMax-M2.7-highspeed",
+            "MiniMax-M3",
         ]
 
 
@@ -435,8 +434,7 @@ class TestMiniMaxCLI:
         ):
             primary, fallbacks = _PROVIDER_MODELS[provider]
             assert primary == "MiniMax-M3"
-            assert "MiniMax-M2.7" in fallbacks
-            assert "MiniMax-M2.7-highspeed" in fallbacks
+            assert fallbacks == ["MiniMax-M2.7"]
 
     @pytest.mark.parametrize(
         ("choice", "provider", "base_url"),
@@ -517,7 +515,7 @@ class TestMiniMaxFactory:
 class TestMiniMaxChatFallback:
     """Verify fallback works with MiniMax models."""
 
-    def test_fallback_to_highspeed_on_primary_failure(self, monkeypatch):
+    def test_fallback_to_secondary_model_on_primary_failure(self, monkeypatch):
         client = _make_minimax_client()
         calls: list[str] = []
 
@@ -558,7 +556,7 @@ class TestMiniMaxLiveAPI:
                 base_url="https://api.minimaxi.com/v1",
                 api_key=os.environ["MINIMAX_API_KEY"],
                 primary_model="MiniMax-M3",
-                fallback_models=["MiniMax-M2.7", "MiniMax-M2.7-highspeed"],
+                fallback_models=["MiniMax-M2.7"],
                 max_tokens=64,
                 timeout_sec=60,
             )


### PR DESCRIPTION
Reason: add target provider/model to existing provider registry

## Summary
- add explicit global and China presets for both supported MiniMax API protocols
- keep MiniMax-M3 primary with MiniMax-M2.7 in the fallback chain across generated configurations
- document endpoint selection and verify message request URL construction

## Checks
- `.venv/bin/python -m pytest tests/test_minimax_provider.py tests/test_rc_cli.py -q`
- `.venv/bin/python -m pytest tests/ -q`