### PR TITLE
fix: restore bugfixes silently dropped by the v0.5.0 release commit

### DIFF
--- a/researchclaw/health.py
+++ b/researchclaw/health.py
@@ -174,7 +174,9 @@ def check_llm_connectivity(base_url: str, api_key: str = "") -> CheckResult:
     headers: dict[str, str] = {}
     if api_key.strip():
         headers["Authorization"] = f"Bearer {api_key}"
-    req = urllib.request.Request(url, headers=headers, method="HEAD")
+    # Use GET instead of HEAD because some OpenAI-compatible gateways
+    # reject HEAD probes on `/models` even though normal GET/model calls work.
+    req = urllib.request.Request(url, headers=headers)
 
     try:
         with urllib.request.urlopen(req, timeout=5):
@@ -186,7 +188,7 @@ def check_llm_connectivity(base_url: str, api_key: str = "") -> CheckResult:
     except urllib.error.HTTPError as exc:
         if exc.code in (404, 405):
             # /models not available (e.g. MiniMax, some proxies) — try
-            # /chat/completions with HEAD/GET as a fallback probe.
+            # /chat/completions as a fallback probe.
             fallback_url = f"{base_url.rstrip('/')}/chat/completions"
             probe_urls = [url, fallback_url] if exc.code == 405 else [fallback_url]
             for probe in probe_urls:

