### PR TITLE
Add biology_singlecell benchmarks (PBMC3k/68k) to benchmark knowledge base

### DIFF
--- a/researchclaw/data/benchmark_knowledge.yaml
+++ b/researchclaw/data/benchmark_knowledge.yaml
@@ -853,3 +853,48 @@ domains:
         source: "sklearn.neural_network.MLPClassifier(hidden_layer_sizes=(256, 128))"
         paper: "Standard neural network baseline"
         pip: []
+
+  biology_singlecell:
+    keywords:
+      - single-cell
+      - single cell
+      - scrna-seq
+      - transcriptomics
+      - cell clustering
+      - pbmc
+    standard_benchmarks:
+      - name: PBMC3k
+        tier: 1
+        domain: biology_singlecell
+        size_mb: 5.9
+        samples: 2700
+        metrics: [ARI, NMI]
+        api: "scanpy.datasets.pbmc3k()"
+      - name: PBMC3k-processed
+        tier: 1
+        domain: biology_singlecell
+        samples: 2638
+        metrics: [ARI, NMI]
+        api: "scanpy.datasets.pbmc3k_processed()"
+      # NOTE: despite the "68k" name, scanpy ships only a ~700-cell reduced
+      # subsample of the original 68k-cell dataset (verified against current
+      # scanpy docs) — not the full 68,000 cells.
+      - name: PBMC68k-reduced
+        tier: 1
+        domain: biology_singlecell
+        samples: 700
+        metrics: [ARI, NMI]
+        api: "scanpy.datasets.pbmc68k_reduced()"
+    common_baselines:
+      - name: Leiden Clustering
+        source: "scanpy.tl.leiden(adata)"
+        paper: "Traag et al., From Louvain to Leiden, Scientific Reports 2019"
+        pip: []
+      - name: K-Means (PCA-reduced)
+        source: "sklearn.cluster.KMeans(n_clusters=k).fit(adata.obsm['X_pca'])"
+        paper: "MacQueen, Some methods for classification and analysis of multivariate observations, 1967"
+        pip: []
+      - name: Agglomerative Clustering
+        source: "sklearn.cluster.AgglomerativeClustering(n_clusters=k)"
+        paper: "Ward, Hierarchical grouping to optimize an objective function, JASA 1963"
+        pip: []

--- a/tests/test_benchmark_agent.py
+++ b/tests/test_benchmark_agent.py
@@ -100,6 +100,55 @@ class TestBenchmarkKnowledge:
 
 
 # ---------------------------------------------------------------------------
+# biology_singlecell domain tests
+# ---------------------------------------------------------------------------
+
+
+class TestBiologySingleCellDomain:
+    """Regression tests for the biology_singlecell benchmark entry."""
+
+    def _domain(self) -> dict[str, Any]:
+        from researchclaw.agents.benchmark_agent.surveyor import _KNOWLEDGE_PATH
+        data = yaml.safe_load(_KNOWLEDGE_PATH.read_text(encoding="utf-8"))
+        return data["domains"]["biology_singlecell"]
+
+    def test_domain_present(self) -> None:
+        from researchclaw.agents.benchmark_agent.surveyor import _KNOWLEDGE_PATH
+        data = yaml.safe_load(_KNOWLEDGE_PATH.read_text(encoding="utf-8"))
+        assert "biology_singlecell" in data["domains"]
+
+    def test_keywords_match_expected_topics(self) -> None:
+        domain = self._domain()
+        keywords = [k.lower() for k in domain["keywords"]]
+        for topic in ["single-cell RNA-seq clustering", "PBMC transcriptomics analysis"]:
+            topic_lower = topic.lower()
+            assert any(kw in topic_lower for kw in keywords), (
+                f"No keyword in {keywords} matches topic {topic!r}"
+            )
+
+    def test_benchmarks_are_tier_1_and_network_free(self) -> None:
+        # All three entries are self-caching scanpy calls (<6MB each), so
+        # they should not require a separate setup-phase download step.
+        domain = self._domain()
+        names = {b["name"] for b in domain["standard_benchmarks"]}
+        assert names == {"PBMC3k", "PBMC3k-processed", "PBMC68k-reduced"}
+        for b in domain["standard_benchmarks"]:
+            assert b["tier"] == 1, f"{b['name']} expected tier 1, got {b['tier']}"
+            assert b["api"].startswith("scanpy.datasets.")
+
+    def test_baselines_use_preinstalled_packages_only(self) -> None:
+        # Dockerfile.biology installs scanpy/anndata/leidenalg/biopython on
+        # top of the numpy/scipy/sklearn base image — no baseline here
+        # should declare an extra pip dependency.
+        domain = self._domain()
+        for bl in domain["common_baselines"]:
+            assert bl["pip"] == [], (
+                f"{bl['name']} declares pip deps {bl['pip']}, but "
+                "Dockerfile.biology has no extra install step for them"
+            )
+
+
+# ---------------------------------------------------------------------------
 # Surveyor tests
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What
Adds a `biology_singlecell` domain entry to `researchclaw/data/benchmark_knowledge.yaml`,
following the existing schema (keywords / standard_benchmarks / common_baselines).

- 3 benchmarks: `PBMC3k`, `PBMC3k-processed`, `PBMC68k-reduced` — all loaded via
  `scanpy.datasets.*` (already installed in `Dockerfile.biology`), all tier 1
  (self-caching calls under 6MB, no separate setup-phase download needed).
- 3 baselines: Leiden clustering, K-Means, Agglomerative clustering — all using
  packages already present in `Dockerfile.biology` (`pip: []` throughout).

Names/sizes/sample counts were checked against current scanpy documentation
rather than assumed. One thing worth a reviewer's eye: despite the name,
`pbmc68k_reduced` ships only a ~700-cell reduced subsample, not the full 68k
cells — flagged inline in the YAML comment so it doesn't surprise anyone later.

## Why
`benchmark_knowledge.yaml` currently covers 16 ML/DL subfields but no non-ML
domain, even though `Dockerfile.biology` and the `biology_*` domain profiles
show biology is an actively sandboxed domain. This is a narrowly-scoped first
increment for single-cell analysis specifically (matching the existing
`biology_singlecell` profile). Happy to follow up with other biology
sub-domains or other domains as separate PRs per the one-concern-per-PR
guideline in CONTRIBUTING.md.

## Tests
- Added `TestBiologySingleCellDomain` (4 tests) to `tests/test_benchmark_agent.py`:
  domain presence, keyword matching, tier/API-prefix correctness, and that no
  baseline needs a pip package beyond what `Dockerfile.biology` installs.
- `pytest tests/` passes locally (2868 passed, 56 pre-existing/unrelated skips).

## Scope
Additive only — no existing domains, agents, or schemas touched.
