### PR TITLE
fix(llm): surface the real error when retries are exhausted, cap OSError backoff

### DIFF
--- a/researchclaw/llm/client.py
+++ b/researchclaw/llm/client.py
@@ -291,7 +291,9 @@ class LLMClient:
         json_mode: bool,
     ) -> LLMResponse:
         """Call with exponential backoff retry."""
+        last_exc: Exception | None = None
         for attempt in range(self.config.max_retries):
+            is_last_attempt = attempt >= self.config.max_retries - 1
             try:
                 return self._raw_call(
                     model, messages, max_tokens, temperature, json_mode
@@ -331,6 +333,9 @@ class LLMClient:
                 # Retryable: 429 (rate limit), transient 400, 500, 502, 503, 504,
                 # 529 (Anthropic overloaded)
                 if status in (400, 429, 500, 502, 503, 504, 529):
+                    last_exc = e
+                    if is_last_attempt:
+                        raise
                     delay = min(
                         self.config.retry_base_delay * (2**attempt),
                         _MAX_BACKOFF_SEC,
@@ -351,35 +356,41 @@ class LLMClient:
                     continue
 
                 raise  # Other HTTP errors
-            except urllib.error.URLError:
-                if attempt < self.config.max_retries - 1:
-                    delay = min(
-                        self.config.retry_base_delay * (2**attempt),
-                        _MAX_BACKOFF_SEC,
-                    )
-                    time.sleep(delay)
-                    continue
-                raise
+            except urllib.error.URLError as e:
+                last_exc = e
+                if is_last_attempt:
+                    raise
+                delay = min(
+                    self.config.retry_base_delay * (2**attempt),
+                    _MAX_BACKOFF_SEC,
+                )
+                time.sleep(delay)
+                continue
             except (TimeoutError, OSError) as exc:
                 # Covers TimeoutError, ConnectionResetError, IncompleteRead, etc.
-                if attempt < self.config.max_retries - 1:
-                    delay = self.config.retry_base_delay * (2**attempt)
-                    logger.info(
-                        "Retry %d/%d for %s (%s). Waiting %.1fs.",
-                        attempt + 1,
-                        self.config.max_retries,
-                        model,
-                        type(exc).__name__,
-                        delay,
-                    )
-                    time.sleep(delay)
-                    continue
-                raise
+                last_exc = exc
+                if is_last_attempt:
+                    raise
+                delay = min(
+                    self.config.retry_base_delay * (2**attempt),
+                    _MAX_BACKOFF_SEC,
+                )
+                logger.info(
+                    "Retry %d/%d for %s (%s). Waiting %.1fs.",
+                    attempt + 1,
+                    self.config.max_retries,
+                    model,
+                    type(exc).__name__,
+                    delay,
+                )
+                time.sleep(delay)
+                continue
 
-        # All retries exhausted
+        # Unreachable when max_retries >= 1: the final attempt either returns
+        # or re-raises. Guards against a non-positive max_retries config.
         raise RuntimeError(
             f"LLM call failed after {self.config.max_retries} retries for model {model}"
-        )
+        ) from last_exc
 
     def _raw_call(
         self,

--- a/tests/test_rc_llm.py
+++ b/tests/test_rc_llm.py
@@ -13,6 +13,7 @@ from researchclaw.llm.client import (
     LLMClient,
     LLMConfig,
     LLMResponse,
+    _MAX_BACKOFF_SEC,
     _NEW_PARAM_MODELS,
     _NO_TEMPERATURE_MODELS,
 )
@@ -525,3 +526,112 @@ def test_chat_uses_fallback_after_first_model_error(monkeypatch: pytest.MonkeyPa
     response = client.chat([{"role": "user", "content": "x"}])
     assert calls == ["gpt-5.2", "gpt-5.1"]
     assert response.model == "gpt-5.1"
+
+
+def _retry_client(*, max_retries: int, retry_base_delay: float = 1.0) -> LLMClient:
+    return LLMClient(
+        LLMConfig(
+            base_url="https://api.example.com/v1",
+            api_key="test-key",
+            primary_model="gpt-test",
+            fallback_models=[],
+            max_retries=max_retries,
+            retry_base_delay=retry_base_delay,
+        )
+    )
+
+
+def _record_sleeps(monkeypatch: pytest.MonkeyPatch) -> list[float]:
+    delays: list[float] = []
+    monkeypatch.setattr(
+        "researchclaw.llm.client.time.sleep", lambda d: delays.append(d)
+    )
+    return delays
+
+
+def _http_error(status: int) -> urllib.error.HTTPError:
+    return urllib.error.HTTPError("url", status, "err", HTTPMessage(), None)
+
+
+def test_retry_reraises_original_http_error_when_exhausted(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Exhausted retries must surface the HTTPError, not mask it.
+
+    preflight() classifies failures via RuntimeError.__cause__, so the
+    original error has to survive the retry loop.
+    """
+    _record_sleeps(monkeypatch)
+    client = _retry_client(max_retries=3)
+    monkeypatch.setattr(
+        LLMClient,
+        "_raw_call",
+        lambda *a, **k: (_ for _ in ()).throw(_http_error(429)),
+    )
+
+    with pytest.raises(urllib.error.HTTPError) as exc_info:
+        client._call_with_retry("gpt-test", [], 10, 0.0, False)
+    assert exc_info.value.code == 429
+
+
+def test_preflight_reports_rate_limit_through_retry_path(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A persistent 429 should still be reported as a rate limit."""
+    _record_sleeps(monkeypatch)
+    client = _retry_client(max_retries=3)
+    monkeypatch.setattr(
+        LLMClient,
+        "_raw_call",
+        lambda *a, **k: (_ for _ in ()).throw(_http_error(429)),
+    )
+
+    ok, msg = client.preflight()
+    assert ok is False
+    assert "Rate limited" in msg
+
+
+def test_retry_does_not_sleep_after_final_attempt(monkeypatch: pytest.MonkeyPatch):
+    """N attempts means N-1 backoff sleeps; the last one is pure waste."""
+    delays = _record_sleeps(monkeypatch)
+    client = _retry_client(max_retries=3)
+    monkeypatch.setattr(
+        LLMClient,
+        "_raw_call",
+        lambda *a, **k: (_ for _ in ()).throw(_http_error(503)),
+    )
+
+    with pytest.raises(urllib.error.HTTPError):
+        client._call_with_retry("gpt-test", [], 10, 0.0, False)
+    assert len(delays) == 2
+
+
+def test_retry_backoff_is_capped_for_os_errors(monkeypatch: pytest.MonkeyPatch):
+    """Connection errors must honour the same 300s ceiling as HTTP errors."""
+    delays = _record_sleeps(monkeypatch)
+    client = _retry_client(max_retries=12)
+    monkeypatch.setattr(
+        LLMClient,
+        "_raw_call",
+        lambda *a, **k: (_ for _ in ()).throw(ConnectionResetError("boom")),
+    )
+
+    with pytest.raises(ConnectionResetError):
+        client._call_with_retry("gpt-test", [], 10, 0.0, False)
+    assert delays, "expected retry sleeps"
+    assert max(delays) <= _MAX_BACKOFF_SEC
+
+
+def test_retry_reraises_original_url_error_when_exhausted(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _record_sleeps(monkeypatch)
+    client = _retry_client(max_retries=2)
+    monkeypatch.setattr(
+        LLMClient,
+        "_raw_call",
+        lambda *a, **k: (_ for _ in ()).throw(urllib.error.URLError("no route")),
+    )
+
+    with pytest.raises(urllib.error.URLError):
+        client._call_with_retry("gpt-test", [], 10, 0.0, False)


### PR DESCRIPTION
Three bugs in `LLMClient._call_with_retry`, all on the path where retries run out. They're separate symptoms but they live in the same ~40 lines and the fix for one is the fix for the others, so I've kept them together.

## The error gets thrown away when retries are exhausted

This is the one that actually bites users. On a persistent retryable status (429, 503, 529…), the loop runs out and raises a bare `RuntimeError`, dropping the `HTTPError` on the floor.

That matters because `preflight()` classifies failures by pulling the `HTTPError` back out of `RuntimeError.__cause__`:

```python
except RuntimeError as e:
    # chat() wraps errors in RuntimeError; extract original HTTPError
    cause = e.__cause__
    if isinstance(cause, urllib.error.HTTPError):
        ...
```

The cause was never set, so that lookup always missed. With a rate-limited key you got:

```
All models failed: All models failed. Last error: LLM call failed after 3 retries for model gpt-test
```

when the code has a perfectly good message sitting right there for exactly this case:

```
Rate limited - try again in a moment
```

Same story for 401/403/404 behind a retry. `doctor` and `preflight` both go through this, which I suspect is some of what was going on in #292 and #241.

The final attempt now re-raises the original exception instead of falling out of the loop. The trailing `RuntimeError` is unreachable for any sane `max_retries` now, but I left it as a guard for `max_retries <= 0` and chained it with `from last_exc` so it can't swallow context either.

### Heads up: part of this is a regression

The diagnostics here were already fixed once in #234 (8ec230d, "track last error across retries"). The v0.5.0 release commit (12d3fd8) reverted it — silently, as far as I can tell, since it's a 318-file +42k/−8.6k commit and nothing in it mentions the retry path. `git log -S"last_err" -- researchclaw/llm/client.py` shows it going in and right back out.

I went a bit further than #234 did: it tracked the error as a formatted *string* for the message, which reads better but still leaves `__cause__` unset, so `preflight()` stays broken. Keeping the exception object fixes both.

Might be worth a look at what else went out in that release commit.

## It sleeps after the last attempt

The `HTTPError` branch had no "is this the final attempt?" guard, so it slept the full backoff *after* the last try and then failed anyway. With the 300s ceiling plus 30% jitter that's up to ~390s of dead waiting per model, and `chat()` walks the whole fallback chain, so you pay it per model.

The `URLError` and `OSError` branches already guarded this with `if attempt < self.config.max_retries - 1`; `HTTPError` just never got it. N attempts now means N−1 sleeps.

## The backoff ceiling wasn't applied to connection errors

`_MAX_BACKOFF_SEC = 300` is described as a "5-minute ceiling for retry delays", and the `HTTPError` and `URLError` branches both `min()` against it. The `TimeoutError`/`OSError` branch didn't — it just did `retry_base_delay * (2**attempt)` and let it rip. Measured delays at `max_retries=12`:

```
1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024
```

That's a 17-minute sleep on a flaky connection, from the branch that catches `ConnectionResetError` and friends — i.e. exactly the transient case you'd want to recover from quickly. Now capped like the other two.

## Why the tests didn't catch any of this

The existing preflight tests patch `chat()` directly:

```python
with patch.object(client, "chat", side_effect=err):
    ok, msg = client.preflight()
```

So `test_preflight_429_rate_limited` passes while the real 429 path is broken — it never enters the retry loop at all. The new tests patch `_raw_call` instead, so they go through `_call_with_retry` for real, and they stub `time.sleep` to assert on the delays rather than actually waiting.

Added five: the HTTPError and URLError re-raise cases, preflight reporting a rate limit through the real path, the sleep count, and the backoff cap.

## Testing

`pytest tests/` → 2802 passed, 56 skipped. Same as before the change; the one warning is a pre-existing unawaited-coroutine thing in `test_servers.py`, unrelated.