--- a/researchclaw/pipeline/stage_impls/_literature.py
+++ b/researchclaw/pipeline/stage_impls/_literature.py
@@ -197,13 +197,33 @@ def _execute_search_strategy(
     queries_list: list[str] = []
     year_min = 2020
     if isinstance(plan, dict):
-        strategies = plan.get("search_strategies", [])
+        strategies = (
+            plan.get("search_strategies")
+            or plan.get("search_phases")
+            or plan.get("phases")
+            or []
+        )
         if isinstance(strategies, list):
             for strat in strategies:
                 if isinstance(strat, dict):
                     qs = strat.get("queries", [])
                     if isinstance(qs, list):
-                        queries_list.extend(str(q) for q in qs if q)
+                        for q in qs:
+                            if isinstance(q, str) and q.strip():
+                                queries_list.append(q.strip())
+                            elif isinstance(q, dict):
+                                for v in q.values():
+                                    if isinstance(v, str) and v.strip():
+                                        queries_list.append(v.strip())
+        top_level_queries = plan.get("queries")
+        if isinstance(top_level_queries, list) and not queries_list:
+            for q in top_level_queries:
+                if isinstance(q, str) and q.strip():
+                    queries_list.append(q.strip())
+                elif isinstance(q, dict):
+                    for v in q.values():
+                        if isinstance(v, str) and v.strip():
+                            queries_list.append(v.strip())
         filters = plan.get("filters", {})
         if isinstance(filters, dict) and filters.get("min_year"):
             try:

--- a/researchclaw/pipeline/stage_impls/_topic.py
+++ b/researchclaw/pipeline/stage_impls/_topic.py
@@ -54,6 +54,15 @@ def _execute_topic_init(
             system=sp.system,
         )
         goal_md = resp.content
+        # Prepend a disclaimer so downstream stages treat any benchmark/SOTA
+        # figures in this file as provisional estimates, not verified facts.
+        # Actual citation and SOTA verification happens in later stages.
+        disclaimer = (
+            "> **Note (Stage 01 — unverified draft):** Benchmark names and SOTA "
+            "claims in this file are LLM-generated estimates. "
+            "They will be verified during the literature search stage.\n\n"
+        )
+        goal_md = disclaimer + goal_md
     else:
         goal_md = f"""# Research Goal
 

--- a/researchclaw/prompts/ml.py
+++ b/researchclaw/prompts/ml.py
@@ -183,9 +183,11 @@ _DEFAULT_STAGES: dict[str, dict[str, Any]] = {
             "will be retrieved in the literature search stage.\n"
             "- Name the specific benchmark/dataset that will be used for evaluation.\n"
             "- If no standard benchmark exists, explain how results will be measured.\n"
-            "- State whether SOTA results exist on this benchmark and what they are.\n"
-            "- Add a 'Benchmark' subsection listing: name, source, metrics, "
-            "current SOTA (if known)."
+            "- Note whether SOTA results are commonly tracked on this benchmark "
+            "(do NOT state specific model names or performance numbers — these "
+            "will be verified in the literature search stage).\n"
+            "- Add a 'Benchmark' subsection listing: name, source, and typical "
+            "metrics — omit unverified performance numbers."
         ),
     },
     "problem_decompose": {

--- a/tests/test_rc_executor.py
+++ b/tests/test_rc_executor.py
@@ -320,11 +320,10 @@ def test_execute_stage_creates_stage_dir_writes_artifacts_and_meta(
     assert "goal.md" in result.artifacts
     assert "hardware_profile.json" in result.artifacts
     assert (run_dir / "stage-01").is_dir()
-    assert (
-        (run_dir / "stage-01" / "goal.md")
-        .read_text(encoding="utf-8")
-        .startswith("# Goal")
-    )
+    goal_text = (run_dir / "stage-01" / "goal.md").read_text(encoding="utf-8")
+    # goal.md now starts with a disclaimer blockquote; the original content follows
+    assert "# Goal" in goal_text
+    assert "unverified draft" in goal_text  # disclaimer is present
     assert (run_dir / "stage-01" / "hardware_profile.json").exists()
     assert len(fake_llm.calls) == 1
 

--- a/tests/test_rc_health.py
+++ b/tests/test_rc_health.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import json
 import socket
 import urllib.error
+import urllib.request
 from pathlib import Path
 from typing import NamedTuple, cast
 from unittest.mock import patch
@@ -604,3 +605,23 @@ def test_print_doctor_report_ascii_fallback(monkeypatch: pytest.MonkeyPatch) -> 
     out = "".join(fake_stdout.parts)
     assert "[OK] python_version: ok" in out
     assert "Result: PASS" in out
+
+
+def test_check_llm_connectivity_probes_with_get_not_head() -> None:
+    """Some OpenAI-compatible gateways reject HEAD on /models (see #292, #241).
+
+    Probing with HEAD makes `doctor` report a false failure for endpoints
+    that serve normal GET traffic fine.
+    """
+    captured: list[urllib.request.Request] = []
+
+    def _capture(req, timeout=None):  # type: ignore[no-untyped-def]
+        captured.append(req)
+        return _DummyHTTPResponse(status=200)
+
+    with patch("urllib.request.urlopen", _capture):
+        result = health.check_llm_connectivity("https://api.example.com/v1")
+
+    assert result.status == "pass"
+    assert captured, "expected a probe request"
+    assert captured[0].get_method() == "GET"

--- a/tests/test_rc_prompts.py
+++ b/tests/test_rc_prompts.py
@@ -112,6 +112,23 @@ class TestPromptManagerDefaults:
         assert "ml" in sp.user
         assert sp.system
 
+    def test_topic_init_no_sota_hallucination(self) -> None:
+        """topic_init prompt must not ask for specific SOTA numbers (issue #238)."""
+        pm = PromptManager()
+        sp = pm.for_stage(
+            "topic_init",
+            topic="graph neural networks",
+            domains="ml",
+            project_name="test",
+            quality_threshold="4.0",
+        )
+        user = sp.user
+        # Must explicitly block paper citations and SOTA figures
+        assert "Do NOT fabricate" in user or "do NOT state specific" in user
+        # Must not ask the model to produce exact SOTA performance numbers
+        assert "what they are" not in user
+        assert "current SOTA (if known)" not in user
+
     def test_json_mode_stages(self) -> None:
         pm = PromptManager()
         json_stages = [


### PR DESCRIPTION
I went looking for the cause of one reverted fix (#234, restored in #304) and found it wasn't a one-off. The v0.5.0 release commit reverted most of a month of merged PRs.

## What happened

`12d3fd8` ("release: AutoResearchClaw v0.5.0") is a single squashed commit — 318 files, +42,268/−8,632 — sitting directly on top of `84dad0a`. Judging by what survived and what didn't, the v0.5.0 work was branched around **2026-04-09/10** and landed on **05-19**, overwriting everything merged in between. Nothing in the commit mentions reverting anything.

The date cutoff is unusually clean:

| merged | commit | fate |
|---|---|---|
| 04-06 | `ad806b5` MiniMax preset URL / from-stage | intact |
| 04-06 | `28478cc` MCP path traversal, dispatcher failover | intact |
| 04-07 | `5dc7fcc` Responses API / MiniMax 404 | intact |
| 04-08 | `be89838` HITL collab fixes | intact |
| 04-10 | `afccebe` scripted HITL adapter | intact |
| 04-10 | `e6a6dfa` perf: lift regex compilation (#231) | **reverted** |
| 04-10 | `7b57457` `--from-stage` without `--output` (#217) | fix kept, **212-line test file deleted** |
| 04-10 | `684ddb2` Gemini native adapter (#227) | **file deleted** |
| 04-11 | `8ec230d` retry error tracking (#234) | **reverted** (→ #304) |
| 04-20 | `9f8d11d` doctor gateway probe | **reverted** |
| 04-20 | `61a92d8` Volcengine/BytePlus presets (#240) | **reverted** |
| 04-20 | `28508f2` SOTA hallucination (#239 / fixes #238) | **reverted** |
| 04-21 | `9f15247` search plan schema variants (#243) | **reverted** |

Everything ≤04-08 survives; almost everything ≥04-10 is gone. `61a92d8` is the sharpest case — it came in via `84dad0a`, the release commit's **own parent**, and was wiped by its own child.

I verified each of these against HEAD rather than trusting a diff heuristic — the refactor moved `prompts.py` into a `prompts/` package, so "file gone" needed checking by hand. `5dc7fcc` looked lost by line-matching but its content genuinely moved into `prompts/ml.py`; it's fine.

## What this PR restores

Three correctness fixes whose removal is unambiguous, each mapping to an issue that's **closed but reproducible again at HEAD**:

**Doctor gateway probe** — `health.py:177` was back to `method="HEAD"` on `/models`, byte-for-byte pre-fix. Gateways that reject HEAD but serve GET normally get reported as unreachable, which is what #292 and #241 were about.

**SOTA hallucination (#238)** — this one is the clearest evidence of an accident rather than a decision. The release didn't just drop the fix, it restored the exact prompt line the fix removed:

```python
# researchclaw/prompts/ml.py:186 at HEAD — the line #239 deleted
"- State whether SOTA results exist on this benchmark and what they are.\n"
"- Add a 'Benchmark' subsection listing: name, source, metrics, "
"current SOTA (if known)."
```

The `goal.md` disclaimer is gone too. Notably `prompts/ml.py:182` still has the anti-fabrication line from `5dc7fcc` (04-07) while line 186 has the pre-#239 text (04-20) — the file is a snapshot from between those two dates, which is exactly the squash artifact you'd expect.

**Search plan schema variants (#243)** — `_literature.py` was back to `plan.get("search_strategies", [])`, so a plan returned as `search_phases` / `phases`, or with dict-wrapped queries, silently produces zero queries.

## What this PR deliberately does *not* restore

These may have been removed on purpose, and that's your call, not mine:

- **Gemini native adapter (#227)** — `llm/gemini_adapter.py` is deleted and no `gemini` preset remains. Cleanly removed, no dangling imports, so this could well be intentional.
- **Volcengine/BytePlus presets (#240)** — gone from `PROVIDER_PRESETS` entirely (HEAD has: anthropic, deepseek, kimi-anthropic, minimax, novita, openai, openai-compatible, openrouter), and `tests/test_volcano_provider.py` was deleted.
- **`e6a6dfa` (#231)** — the regex hoisting is undone (`_helpers.py:527` compiles per-call again). Perf only, and a separate concern.
- **`7b57457` (#217)** — the fix survives, but its 212-line `tests/test_from_stage_run_dir.py` was deleted, so it's now unprotected.

Happy to send any of those as follow-ups if you confirm they weren't intentional.

## Testing

`pytest tests/` → 2799 passed, 56 skipped (2797 on main + the 2 tests added here).

#239's tests were dropped by the release too, so they're restored: the `test_rc_prompts.py` guard, and the `test_rc_executor.py` assertion that had to change because `goal.md` now leads with the disclaimer. I added a probe-method test for the doctor fix. I checked the new tests actually fail against un-restored source rather than passing vacuously:

```
FAILED tests/test_rc_health.py::test_check_llm_connectivity_probes_with_get_not_head
FAILED tests/test_rc_prompts.py::TestPromptManagerDefaults::test_topic_init_no_sota_hallucination
```

**#243 has no test and I didn't add one.** Its parsing sits inline in `_execute_search_strategy`, which needs run-dir artifacts, adapters and an LLM path to drive, so any test I wrote would be mostly mock scaffolding. Worth noting the original also shipped without tests — which is a large part of why it disappeared unnoticed for three months. If you want it covered, extracting the plan-parsing into a helper would make it a one-liner to test; happy to do that separately.

## Worth considering

The single most useful change here isn't in the diff: whatever produced `12d3fd8` should rebase rather than squash onto main, or at minimum diff against `main` before landing. Five merged community PRs were reverted with no notice, and the only reason any of it surfaced is that I chased an unrelated 429 error message. I'd suggest a CI check that fails when a PR deletes a test file it didn't add — that alone would have caught #217, #240 and #227.

I'd also hold off closing #238, #241, #292 and #243 as fixed until this (or an equivalent) lands, since all four currently reproduce on main.
