### PR TITLE
fix(literature): don't sleep after the final Semantic Scholar retry attempt

### DIFF
--- a/researchclaw/literature/semantic_scholar.py
+++ b/researchclaw/literature/semantic_scholar.py
@@ -226,6 +226,7 @@ def _request_with_retry(
         return None
 
     for attempt in range(_MAX_RETRIES):
+        is_last_attempt = attempt >= _MAX_RETRIES - 1
         try:
             req = urllib.request.Request(url, headers=headers)
             with urllib.request.urlopen(req, timeout=_TIMEOUT_SEC) as resp:
@@ -236,6 +237,8 @@ def _request_with_retry(
             if exc.code == 429:
                 if _cb_on_429():
                     return None  # breaker tripped
+                if is_last_attempt:
+                    break
                 delay = min(2 ** (attempt + 1), _MAX_WAIT_SEC)
                 jitter = random.uniform(0, delay * 0.3)
                 wait = delay + jitter
@@ -250,16 +253,19 @@ def _request_with_retry(
             logger.warning("S2 HTTP %d for %s", exc.code, url)
             return None
         except (urllib.error.URLError, OSError, json.JSONDecodeError) as exc:
+            if is_last_attempt:
+                logger.warning("S2 request failed (%s) on final attempt", exc)
+                break
             wait = min(2**attempt, _MAX_WAIT_SEC)
-            jitter = random.uniform(0, wait * 0.2)
+            wait += random.uniform(0, wait * 0.2)
             logger.warning(
-                "S2 request failed (%s). Retry %d/%d in %ds \u2026",
+                "S2 request failed (%s). Retry %d/%d in %.1fs \u2026",
                 exc,
                 attempt + 1,
                 _MAX_RETRIES,
                 wait,
             )
-            time.sleep(wait + jitter)
+            time.sleep(wait)
     logger.error("S2 request exhausted retries for: %s", url)
     return None
 
@@ -343,6 +349,7 @@ def _post_with_retry(
         return None
 
     for attempt in range(_MAX_RETRIES):
+        is_last_attempt = attempt >= _MAX_RETRIES - 1
         try:
             req = urllib.request.Request(url, data=body, headers=headers, method="POST")
             with urllib.request.urlopen(req, timeout=_TIMEOUT_SEC) as resp:
@@ -353,6 +360,8 @@ def _post_with_retry(
             if exc.code == 429:
                 if _cb_on_429():
                     return None
+                if is_last_attempt:
+                    break
                 delay = min(2 ** (attempt + 1), _MAX_WAIT_SEC)
                 jitter = random.uniform(0, delay * 0.3)
                 logger.warning(
@@ -366,16 +375,19 @@ def _post_with_retry(
             logger.warning("S2 batch HTTP %d", exc.code)
             return None
         except (urllib.error.URLError, OSError, json.JSONDecodeError) as exc:
+            if is_last_attempt:
+                logger.warning("S2 batch request failed (%s) on final attempt", exc)
+                break
             wait = min(2**attempt, _MAX_WAIT_SEC)
-            jitter = random.uniform(0, wait * 0.2)
+            wait += random.uniform(0, wait * 0.2)
             logger.warning(
-                "S2 batch request failed (%s). Retry %d/%d in %ds…",
+                "S2 batch request failed (%s). Retry %d/%d in %.1fs…",
                 exc,
                 attempt + 1,
                 _MAX_RETRIES,
                 wait,
             )
-            time.sleep(wait + jitter)
+            time.sleep(wait)
 
     logger.error("S2 batch request exhausted retries")
     return None

--- a/tests/test_rc_literature.py
+++ b/tests/test_rc_literature.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import textwrap
+from email.message import Message
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -808,3 +809,74 @@ class TestCacheTTL:
 
 
 import urllib.error
+
+
+class TestS2RetrySleepBudget:
+    """The retry loops must not sleep after their final attempt."""
+
+    def _run(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        exc: Exception,
+        call: str,
+    ) -> list[float]:
+        import researchclaw.literature.semantic_scholar as s2
+
+        s2._reset_circuit_breaker()
+        delays: list[float] = []
+        monkeypatch.setattr(
+            "researchclaw.literature.semantic_scholar.urllib.request.urlopen",
+            lambda *a, **kw: (_ for _ in ()).throw(exc),
+        )
+        monkeypatch.setattr(
+            "researchclaw.literature.semantic_scholar.time.sleep",
+            lambda d: delays.append(d),
+        )
+        if call == "get":
+            assert s2._request_with_retry("https://x/y", {}) is None
+        else:
+            assert s2._post_with_retry("https://x/y", {}, b"{}") is None
+        return delays
+
+    def test_get_connection_error_does_not_sleep_after_final_attempt(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from researchclaw.literature.semantic_scholar import _MAX_RETRIES
+
+        delays = self._run(monkeypatch, ConnectionResetError("boom"), "get")
+        assert len(delays) == _MAX_RETRIES - 1
+
+    def test_post_connection_error_does_not_sleep_after_final_attempt(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from researchclaw.literature.semantic_scholar import _MAX_RETRIES
+
+        delays = self._run(monkeypatch, ConnectionResetError("boom"), "post")
+        assert len(delays) == _MAX_RETRIES - 1
+
+    def test_get_429_does_not_sleep_after_final_attempt(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from researchclaw.literature.semantic_scholar import _MAX_RETRIES
+
+        err = urllib.error.HTTPError("url", 429, "Too Many", Message(), None)
+        delays = self._run(monkeypatch, err, "get")
+        assert len(delays) <= _MAX_RETRIES - 1
+
+    def test_post_429_does_not_sleep_after_final_attempt(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from researchclaw.literature.semantic_scholar import _MAX_RETRIES
+
+        err = urllib.error.HTTPError("url", 429, "Too Many", Message(), None)
+        delays = self._run(monkeypatch, err, "post")
+        assert len(delays) <= _MAX_RETRIES - 1
+
+    def test_retries_still_back_off_between_attempts(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Guard against 'fixing' the sleep by removing backoff entirely."""
+        delays = self._run(monkeypatch, ConnectionResetError("boom"), "get")
+        assert delays, "expected backoff sleeps between attempts"
+        assert delays == sorted(delays), "backoff should be non-decreasing"
+        assert all(d > 0 for d in delays)


### PR DESCRIPTION
Both retry loops in `semantic_scholar.py` (`_request_with_retry` and `_post_with_retry`) slept their full backoff *after* the final attempt, then gave up anyway. The log line is the giveaway — with `_MAX_RETRIES = 3`:

```
S2 request failed (boom). Retry 2/3 in 2s…
S2 request failed (boom). Retry 3/3 in 4s…     <- there is no attempt 4
S2 request exhausted retries for: ...
```

It announces "Retry 3/3", sleeps 4s (+jitter), and returns `None`. Nothing retries. Measured sleep budget on a persistent connection error, before/after:

| | before | after |
|---|---|---|
| `_request_with_retry` | `[1.1, 2.2, 4.3]` | `[1.1, 2.2]` |
| `_post_with_retry` | `[1.2, 2.4, 4.3]` | `[1.2, 2.4]` |

So ~4–5s burned per exhausted call. That's per source per query, and `search_papers_multi_query` loops over both, so it multiplies out — on precisely the flaky-network runs you least want to sit through.

## Only one branch was actually broken

Worth being precise, because it wasn't what I first assumed. The **429 branch is fine**, and not by design — it's saved by the circuit breaker:

```python
if exc.code == 429:
    if _cb_on_429():
        return None  # breaker tripped -> returns before the sleep
```

`_CB_THRESHOLD` is 3 and `_MAX_RETRIES` is 3, so the third consecutive 429 trips the breaker and returns early, skipping the sleep. Correct — but only as long as those two unrelated constants stay equal. Drop `_MAX_RETRIES` to 2, or raise `_CB_THRESHOLD`, and the same wasted sleep reappears with no test to catch it.

Rather than leave that coupling implicit, both branches now carry an explicit `is_last_attempt` guard. The 429 path still calls `_cb_on_429()` first, so breaker accounting is unchanged — it just skips the pointless sleep.

The only branch with a live bug is the connection-error one (`URLError`/`OSError`/`JSONDecodeError`), which has no breaker involvement at all.

## Drive-by

The connection-error log statement reported `wait` while actually sleeping `wait + jitter`, and formatted a float with `%d` (so a 4.25s sleep logged as `4s`). Since I was rewriting those exact lines I folded the jitter in and switched to `%.1f`. Happy to pull this out if you'd rather keep the PR to one thing.

## Testing

`pytest tests/` → 2802 passed, 56 skipped, unchanged from before.

The new tests assert the sleep budget for both functions and both branches. I checked they actually fail against the unfixed code rather than just passing alongside it:

```
FAILED TestS2RetrySleepBudget::test_get_connection_error_does_not_sleep_after_final_attempt
FAILED TestS2RetrySleepBudget::test_post_connection_error_does_not_sleep_after_final_attempt
2 failed, 3 passed
```

The three that pass either way are the 429 cases (never broken, per above) — they're there as guards on the constant coupling. There's also one asserting backoff still grows between attempts, so this can't be "fixed" later by just deleting the sleeps.

Behaviour is otherwise unchanged: same attempt count, same backoff growth, same `None` return, same breaker semantics.

---

Same class of bug as #304 (the `LLMClient` retry loop), but independent code — either can land without the other.
