### PR TITLE
docs(config): document the reviewer / debate / tournament knobs

### DIFF
--- a/config.researchclaw.example.yaml
+++ b/config.researchclaw.example.yaml
@@ -71,6 +71,54 @@ llm:
   # fallback_models:
   #   - "mistral"
 
+  # --- Independent reviewer / judge model (opt-in) ---
+  # By default the model that produced an artifact also reviews and judges it.
+  # Set reviewer_model to have a DIFFERENT model answer Stage 18 (peer review)
+  # and the Stage 20 quality gate; generation and revision stay with the author
+  # model. Leaving it empty keeps the legacy same-model behaviour.
+  # Set reviewer_model alone to judge with another model on the SAME endpoint,
+  # or add the reviewer_* fields below for a fully independent provider
+  # (e.g. generator = GPT, reviewer = Claude). Stage 18 records which model
+  # judged the paper in review_provenance.json.
+  reviewer_model: ""          # e.g. "claude-sonnet-4-6" — empty disables
+  reviewer_provider: ""       # e.g. "anthropic" — defaults to provider above
+  reviewer_base_url: ""       # defaults to base_url above
+  reviewer_api_key_env: ""    # e.g. "ANTHROPIC_API_KEY" — defaults to api_key_env
+  reviewer_api_key: ""        # inline key (optional; prefer the env var)
+
+  # --- Multi-model debate for Stage 8 hypothesis generation (opt-in) ---
+  # Builds a panel from primary_model + reviewer_model + fallback_models
+  # (deduplicated) and binds each debate role to a different model, so the
+  # perspectives genuinely disagree instead of one model arguing with itself.
+  # After `debate_rounds` rebuttal round(s), reviewer_model RANKS the positions
+  # and primary_model writes the final text from that ranking — ranking and
+  # writing are split so the disagreements are not averaged into consensus.
+  # Records debate_record.json. Multiplies LLM calls.
+  #
+  # To enable it you need BOTH of the following, plus a real panel:
+  #   debate_enabled: true       # otherwise Stage 8 uses the single-model path
+  #   tournament_enabled: false  # the tournament takes priority on Stage 8
+  # and primary_model + reviewer_model + fallback_models must dedupe to >= 2
+  # distinct models. A reviewer_model different from primary_model keeps the
+  # ranking independent.
+  # Env overrides: ARC_DEBATE_ROUNDS=<n>, ARC_ABL_DISABLE_DEBATE=1 (ablation:
+  # collapse the panel to a single role).
+  # debate_enabled: false
+  # debate_rounds: 1           # rebuttal rounds; 0 = opening statements only
+
+  # --- Best-of-N tournament for Stage 8 hypothesis generation (opt-in) ---
+  # Generates N candidate hypothesis sets from diverse stances (round-robin over
+  # the debate panel when one is available), then reviewer_model scores and ranks
+  # them and only the winner proceeds — the pipeline stays linear, with one
+  # canonical artifact per stage. Blank generations are dropped before judging,
+  # so an empty candidate cannot be handed a fabricated score. Records
+  # tournament_record.json. Multiplies LLM calls (~N generations + 1 judge).
+  # Takes priority over debate when both are enabled.
+  # Env overrides: ARC_TOURNAMENT_CANDIDATES=<n>, ARC_ABL_DISABLE_TOURNAMENT=1
+  # (ablation: collapse to a single candidate).
+  # tournament_enabled: false
+  # tournament_candidates: 3   # < 2 disables the tournament
+
 literature_search:
   # Stage 4 academic search backends. Defaults preserve the current
   # OpenAlex -> Semantic Scholar -> arXiv order.


### PR DESCRIPTION
Documents the nine reviewer, debate, and tournament settings in `config.researchclaw.example.yaml` after #316. The scope matches the current Stage 8 wiring; #318 extends the stage coverage separately.

The comments explain tournament precedence, environment overrides, and the actual single-model behavior: a one-model panel still enters the debate engine with all roles assigned to that model. They also clarify that a reviewer model can participate in the panel, so differing from the primary model alone does not establish judge independence.

Validation: parsed the original and updated YAML and confirmed that the configuration values are identical. The reviewer remains unset and debate/tournament remain disabled by default.