### PR TITLE
fix(literature): sort candidates by keyword overlap before char-cap truncation

### DIFF
--- a/researchclaw/pipeline/stage_impls/_literature.py
+++ b/researchclaw/pipeline/stage_impls/_literature.py
@@ -481,7 +481,6 @@ def _execute_literature_collect(
     if config.web_search.enabled:
         try:
             from researchclaw.web.agent import WebSearchAgent
-            import os
 
             tavily_key = config.web_search.tavily_api_key or os.environ.get(
                 config.web_search.tavily_api_key_env, ""
@@ -645,7 +644,7 @@ def _execute_literature_collect(
 
 
 _MAX_ABSTRACT_LEN = 800  # Truncate long abstracts to reduce token usage
-_MAX_CANDIDATES_CHARS = 30_000  # Cap total candidates text sent to LLM
+_MAX_CANDIDATES_CHARS = 100_000  # Cap total candidates text sent to LLM
 
 
 def _execute_literature_screen(
@@ -686,6 +685,13 @@ def _execute_literature_screen(
     # If pre-filter dropped everything, fall back to original (safety valve)
     if not filtered_rows:
         filtered_rows = _parse_jsonl_rows(candidates_text)
+    # Sort by keyword overlap (descending) before the char cap below drops
+    # anything — candidates arrive in raw search order (whichever query/
+    # source happened to return them), not relevance order. Without this,
+    # the _MAX_CANDIDATES_CHARS truncation can silently drop every relevant
+    # paper while keeping only whatever off-topic results came first, and
+    # the LLM correctly (but uselessly) rejects the truncated set it saw.
+    filtered_rows.sort(key=lambda r: r.get("keyword_overlap", 0), reverse=True)
     # Truncate abstracts and strip authors to reduce token usage
     for row in filtered_rows:
         abstract = row.get("abstract", "")


### PR DESCRIPTION
## Summary
- Stage 5 (LITERATURE_SCREEN) was rejecting **all** candidates on niche/cross-domain topics. Root cause: `candidates.jsonl` retains raw search order (whichever query/source happened to return a paper), and `_MAX_CANDIDATES_CHARS` truncates the serialized candidate list *before* it's sent to the screening LLM. On a real run with 1418 filtered candidates, the 30,000-char cap only covered the first ~15-20 rows — all off-topic noise pulled in by a low-signal expanded query (e.g. "The Stated vs. Revealed survey"). Every relevant paper sat past index 246 and never reached the screening prompt, so the LLM correctly (but uselessly) rejected the unrepresentative slice it was shown, and the stage paused with `model_rejected_all`.
- Fix: sort `filtered_rows` by `keyword_overlap` (already computed during the pre-filter) descending before truncating, so relevant candidates survive the cap regardless of raw search order. Also raised `_MAX_CANDIDATES_CHARS` from 30k to 100k chars so more of the relevant pool gets through.

## Verification
- Replayed the fix against the actual candidates.jsonl (1495 papers) from a run that had been stuck for 3 HITL-approval cycles in a row with an empty shortlist. Post-fix, the top of the truncated candidate list is dominated by genuinely on-topic papers (45 relevant candidates fit under the new cap, well above the pipeline's 15-paper minimum shortlist size).
- Re-ran the stuck pipeline end-to-end from the Stage 5 checkpoint: it produced a real 26-paper shortlist (top hit: 0.9 relevance) and progressed through Stages 6-9 (KNOWLEDGE_EXTRACT, SYNTHESIS, HYPOTHESIS_GEN, EXPERIMENT_DESIGN) for the first time, versus previously looping indefinitely on Stage 5.
- `pytest tests/test_rc_literature.py` (run under the project's .venv, Python 3.11) — 47 passed.

## Test plan
- [x] pytest tests/test_rc_literature.py (project .venv)
- [x] Manual replay of Stage 5 filtering/sorting logic against a real stuck-run candidate set
- [x] Live pipeline resume from checkpoint through Stage 9
