### PR TITLE
feat(llm): pass reasoning effort through to reasoning models

### DIFF
--- a/config.researchclaw.example.yaml
+++ b/config.researchclaw.example.yaml
@@ -40,6 +40,11 @@ llm:
   wire_api: "chat_completions"  # Set to "responses" for Responses-only gateways
   api_key_env: "OPENAI_API_KEY"
   api_key: ""
+  # Reasoning effort for reasoning models (o-series, gpt-5.x) reached through
+  # OpenAI or OpenRouter: xhigh | high | medium | low | minimal | none.
+  # Empty = provider default. Models that are not reasoning models never see
+  # the parameter, so this is safe to leave set when switching models.
+  reasoning_effort: ""
   primary_model: "gpt-4o"
   fallback_models:
     - "gpt-4.1"

--- a/researchclaw/config.py
+++ b/researchclaw/config.py
@@ -215,6 +215,10 @@ class LlmConfig:
     reviewer_base_url: str = ""
     reviewer_api_key: str = ""
     reviewer_api_key_env: str = ""
+    # Reasoning effort for reasoning models (o-series, gpt-5.x) reached through
+    # OpenAI or OpenRouter: xhigh | high | medium | low | minimal | none.
+    # Empty = provider default. Non-reasoning models never see the parameter.
+    reasoning_effort: str = ""
     # Multi-model debate engine. Opt-in; the debate panel reuses existing models
     # (primary_model + reviewer_model + fallback_models, deduped), each role
     # bound to a different model. The judge reuses reviewer_model.
@@ -1195,6 +1199,7 @@ def _parse_llm_config(data: dict[str, Any]) -> LlmConfig:
         reviewer_provider=data.get("reviewer_provider", ""),
         reviewer_base_url=data.get("reviewer_base_url", ""),
         reviewer_api_key=data.get("reviewer_api_key", ""),
+        reasoning_effort=str(data.get("reasoning_effort", "") or ""),
         reviewer_api_key_env=data.get("reviewer_api_key_env", ""),
         debate_enabled=bool(data.get("debate_enabled", False)),
         debate_rounds=_safe_int(data.get("debate_rounds"), 1),

--- a/researchclaw/llm/client.py
+++ b/researchclaw/llm/client.py
@@ -44,6 +44,23 @@ _NO_TEMPERATURE_MODELS = frozenset(
     }
 )
 
+
+def _strip_provider(model: str) -> str:
+    """Strip an OpenRouter-style provider prefix: 'openai/gpt-5.4' -> 'gpt-5.4'."""
+    return model.split("/", 1)[1] if model and "/" in model else (model or "")
+
+
+def _supports_reasoning_effort(model: str) -> bool:
+    """True for models that accept a ``reasoning.effort`` parameter.
+
+    Reuses ``_NEW_PARAM_MODELS`` rather than keeping a second list: the models
+    that need ``max_completion_tokens`` are the same reasoning family. Tolerates
+    a provider prefix so the check also works through OpenRouter.
+    """
+    m = _strip_provider(model).lower()
+    return any(m.startswith(prefix) for prefix in _NEW_PARAM_MODELS)
+
+
 _DEFAULT_USER_AGENT = (
     "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
     "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
@@ -83,6 +100,8 @@ class LLMConfig:
     retry_base_delay: float = 2.0
     timeout_sec: int = 300
     user_agent: str = _DEFAULT_USER_AGENT
+    # Reasoning effort for reasoning models; empty = provider default.
+    reasoning_effort: str = ""
     # MetaClaw bridge: extra headers for proxy requests
     extra_headers: dict[str, str] = field(default_factory=dict)
     # MetaClaw bridge: fallback URL if primary (proxy) is unreachable
@@ -163,6 +182,7 @@ class LLMClient:
             fallback_url=fallback_url,
             fallback_api_key=fallback_api_key,
             timeout_sec=getattr(rc_config.llm, "timeout_sec", 600),
+            reasoning_effort=getattr(rc_config.llm, "reasoning_effort", "") or "",
         )
         client = cls(config)
 
@@ -225,6 +245,7 @@ class LLMClient:
             primary_model=reviewer_model,
             fallback_models=[],
             timeout_sec=getattr(llm, "timeout_sec", 600),
+            reasoning_effort=getattr(llm, "reasoning_effort", "") or "",
         )
         client = cls(config)
 
@@ -498,6 +519,13 @@ class LLMClient:
                     body["max_completion_tokens"] = max(max_tokens, reasoning_min)
                 else:
                     body["max_tokens"] = max_tokens
+
+                # Pass reasoning effort through to reasoning models when it is
+                # configured. Gated on the model so non-reasoning models, which
+                # reject an unknown `reasoning` field with HTTP 400, never see it.
+                _effort = (self.config.reasoning_effort or "").strip()
+                if _effort and _supports_reasoning_effort(model):
+                    body["reasoning"] = {"effort": _effort}
 
             if json_mode:
                 # Many OpenAI-compatible providers don't support the


### PR DESCRIPTION
Reasoning models accept a `reasoning.effort` parameter, but there is currently no way to set it, so every call runs at the provider default.

This matters most for the judge roles added in #316. A reviewer or a tournament judge is exactly the kind of task where more deliberation changes the *verdict* rather than just the wording — it is a scoring decision, not a generation one.

`llm.reasoning_effort` (`xhigh | high | medium | low | minimal | none`) is threaded into both the generator and the reviewer client. Empty by default, so nothing changes unless it is set.

### The part worth reviewing

The parameter is **gated on the model**, because non-reasoning models reject an unknown `reasoning` field with HTTP 400. Getting this wrong would break every run on a `gpt-4o`-class model, so:

- `_supports_reasoning_effort` **reuses the existing `_NEW_PARAM_MODELS` set** instead of introducing a second model list. The models that need `max_completion_tokens` are the same reasoning family, and one list cannot drift out of sync with itself.
- It tolerates a provider prefix, so the check still works for `openai/gpt-5.4` through OpenRouter — the existing `_NEW_PARAM_MODELS` call sites do a bare `startswith` and would miss those.

**One consequence to flag:** `o1` is not covered, because it is absent from `_NEW_PARAM_MODELS`. I did not add it, since that set also controls the token parameter and I did not want to change unrelated behaviour in this PR — but if o1 should be there, adding it fixes both call sites at once.

### Verified

13 model names classify as expected, including provider-prefixed and non-OpenAI ones:

```
gpt-5.4, gpt-5, o3, o3-mini, o4-mini            -> True
openai/gpt-5.4, openai/o3-mini                  -> True
gpt-4o, gpt-4.1, claude-sonnet-4-6, deepseek-chat, ""  -> False
anthropic/claude-sonnet-4-6                     -> False
```

The example config still parses to an empty value, and a configured effort reaches the reviewer client built by `reviewer_from_rc_config`.

Full suite: 2951 passed, 0 failed, 56 skipped.

*Independent of #317 and #318; it touches a different part of the example config, so the three should not conflict.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
