### PR TITLE
feat(llm): add Atlas Cloud provider preset

### DIFF
--- a/config.researchclaw.example.yaml
+++ b/config.researchclaw.example.yaml
@@ -51,6 +51,12 @@ llm:
   # fallback_models:
   #   - "MiniMax-M2.7"
   #   - "MiniMax-M2.7-highspeed"
+  # --- Atlas Cloud provider example ---
+  # provider: "atlascloud"
+  # api_key_env: "ATLASCLOUD_API_KEY"
+  # primary_model: "deepseek-ai/deepseek-v4-pro"
+  # fallback_models:
+  #   - "deepseek-ai/deepseek-v4-flash"
   # --- Ollama (local) example ---
   # provider: "ollama"
   # base_url: "http://localhost:11434/v1"

--- a/researchclaw/cli.py
+++ b/researchclaw/cli.py
@@ -776,6 +776,7 @@ _PROVIDER_CHOICES = {
     "4": ("minimax", "MINIMAX_API_KEY"),
     "5": ("acp", ""),
     "6": ("ollama", ""),
+    "7": ("atlascloud", "ATLASCLOUD_API_KEY"),
 }
 
 _PROVIDER_URLS = {
@@ -784,6 +785,7 @@ _PROVIDER_URLS = {
     "deepseek": "https://api.deepseek.com/v1",
     "minimax": "https://api.minimaxi.com/v1",
     "ollama": "http://localhost:11434/v1",
+    "atlascloud": "https://api.atlascloud.ai/v1",
 }
 
 _PROVIDER_MODELS = {
@@ -795,6 +797,10 @@ _PROVIDER_MODELS = {
     "deepseek": ("deepseek-chat", ["deepseek-reasoner"]),
     "minimax": ("MiniMax-M3", ["MiniMax-M2.7", "MiniMax-M2.7-highspeed"]),
     "ollama": ("llama3.2", ["mistral", "qwen2.5:7b"]),
+    "atlascloud": (
+        "deepseek-ai/deepseek-v4-pro",
+        ["deepseek-ai/deepseek-v4-flash"],
+    ),
 }
 
 
@@ -832,6 +838,7 @@ def cmd_init(args: argparse.Namespace) -> int:
         print("  4) minimax      (requires MINIMAX_API_KEY)")
         print("  5) acp          (local AI agent — no API key needed)")
         print("  6) ollama       (local Ollama server — no API key needed)")
+        print("  7) atlascloud   (requires ATLASCLOUD_API_KEY)")
         try:
             raw = input("Choice [1]: ").strip()
         except (EOFError, KeyboardInterrupt):

--- a/researchclaw/llm/__init__.py
+++ b/researchclaw/llm/__init__.py
@@ -20,6 +20,9 @@ PROVIDER_PRESETS = {
     "deepseek": {
         "base_url": "https://api.deepseek.com/v1",
     },
+    "atlascloud": {
+        "base_url": "https://api.atlascloud.ai/v1",
+    },
     "anthropic": {
         "base_url": "https://api.anthropic.com",
     },
@@ -50,6 +53,7 @@ def create_llm_client(config: RCConfig) -> LLMClient | ACPClient:
     - ``"openrouter"`` → :class:`LLMClient` with OpenRouter base URL
     - ``"openai"`` → :class:`LLMClient` with OpenAI base URL
     - ``"deepseek"`` → :class:`LLMClient` with DeepSeek base URL
+    - ``"atlascloud"`` → :class:`LLMClient` with Atlas Cloud base URL
     - ``"novita"`` → :class:`LLMClient` with Novita AI base URL
     - ``"minimax"`` → :class:`LLMClient` with MiniMax base URL
     - ``"openai-compatible"`` (default) → :class:`LLMClient` with custom base_url

--- a/tests/test_atlascloud_provider.py
+++ b/tests/test_atlascloud_provider.py
@@ -1,0 +1,170 @@
+"""Tests for the Atlas Cloud OpenAI-compatible provider preset."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import urllib.request
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Mapping
+
+import pytest
+
+from researchclaw.cli import (
+    _PROVIDER_CHOICES,
+    _PROVIDER_MODELS,
+    _PROVIDER_URLS,
+    cmd_init,
+)
+from researchclaw.llm import PROVIDER_PRESETS, create_llm_client
+from researchclaw.llm.client import LLMClient, LLMConfig
+
+
+class _DummyHTTPResponse:
+    def __init__(self, payload: Mapping[str, Any]):
+        self._payload = payload
+
+    def read(self) -> bytes:
+        return json.dumps(self._payload).encode("utf-8")
+
+    def __enter__(self) -> _DummyHTTPResponse:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+
+def _rc_config(
+    *,
+    api_key: str = "",
+    api_key_env: str = "ATLASCLOUD_API_KEY",
+    base_url: str = "",
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        llm=SimpleNamespace(
+            provider="atlascloud",
+            base_url=base_url,
+            api_key=api_key,
+            api_key_env=api_key_env,
+            wire_api="chat_completions",
+            primary_model="deepseek-ai/deepseek-v4-pro",
+            fallback_models=("deepseek-ai/deepseek-v4-flash",),
+            timeout_sec=60,
+        )
+    )
+
+
+def test_atlascloud_preset_and_cli_registration() -> None:
+    assert PROVIDER_PRESETS["atlascloud"]["base_url"] == (
+        "https://api.atlascloud.ai/v1"
+    )
+    assert any(value[0] == "atlascloud" for value in _PROVIDER_CHOICES.values())
+    assert _PROVIDER_URLS["atlascloud"] == "https://api.atlascloud.ai/v1"
+    assert _PROVIDER_MODELS["atlascloud"] == (
+        "deepseek-ai/deepseek-v4-pro",
+        ["deepseek-ai/deepseek-v4-flash"],
+    )
+
+
+def test_from_rc_config_uses_preset_and_isolated_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ATLASCLOUD_API_KEY", "test-atlascloud-key")
+    monkeypatch.setenv("OPENAI_API_KEY", "unrelated-openai-key")
+
+    client = create_llm_client(_rc_config())
+
+    assert isinstance(client, LLMClient)
+    assert client.config.base_url == "https://api.atlascloud.ai/v1"
+    assert client.config.api_key == "test-atlascloud-key"
+    assert client._model_chain == [
+        "deepseek-ai/deepseek-v4-pro",
+        "deepseek-ai/deepseek-v4-flash",
+    ]
+
+
+def test_custom_base_url_overrides_atlascloud_preset() -> None:
+    client = LLMClient.from_rc_config(
+        _rc_config(
+            api_key="test-key",
+            api_key_env="",
+            base_url="https://proxy.test/v1",
+        )
+    )
+
+    assert client.config.base_url == "https://proxy.test/v1"
+
+
+def test_atlascloud_request_uses_openai_compatible_endpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_urlopen(
+        request: urllib.request.Request, timeout: int
+    ) -> _DummyHTTPResponse:
+        captured["request"] = request
+        captured["timeout"] = timeout
+        return _DummyHTTPResponse(
+            {
+                "model": "deepseek-ai/deepseek-v4-pro",
+                "choices": [
+                    {"message": {"content": "pong"}, "finish_reason": "stop"}
+                ],
+                "usage": {
+                    "prompt_tokens": 5,
+                    "completion_tokens": 1,
+                    "total_tokens": 6,
+                },
+            }
+        )
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    client = LLMClient(
+        LLMConfig(
+            base_url="https://api.atlascloud.ai/v1",
+            api_key="test-atlascloud-key",
+            primary_model="deepseek-ai/deepseek-v4-pro",
+            fallback_models=[],
+            timeout_sec=60,
+        )
+    )
+
+    response = client._raw_call(
+        "deepseek-ai/deepseek-v4-pro",
+        [{"role": "user", "content": "ping"}],
+        1024,
+        0.2,
+        False,
+    )
+
+    request = captured["request"]
+    assert isinstance(request, urllib.request.Request)
+    assert request.full_url == "https://api.atlascloud.ai/v1/chat/completions"
+    assert request.get_header("Authorization") == "Bearer test-atlascloud-key"
+    assert captured["timeout"] == 60
+    assert response.content == "pong"
+
+
+def test_init_wizard_writes_atlascloud_defaults(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    class _TTY:
+        def isatty(self) -> bool:
+            return True
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(sys, "stdin", _TTY())
+    monkeypatch.setattr("builtins.input", lambda _prompt: "7")
+    monkeypatch.setattr("researchclaw.cli._prompt_opencode_install", lambda: False)
+
+    assert cmd_init(argparse.Namespace(force=False)) == 0
+    content = (tmp_path / "config.arc.yaml").read_text(encoding="utf-8")
+
+    assert 'provider: "atlascloud"' in content
+    assert 'base_url: "https://api.atlascloud.ai/v1"' in content
+    assert 'api_key_env: "ATLASCLOUD_API_KEY"' in content
+    assert 'primary_model: "deepseek-ai/deepseek-v4-pro"' in content
+    assert '    - "deepseek-ai/deepseek-v4-flash"' in content


### PR DESCRIPTION
## Summary

- add an `atlascloud` OpenAI-compatible provider preset at `https://api.atlascloud.ai/v1`
- register Atlas Cloud in the interactive init flow with isolated `ATLASCLOUD_API_KEY` configuration
- provide maintained DeepSeek V4 Pro/Flash defaults, a commented config example, and focused provider tests

## Validation

- `.venv/bin/python -m pytest tests/test_atlascloud_provider.py tests/test_minimax_provider.py tests/test_rc_cli.py -q` (`51 passed, 3 skipped`)
- `.venv/bin/python -m pytest tests/ -q` (`2869 passed, 56 skipped`; one existing AsyncMock warning in `tests/test_servers.py`)
- `.venv/bin/python -m compileall -q researchclaw tests/test_atlascloud_provider.py`
- verified the configured models and OpenAI chat-completions capability against the public Atlas Cloud model catalog

## Build note

`pip wheel . --no-deps` reaches the existing package-data step, then fails because `researchclaw/templates/styles/iclr_2025/iclr2025_conference.bst` is added to the wheel twice. This change does not touch packaging or template files.